### PR TITLE
feat: add if*generation*Match support, pt2

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -36,6 +36,10 @@ _GENERATION_MATCH_PARAMETERS = (
     ("if_generation_not_match", "ifGenerationNotMatch"),
     ("if_metageneration_match", "ifMetagenerationMatch"),
     ("if_metageneration_not_match", "ifMetagenerationNotMatch"),
+    ("if_source_generation_match", "ifSourceGenerationMatch"),
+    ("if_source_generation_not_match", "ifSourceGenerationNotMatch"),
+    ("if_source_metageneration_match", "ifSourceMetagenerationMatch"),
+    ("if_source_metageneration_not_match", "ifSourceMetagenerationNotMatch"),
 )
 
 

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -404,24 +404,24 @@ def _convert_to_timestamp(value):
     return mtime
 
 
-def _add_generation_match_parameters(name_value_pairs, **parameters):
+def _add_generation_match_parameters(parameters, **match_parameters):
     """Add generation match parameters into the given parameters list.
 
-    :type name_value_pairs: list or dict
-    :param name_value_pairs: Parameters list or dict.
+    :type parameters: list or dict
+    :param parameters: Parameters list or dict.
 
-    :type parameters: dict
-    :param parameters: if*generation*match parameters to add.
+    :type match_parameters: dict
+    :param match_parameters: if*generation*match parameters to add.
     """
     for snakecase_name, camelcase_name in _GENERATION_MATCH_PARAMETERS:
-        value = parameters.get(snakecase_name)
+        value = match_parameters.get(snakecase_name)
 
         if value is not None:
-            if isinstance(name_value_pairs, list):
-                name_value_pairs.append((camelcase_name, value))
+            if isinstance(parameters, list):
+                parameters.append((camelcase_name, value))
 
-            elif isinstance(name_value_pairs, dict):
-                name_value_pairs[camelcase_name] = value
+            elif isinstance(parameters, dict):
+                parameters[camelcase_name] = value
 
 
 def _raise_for_more_than_one_none(**kwargs):

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -133,6 +133,8 @@ class _PropertyMixin(object):
         self,
         client=None,
         timeout=_DEFAULT_TIMEOUT,
+        if_generation_match=None,
+        if_generation_not_match=None,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
     ):
@@ -152,6 +154,19 @@ class _PropertyMixin(object):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
+        :type if_generation_match: long
+        :param if_generation_match: (Optional) Make the operation conditional on whether
+                                    the blob's current generation matches the given value.
+                                    Setting to 0 makes the operation succeed only if there
+                                    are no live versions of the blob.
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match: (Optional) Make the operation conditional on whether
+                                        the blob's current generation does not match the given
+                                        value. If no live blob exists, the precondition fails.
+                                        Setting to 0 makes the operation succeed only if there
+                                        is a live version of the blob.
+
         :type if_metageneration_match: long
         :param if_metageneration_match: (Optional) Make the operation conditional on whether the
                                         blob's current metageneration matches the given value.
@@ -164,6 +179,10 @@ class _PropertyMixin(object):
                  ``if_metageneration_not_match`` are both set.
         """
         _raise_for_more_than_one_none(
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+        )
+        _raise_for_more_than_one_none(
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
         )
@@ -174,6 +193,8 @@ class _PropertyMixin(object):
         query_params["projection"] = "noAcl"
         _add_generation_match_parameters(
             query_params,
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
         )
@@ -219,6 +240,8 @@ class _PropertyMixin(object):
         self,
         client=None,
         timeout=_DEFAULT_TIMEOUT,
+        if_generation_match=None,
+        if_generation_not_match=None,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
     ):
@@ -240,6 +263,19 @@ class _PropertyMixin(object):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
+        :type if_generation_match: long
+        :param if_generation_match: (Optional) Make the operation conditional on whether
+                                    the blob's current generation matches the given value.
+                                    Setting to 0 makes the operation succeed only if there
+                                    are no live versions of the blob.
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match: (Optional) Make the operation conditional on whether
+                                        the blob's current generation does not match the given
+                                        value. If no live blob exists, the precondition fails.
+                                        Setting to 0 makes the operation succeed only if there
+                                        is a live version of the blob.
+
         :type if_metageneration_match: long
         :param if_metageneration_match: (Optional) Make the operation conditional on whether the
                                         blob's current metageneration matches the given value.
@@ -249,8 +285,14 @@ class _PropertyMixin(object):
                                             blob's current metageneration does not match the given value.
 
         :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match`` are both set.
+                 ``if_metageneration_not_match``, or
+                 ``if_generation_match`` and ``if_generation_not_match``
+                 are both set.
         """
