### PR TITLE
fix(storage): use OrderedDict while encoding POST policy

### DIFF
--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -16,6 +16,7 @@
 
 import base64
 import binascii
+import collections
 import datetime
 import functools
 import json
@@ -972,7 +973,14 @@ class Client(ClientWithProject):
 
         # encode policy for signing
         policy = json.dumps(
-            {"conditions": conditions, "expiration": policy_expires.isoformat() + "Z"},
+            collections.OrderedDict(
+                sorted(
+                    {
+                        "conditions": conditions,
+                        "expiration": policy_expires.isoformat() + "Z",
+                    }.items()
+                )
+            ),
             separators=(",", ":"),
         )
         str_to_sign = base64.b64encode(policy.encode("utf-8"))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1762,6 +1762,10 @@ def test_conformance_post_policy(test_data):
                     scheme=in_data.get("scheme"),
                 )
     fields = policy["fields"]
+    out_data = test_data["policyOutput"]
+
+    decoded_policy = base64.b64decode(fields["policy"]).decode("unicode_escape")
+    assert decoded_policy == out_data["expectedDecodedPolicy"]
 
     for field in (
         "x-goog-algorithm",
@@ -1771,9 +1775,6 @@ def test_conformance_post_policy(test_data):
     ):
         assert fields[field] == test_data["policyOutput"]["fields"][field]
 
-    out_data = test_data["policyOutput"]
-    decoded_policy = base64.b64decode(fields["policy"]).decode("unicode_escape")
-    assert decoded_policy == out_data["expectedDecodedPolicy"]
     assert policy["url"] == out_data["url"]
 
 


### PR DESCRIPTION
Towards https://github.com/googleapis/python-storage/pull/64#issuecomment-607430718
Sometimes policy losses it's order while encoding into JSON. Adding `OrderedDict()` to fix this.