### PR TITLE
test: delete client conformance tests dummy

### DIFF
--- a/tests/unit/test__signing.py
+++ b/tests/unit/test__signing.py
@@ -32,7 +32,6 @@ from . import _read_local_json
 
 _SERVICE_ACCOUNT_JSON = _read_local_json("url_signer_v4_test_account.json")
 _CONFORMANCE_TESTS = _read_local_json("url_signer_v4_test_data.json")["signingV4Tests"]
-_CLIENT_TESTS = [test for test in _CONFORMANCE_TESTS if "bucket" not in test]
 _BUCKET_TESTS = [
     test for test in _CONFORMANCE_TESTS if "bucket" in test and not test.get("object")
 ]
@@ -806,12 +805,6 @@ def _run_conformance_test(
     )
 
     assert url == test_data["expectedUrl"]
-
-
-@pytest.mark.parametrize("test_data", _CLIENT_TESTS)
-@pytest.mark.skip(reason="Bucketless URLs not yet supported")
-def test_conformance_client(test_data):
-    pass  # pragma: NO COVER
 
 
 @pytest.mark.parametrize("test_data", _BUCKET_TESTS)


### PR DESCRIPTION
This code has been added a year ago, and is never used. `_CLIENT_TESTS` is always empty. Proposing to erase this code.