+        _raise_for_more_than_one_none(
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+        )
         _raise_for_more_than_one_none(
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
@@ -262,6 +304,8 @@ class _PropertyMixin(object):
         query_params["projection"] = "full"
         _add_generation_match_parameters(
             query_params,
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
         )
@@ -282,6 +326,8 @@ class _PropertyMixin(object):
         self,
         client=None,
         timeout=_DEFAULT_TIMEOUT,
+        if_generation_match=None,
+        if_generation_not_match=None,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
     ):
@@ -303,17 +349,35 @@ class _PropertyMixin(object):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
+        :type if_generation_match: long
+        :param if_generation_match: (Optional) Make the operation conditional on whether
+                                    the blob's current generation matches the given value.
+                                    Setting to 0 makes the operation succeed only if there
+                                    are no live versions of the blob.
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match: (Optional) Make the operation conditional on whether
+                                        the blob's current generation does not match the given
+                                        value. If no live blob exists, the precondition fails.
+                                        Setting to 0 makes the operation succeed only if there
+                                        is a live version of the blob.
+
         :type if_metageneration_match: long
         :param if_metageneration_match: (Optional) Make the operation conditional on whether the
                                         blob's current metageneration matches the given value.
 
-        :type if_metageneration_not_match: long
-        :param if_metageneration_not_match: (Optional) Make the operation conditional on whether the
-                                            blob's current metageneration does not match the given value.
+        :raises: :class:`ValueError` if ``if_metageneration_match`` and
+                 ``if_metageneration_not_match``, or
+                 ``if_generation_match`` and ``if_generation_not_match``
+                 are both set.
 
         :raises: :class:`ValueError` if ``if_metageneration_match`` and
                  ``if_metageneration_not_match`` are both set.
         """
+        _raise_for_more_than_one_none(
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+        )
         _raise_for_more_than_one_none(
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -762,20 +762,7 @@ class Blob(_PropertyMixin):
 
         :rtype: str
         :returns: The download URL for the current blob.
-
-        :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match``, or
-                 ``if_generation_match`` and ``if_generation_not_match``
-                 are both set.
         """
