### PR TITLE
Fix typo in docs: paramters -> parameters

### DIFF
--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -220,7 +220,7 @@ def canonicalize_v2(method, resource, query_parameters, headers):
 
     :type query_parameters: dict
     :param query_parameters:
-        (Optional) Additional query paramtersto be included as part of the
+        (Optional) Additional query parameters to be included as part of the
         signed URLs.  See:
         https://cloud.google.com/storage/docs/xml-api/reference-headers#query
 
@@ -352,7 +352,7 @@ def generate_signed_url_v2(
 
     :type query_parameters: dict
     :param query_parameters:
-        (Optional) Additional query paramtersto be included as part of the
+        (Optional) Additional query parameters to be included as part of the
         signed URLs.  See:
         https://cloud.google.com/storage/docs/xml-api/reference-headers#query
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -445,7 +445,7 @@ class Blob(_PropertyMixin):
 
         :type query_parameters: dict
         :param query_parameters:
-            (Optional) Additional query paramtersto be included as part of the
+            (Optional) Additional query parameters to be included as part of the
             signed URLs.  See:
             https://cloud.google.com/storage/docs/xml-api/reference-headers#query
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2452,7 +2452,7 @@ class Bucket(_PropertyMixin):
 
         :type query_parameters: dict
         :param query_parameters:
-            (Optional) Additional query paramtersto be included as part of the
+            (Optional) Additional query parameters to be included as part of the
             signed URLs.  See:
             https://cloud.google.com/storage/docs/xml-api/reference-headers#query
 

--- a/tests/unit/test__signing.py
+++ b/tests/unit/test__signing.py
@@ -339,7 +339,7 @@ class Test_canonicalize_v2(unittest.TestCase):
             canonical.headers, ["x-goog-extension:foobar", "x-goog-resumable:start"]
         )
 
-    def test_w_query_paramters(self):
+    def test_w_query_parameters(self):
         method = "GET"
         resource = "/bucket/blob"
         query_parameters = {"foo": "bar", "baz": "qux"}


### PR DESCRIPTION
Just a docs update, so no body here.