### PR TITLE
chore: bump google-auth dependency to v1.11.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = "1.25.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-auth >= 1.9.0, < 2.0dev",
+    "google-auth >= 1.11.0, < 2.0dev",
     "google-cloud-core >= 1.2.0, < 2.0dev",
     "google-resumable-media >= 0.5.0, < 0.6dev",
 ]


### PR DESCRIPTION
Closes #14.
Closes #18.

This PR bumps google-auth version to benefit from its recent fixes, e.g. preventing unnecessary Timeout errors on long uploads.

Replaces [the same PR](https://github.com/googleapis/google-cloud-python/pull/10211) in the old repo.

### PR checklist
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