-        _raise_for_more_than_one_none(
-            if_generation_match=if_generation_match,
-            if_generation_not_match=if_generation_not_match,
-        )
-        _raise_for_more_than_one_none(
-            if_metageneration_match=if_metageneration_match,
-            if_metageneration_not_match=if_metageneration_not_match,
-        )
         name_value_pairs = []
         if self.media_link is None:
             base_url = _DOWNLOAD_URL_TEMPLATE.format(
@@ -943,11 +930,6 @@ class Blob(_PropertyMixin):
                                             blob's current metageneration does not match the given value.
 
         :raises: :class:`google.cloud.exceptions.NotFound`
-
-        :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match``, or
-                 ``if_generation_match`` and ``if_generation_not_match``
-                 are both set.
         """
         client = self._require_client(client)
 
@@ -1025,11 +1007,6 @@ class Blob(_PropertyMixin):
                                             blob's current metageneration does not match the given value.
 
         :raises: :class:`google.cloud.exceptions.NotFound`
-
-        :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match``, or
-                 ``if_generation_match`` and ``if_generation_not_match``
-                 are both set.
         """
         try:
             with open(filename, "wb") as file_obj:
@@ -1112,11 +1089,6 @@ class Blob(_PropertyMixin):
         :returns: The data stored in this blob.
 
         :raises: :class:`google.cloud.exceptions.NotFound`
-
-        :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match``, or
-                 ``if_generation_match`` and ``if_generation_not_match``
-                 are both set.
         """
         string_buffer = BytesIO()
         self.download_to_file(
@@ -2390,32 +2362,7 @@ class Blob(_PropertyMixin):
                   ``bytes_rewritten`` is the number of bytes rewritten so far,
                   and ``total_bytes`` is the total number of bytes to be
                   rewritten.
-
-        :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match``, or
-                 ``if_generation_match`` and ``if_generation_not_match``,
-                 or ``if_source_generation_match`` and
-                 ``if_source_generation_not_match``, or
-                 ``if_source_metageneration_match`` and
-                 ``if_source_metageneration_not_match``
-                 are both set.
         """
-        _raise_for_more_than_one_none(
-            if_generation_match=if_generation_match,
-            if_generation_not_match=if_generation_not_match,
-        )
-        _raise_for_more_than_one_none(
-            if_metageneration_match=if_metageneration_match,
-            if_metageneration_not_match=if_metageneration_not_match,
-        )
-        _raise_for_more_than_one_none(
-            if_source_generation_match=if_source_generation_match,
-            if_source_generation_not_match=if_source_generation_not_match,
-        )
-        _raise_for_more_than_one_none(
-            if_source_metageneration_match=if_source_metageneration_match,
-            if_source_metageneration_not_match=if_source_metageneration_not_match,
-        )
         client = self._require_client(client)
         headers = _get_encryption_headers(self._encryption_key)
         headers.update(_get_encryption_headers(source._encryption_key, source=True))
@@ -2560,15 +2507,6 @@ class Blob(_PropertyMixin):
                                                    conditional on whether the source
                                                    object's current metageneration
                                                    does not match the given value.
-
-        :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match``, or
-                 ``if_generation_match`` and ``if_generation_not_match``,
-                 or ``if_source_generation_match`` and
-                 ``if_source_generation_not_match``, or
-                 ``if_source_metageneration_match`` and
-                 ``if_source_metageneration_not_match``
-                 are both set.
         """
         if new_class not in self.STORAGE_CLASSES:
             raise ValueError("Invalid storage class: %s" % (new_class,))

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -57,6 +57,7 @@ from google.cloud.exceptions import NotFound
 from google.cloud.storage._helpers import _PropertyMixin
 from google.cloud.storage._helpers import _scalar_property
 from google.cloud.storage._helpers import _convert_to_timestamp
+from google.cloud.storage._helpers import _raise_for_more_than_one_none
 from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage.acl import ACL
@@ -2639,24 +2640,3 @@ def _add_query_parameters(base_url, name_value_pairs):
     query = parse_qsl(query)
     query.extend(name_value_pairs)
     return urlunsplit((scheme, netloc, path, urlencode(query), frag))
-
-
-def _raise_for_more_than_one_none(**kwargs):
-    """Raise ``ValueError`` exception if more than one parameter was set.
-
-    :type error: :exc:`ValueError`
-    :param error: Description of which fields were set
-
-    :raises: :class:`~ValueError` containing the fields that were set
-    """
-    if sum(arg is not None for arg in kwargs.values()) > 1:
-        escaped_keys = ["'%s'" % name for name in kwargs.keys()]
-
-        keys_but_last = ", ".join(escaped_keys[:-1])
-        last_key = escaped_keys[-1]
-
-        msg = "Pass at most one of {keys_but_last} and {last_key}".format(
-            keys_but_last=keys_but_last, last_key=last_key
-        )
-
-        raise ValueError(msg)

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1485,15 +1485,6 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The new Blob.
 
-        :raises: :class:`ValueError` if ``if_metageneration_match`` and
-                 ``if_metageneration_not_match``, or
-                 ``if_generation_match`` and ``if_generation_not_match``,
-                 or ``if_source_generation_match`` and
-                 ``if_source_generation_not_match``, or
-                 ``if_source_metageneration_match`` and
-                 ``if_source_metageneration_not_match``
-                 are both set.
-
         Example:
             Copy a blob including ACL.
 
@@ -1508,22 +1499,6 @@ class Bucket(_PropertyMixin):
             >>> new_blob = bucket.copy_blob(blob, dst_bucket)
             >>> new_blob.acl.save(blob.acl)
         """
-        _raise_for_more_than_one_none(
-            if_generation_match=if_generation_match,
-            if_generation_not_match=if_generation_not_match,
-        )
-        _raise_for_more_than_one_none(
-            if_metageneration_match=if_metageneration_match,
-            if_metageneration_not_match=if_metageneration_not_match,
-        )
-        _raise_for_more_than_one_none(
-            if_source_generation_match=if_source_generation_match,
-            if_source_generation_not_match=if_source_generation_not_match,
-        )
-        _raise_for_more_than_one_none(
-            if_source_metageneration_match=if_source_metageneration_match,
-            if_source_metageneration_not_match=if_source_metageneration_not_match,
-        )
         client = self._require_client(client)
         query_params = {}
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1421,6 +1421,14 @@ class Bucket(_PropertyMixin):
         preserve_acl=True,
         source_generation=None,
         timeout=_DEFAULT_TIMEOUT,
+        if_generation_match=None,
+        if_generation_not_match=None,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+        if_source_generation_match=None,
+        if_source_generation_not_match=None,
+        if_source_metageneration_match=None,
+        if_source_metageneration_not_match=None,
     ):
         """Copy the given blob to the given bucket, optionally with a new name.
 
@@ -1438,7 +1446,7 @@ class Bucket(_PropertyMixin):
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
-        :param client: (Optional) The client to use.  If not passed, falls back
+        :param client: (Optional) The client to use. If not passed, falls back
                        to the ``client`` stored on the current bucket.
 
         :type preserve_acl: bool
@@ -1457,8 +1465,74 @@ class Bucket(_PropertyMixin):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
+        :type if_generation_match: long
+        :param if_generation_match: (Optional) Makes the operation
+                                    conditional on whether the destination
+                                    object's current generation matches the
+                                    given value. Setting to 0 makes the
+                                    operation succeed only if there are no
+                                    live versions of the object.
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match: (Optional) Makes the operation
+                                        conditional on whether the
+                                        destination object's current
+                                        generation does not match the given
+                                        value. If no live object exists,
+                                        the precondition fails. Setting to
+                                        0 makes the operation succeed only
+                                        if there is a live version
+                                        of the object.
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match: (Optional) Makes the operation
+                                        conditional on whether the
+                                        destination object's current
+                                        metageneration matches the given
+                                        value.
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match: (Optional) Makes the operation
+                                            conditional on whether the
+                                            destination object's current
+                                            metageneration does not match
+                                            the given value.
+
+        :type if_source_generation_match: long
+        :param if_source_generation_match: (Optional) Makes the operation
+                                           conditional on whether the source
+                                           object's generation matches the
+                                           given value.
+
+        :type if_source_generation_not_match: long
+        :param if_source_generation_not_match: (Optional) Makes the operation
+                                               conditional on whether the source
+                                               object's generation does not match
+                                               the given value.
+
+        :type if_source_metageneration_match: long
+        :param if_source_metageneration_match: (Optional) Makes the operation
+                                               conditional on whether the source
+                                               object's current metageneration
+                                               matches the given value.
+
+        :type if_source_metageneration_not_match: long
+        :param if_source_metageneration_not_match: (Optional) Makes the operation
+                                                   conditional on whether the source
+                                                   object's current metageneration
+                                                   does not match the given value.
+
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The new Blob.
+
+        :raises: :class:`ValueError` if ``if_metageneration_match`` and
+                 ``if_metageneration_not_match``, or
+                 ``if_generation_match`` and ``if_generation_not_match``,
+                 or ``if_source_generation_match`` and
+                 ``if_source_generation_not_match``, or
+                 ``if_source_metageneration_match`` and
+                 ``if_source_metageneration_not_match``
+                 are both set.
 
         Example:
             Copy a blob including ACL.
@@ -1474,6 +1548,22 @@ class Bucket(_PropertyMixin):
             >>> new_blob = bucket.copy_blob(blob, dst_bucket)
             >>> new_blob.acl.save(blob.acl)
         """
+        _raise_for_more_than_one_none(
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+        )
+        _raise_for_more_than_one_none(
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+        )
+        _raise_for_more_than_one_none(
+            if_source_generation_match=if_source_generation_match,
+            if_source_generation_not_match=if_source_generation_not_match,
+        )
+        _raise_for_more_than_one_none(
+            if_source_metageneration_match=if_source_metageneration_match,
+            if_source_metageneration_not_match=if_source_metageneration_not_match,
+        )
         client = self._require_client(client)
         query_params = {}
 
@@ -1482,6 +1572,18 @@ class Bucket(_PropertyMixin):
 
         if source_generation is not None:
             query_params["sourceGeneration"] = source_generation
+
+        _add_generation_match_parameters(
+            query_params,
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+            if_source_generation_match=if_source_generation_match,
+            if_source_generation_not_match=if_source_generation_not_match,
+            if_source_metageneration_match=if_source_metageneration_match,
+            if_source_metageneration_not_match=if_source_metageneration_not_match,
+        )
 
         if new_name is None:
             new_name = blob.name

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -281,7 +281,13 @@ class Client(ClientWithProject):
         """
         return Batch(client=self)
 
-    def get_bucket(self, bucket_or_name, timeout=_DEFAULT_TIMEOUT):
+    def get_bucket(
+        self,
+        bucket_or_name,
+        timeout=_DEFAULT_TIMEOUT,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+    ):
         """API call: retrieve a bucket via a GET request.
 
         See
@@ -300,6 +306,14 @@ class Client(ClientWithProject):
                 Can also be passed as a tuple (connect_timeout, read_timeout).
                 See :meth:`requests.Session.request` documentation for details.
 
+            if_metageneration_match (Optional[long]):
+                Make the operation conditional on whether the
+                blob's current metageneration matches the given value.
+
+            if_metageneration_not_match (Optional[long]):
+                Make the operation conditional on whether the blob's
+                current metageneration does not match the given value.
+
         Returns:
             google.cloud.storage.bucket.Bucket
                 The bucket matching the name provided.
@@ -307,6 +321,10 @@ class Client(ClientWithProject):
         Raises:
             google.cloud.exceptions.NotFound
                 If the bucket is not found.
+
+            ValueError
+                If `if_metageneration_match` and
+                `if_metageneration_not_match` are both set.
 
         Examples:
             Retrieve a bucket using a string.
@@ -329,11 +347,21 @@ class Client(ClientWithProject):
 
         """
         bucket = self._bucket_arg_to_bucket(bucket_or_name)
-
-        bucket.reload(client=self, timeout=timeout)
+        bucket.reload(
+            client=self,
+            timeout=timeout,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+        )
         return bucket
 
-    def lookup_bucket(self, bucket_name, timeout=_DEFAULT_TIMEOUT):
+    def lookup_bucket(
+        self,
+        bucket_name,
+        timeout=_DEFAULT_TIMEOUT,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+    ):
         """Get a bucket by name, returning None if not found.
 
         You can use this if you would rather check for a None value
@@ -353,11 +381,27 @@ class Client(ClientWithProject):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
+        :type if_metageneration_match: long
+        :param if_metageneration_match: (Optional) Make the operation conditional on whether the
+                                        blob's current metageneration matches the given value.
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match: (Optional) Make the operation conditional on whether the
+                                            blob's current metageneration does not match the given value.
+
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The bucket matching the name provided or None if not found.
+
+        :raises: :class:`ValueError` if ``if_metageneration_match`` and
+                 ``if_metageneration_not_match`` are both set.
         """
         try:
-            return self.get_bucket(bucket_name, timeout=timeout)
+            return self.get_bucket(
+                bucket_name,
+                timeout=timeout,
+                if_metageneration_match=if_metageneration_match,
+                if_metageneration_not_match=if_metageneration_not_match,
+            )
         except NotFound:
             return None
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -126,6 +126,37 @@ class Test_PropertyMixin(unittest.TestCase):
         )
         self.assertEqual(derived._changes, set())
 
+    def test_reload_with_metageneration_match(self):
+        METAGENERATION_NUMBER = 6
+
+        connection = _Connection({"foo": "Foo"})
+        client = _Client(connection)
+        derived = self._derivedClass("/path")()
+        # Make sure changes is not a set instance before calling reload
+        # (which will clear / replace it with an empty set), checked below.
+        derived._changes = object()
+        derived.reload(
+            client=client, timeout=42, if_metageneration_match=METAGENERATION_NUMBER
+        )
+        self.assertEqual(derived._properties, {"foo": "Foo"})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(
+            kw[0],
+            {
+                "method": "GET",
+                "path": "/path",
+                "query_params": {
+                    "projection": "noAcl",
+                    "ifMetagenerationMatch": METAGENERATION_NUMBER,
+                },
+                "headers": {},
+                "_target_object": derived,
+                "timeout": 42,
+            },
+        )
+        self.assertEqual(derived._changes, set())
+
     def test_reload_w_user_project(self):
         user_project = "user-project-123"
         connection = _Connection({"foo": "Foo"})
@@ -191,6 +222,41 @@ class Test_PropertyMixin(unittest.TestCase):
         # Make sure changes get reset by patch().
         self.assertEqual(derived._changes, set())
 
+    def test_patch_with_metageneration_match(self):
+        METAGENERATION_NUMBER = 6
+
+        connection = _Connection({"foo": "Foo"})
+        client = _Client(connection)
+        derived = self._derivedClass("/path")()
+        # Make sure changes is non-empty, so we can observe a change.
+        BAR = object()
+        BAZ = object()
+        derived._properties = {"bar": BAR, "baz": BAZ}
+        derived._changes = set(["bar"])  # Ignore baz.
+        derived.patch(
+            client=client, timeout=42, if_metageneration_match=METAGENERATION_NUMBER
+        )
+        self.assertEqual(derived._properties, {"foo": "Foo"})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(
+            kw[0],
+            {
+                "method": "PATCH",
+                "path": "/path",
+                "query_params": {
+                    "projection": "full",
+                    "ifMetagenerationMatch": METAGENERATION_NUMBER,
+                },
+                # Since changes does not include `baz`, we don't see it sent.
+                "data": {"bar": BAR},
+                "_target_object": derived,
+                "timeout": 42,
+            },
+        )
+        # Make sure changes get reset by patch().
+        self.assertEqual(derived._changes, set())
+
     def test_patch_w_user_project(self):
         user_project = "user-project-123"
         connection = _Connection({"foo": "Foo"})
@@ -236,6 +302,34 @@ class Test_PropertyMixin(unittest.TestCase):
         self.assertEqual(kw[0]["method"], "PUT")
         self.assertEqual(kw[0]["path"], "/path")
         self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+        self.assertEqual(kw[0]["data"], {"bar": BAR, "baz": BAZ})
+        self.assertEqual(kw[0]["timeout"], 42)
+        # Make sure changes get reset by patch().
+        self.assertEqual(derived._changes, set())
+
+    def test_update_with_metageneration_not_match(self):
+        GENERATION_NUMBER = 6
+
+        connection = _Connection({"foo": "Foo"})
+        client = _Client(connection)
+        derived = self._derivedClass("/path")()
+        # Make sure changes is non-empty, so we can observe a change.
+        BAR = object()
+        BAZ = object()
+        derived._properties = {"bar": BAR, "baz": BAZ}
+        derived._changes = set(["bar"])  # Update sends 'baz' anyway.
+        derived.update(
+            client=client, timeout=42, if_metageneration_not_match=GENERATION_NUMBER
+        )
+        self.assertEqual(derived._properties, {"foo": "Foo"})
+        kw = connection._requested
+        self.assertEqual(len(kw), 1)
+        self.assertEqual(kw[0]["method"], "PUT")
+        self.assertEqual(kw[0]["path"], "/path")
+        self.assertEqual(
+            kw[0]["query_params"],
+            {"projection": "full", "ifMetagenerationNotMatch": GENERATION_NUMBER},
+        )
         self.assertEqual(kw[0]["data"], {"bar": BAR, "baz": BAZ})
         self.assertEqual(kw[0]["timeout"], 42)
         # Make sure changes get reset by patch().

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -478,6 +478,22 @@ class Test__add_generation_match_parameters(unittest.TestCase):
         )
         self.assertEqual(params, EXPECTED_PARAMS)
 
+    def test_add_generation_match_parameters_tuple(self):
+        GENERATION_NUMBER = 9
+        METAGENERATION_NUMBER = 6
+        EXPECTED_PARAMS = (
+            ("param1", "value1"),
+            ("param2", "value2"),
+        )
+
+        params = (("param1", "value1"), ("param2", "value2"))
+        self._call_fut(
+            params,
+            if_generation_match=GENERATION_NUMBER,
+            if_metageneration_match=METAGENERATION_NUMBER,
+        )
+        self.assertEqual(params, EXPECTED_PARAMS)
+
 
 class _Connection(object):
     def __init__(self, *responses):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -437,6 +437,48 @@ class Test__base64_md5hash(unittest.TestCase):
         self.assertEqual(MD5.hash_obj._blocks, [BYTES_TO_SIGN])
 
 
+class Test__add_generation_match_parameters(unittest.TestCase):
+    def _call_fut(self, params, **match_params):
+        from google.cloud.storage._helpers import _add_generation_match_parameters
+
+        return _add_generation_match_parameters(params, **match_params)
+
+    def test_add_generation_match_parameters_list(self):
+        GENERATION_NUMBER = 9
+        METAGENERATION_NUMBER = 6
+        EXPECTED_PARAMS = [
+            ("param1", "value1"),
+            ("param2", "value2"),
+            ("ifGenerationMatch", GENERATION_NUMBER),
+            ("ifMetagenerationMatch", METAGENERATION_NUMBER),
+        ]
+        params = [("param1", "value1"), ("param2", "value2")]
+        self._call_fut(
+            params,
+            if_generation_match=GENERATION_NUMBER,
+            if_metageneration_match=METAGENERATION_NUMBER,
+        )
+        self.assertEqual(params, EXPECTED_PARAMS)
+
+    def test_add_generation_match_parameters_dict(self):
+        GENERATION_NUMBER = 9
+        METAGENERATION_NUMBER = 6
+        EXPECTED_PARAMS = {
+            "param1": "value1",
+            "param2": "value2",
+            "ifGenerationMatch": GENERATION_NUMBER,
+            "ifMetagenerationMatch": METAGENERATION_NUMBER,
+        }
+
+        params = {"param1": "value1", "param2": "value2"}
+        self._call_fut(
+            params,
+            if_generation_match=GENERATION_NUMBER,
+            if_metageneration_match=METAGENERATION_NUMBER,
+        )
+        self.assertEqual(params, EXPECTED_PARAMS)
+
+
 class _Connection(object):
     def __init__(self, *responses):
         self._responses = responses

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -1211,7 +1211,9 @@ class Test_Blob(unittest.TestCase):
 
         client = mock.Mock(spec=["_http"])
 
-        blob = self._make_one("blob-name", bucket=_Bucket(client), properties={"mediaLink": MEDIA_LINK})
+        blob = self._make_one(
+            "blob-name", bucket=_Bucket(client), properties={"mediaLink": MEDIA_LINK}
+        )
         blob._do_download = mock.Mock()
 
         with _NamedTemporaryFile() as temp:
@@ -1320,9 +1322,7 @@ class Test_Blob(unittest.TestCase):
 
         client = mock.Mock(spec=["_http"])
         blob = self._make_one(
-            "blob-name",
-            bucket=_Bucket(client),
-            properties={"mediaLink": MEDIA_LINK}
+            "blob-name", bucket=_Bucket(client), properties={"mediaLink": MEDIA_LINK}
         )
         blob.download_to_file = mock.Mock()
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -623,13 +623,23 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BUCKET_NAME = "bucket-name"
-        URI = "/".join(
+        URI1 = "/".join(
             [
                 client._connection.API_BASE_URL,
                 "storage",
                 client._connection.API_VERSION,
                 "b",
                 "%s?projection=noAcl&ifMetagenerationMatch=%s"
+                % (BUCKET_NAME, METAGENERATION_NUMBER),
+            ]
+        )
+        URI2 = "/".join(
+            [
+                client._connection.API_BASE_URL,
+                "storage",
+                client._connection.API_VERSION,
+                "b",
+                "%s?ifMetagenerationMatch=%s&projection=noAcl"
                 % (BUCKET_NAME, METAGENERATION_NUMBER),
             ]
         )
@@ -644,11 +654,13 @@ class TestClient(unittest.TestCase):
         self.assertEqual(bucket.name, BUCKET_NAME)
         http.request.assert_called_once_with(
             method="GET",
-            url=URI,
+            url=mock.ANY,
             data=mock.ANY,
             headers=mock.ANY,
             timeout=self._get_default_timeout(),
         )
+        _, kwargs = http.request.call_args
+        self.assertIn(kwargs.get("url"), (URI1, URI2))
 
     def test_create_bucket_w_missing_client_project(self):
         credentials = _make_credentials()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -445,13 +445,23 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
 
         BUCKET_NAME = "bucket-name"
-        URI = "/".join(
+        URI1 = "/".join(
             [
                 client._connection.API_BASE_URL,
                 "storage",
                 client._connection.API_VERSION,
                 "b",
                 "%s?projection=noAcl&ifMetagenerationMatch=%s"
+                % (BUCKET_NAME, METAGENERATION_NUMBER),
+            ]
+        )
+        URI2 = "/".join(
+            [
+                client._connection.API_BASE_URL,
+                "storage",
+                client._connection.API_VERSION,
+                "b",
+                "%s?ifMetagenerationMatch=%s&projection=noAcl"
                 % (BUCKET_NAME, METAGENERATION_NUMBER),
             ]
         )
@@ -466,11 +476,13 @@ class TestClient(unittest.TestCase):
         self.assertEqual(bucket.name, BUCKET_NAME)
         http.request.assert_called_once_with(
             method="GET",
-            url=URI,
+            url=mock.ANY,
             data=mock.ANY,
             headers=mock.ANY,
             timeout=self._get_default_timeout(),
         )
+        _, kwargs = http.request.call_args
+        self.assertIn(kwargs.get("url"), (URI1, URI2))
 
     def test_get_bucket_with_object_miss(self):
         from google.cloud.exceptions import NotFound

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -436,6 +436,42 @@ class TestClient(unittest.TestCase):
             timeout=self._get_default_timeout(),
         )
 
+    def test_get_bucket_with_metageneration_match(self):
+        from google.cloud.storage.bucket import Bucket
+
+        PROJECT = "PROJECT"
+        CREDENTIALS = _make_credentials()
+        METAGENERATION_NUMBER = 6
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+
+        BUCKET_NAME = "bucket-name"
+        URI = "/".join(
+            [
+                client._connection.API_BASE_URL,
+                "storage",
+                client._connection.API_VERSION,
+                "b",
+                "%s?projection=noAcl&ifMetagenerationMatch=%s"
+                % (BUCKET_NAME, METAGENERATION_NUMBER),
+            ]
+        )
+        data = {"name": BUCKET_NAME}
+        http = _make_requests_session([_make_json_response(data)])
+        client._http_internal = http
+
+        bucket = client.get_bucket(
+            BUCKET_NAME, if_metageneration_match=METAGENERATION_NUMBER
+        )
+        self.assertIsInstance(bucket, Bucket)
+        self.assertEqual(bucket.name, BUCKET_NAME)
+        http.request.assert_called_once_with(
+            method="GET",
+            url=URI,
+            data=mock.ANY,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
+        )
+
     def test_get_bucket_with_object_miss(self):
         from google.cloud.exceptions import NotFound
         from google.cloud.storage.bucket import Bucket
@@ -556,6 +592,42 @@ class TestClient(unittest.TestCase):
 
         bucket = client.lookup_bucket(BUCKET_NAME)
 
+        self.assertIsInstance(bucket, Bucket)
+        self.assertEqual(bucket.name, BUCKET_NAME)
+        http.request.assert_called_once_with(
+            method="GET",
+            url=URI,
+            data=mock.ANY,
+            headers=mock.ANY,
+            timeout=self._get_default_timeout(),
+        )
+
+    def test_lookup_bucket_with_metageneration_match(self):
+        from google.cloud.storage.bucket import Bucket
+
+        PROJECT = "PROJECT"
+        CREDENTIALS = _make_credentials()
+        METAGENERATION_NUMBER = 6
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+
+        BUCKET_NAME = "bucket-name"
+        URI = "/".join(
+            [
+                client._connection.API_BASE_URL,
+                "storage",
+                client._connection.API_VERSION,
+                "b",
+                "%s?projection=noAcl&ifMetagenerationMatch=%s"
+                % (BUCKET_NAME, METAGENERATION_NUMBER),
+            ]
+        )
+        data = {"name": BUCKET_NAME}
+        http = _make_requests_session([_make_json_response(data)])
+        client._http_internal = http
+
+        bucket = client.lookup_bucket(
+            BUCKET_NAME, if_metageneration_match=METAGENERATION_NUMBER
+        )
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, BUCKET_NAME)
         http.request.assert_called_once_with(


### PR DESCRIPTION
Add `if*generation*match` args into methods:

`Blob.download_to_file()`
`Blob.download_to_filename()`
`Blob.download_as_string()`
`Blob.rewrite()`
`Blob.update_storage_class()`
`Bucket.copy_blob()`

Towards #127 