### PR TITLE
tests: pin google-cloud-kms to un-break systests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -125,7 +125,7 @@ def system(session):
         "google-cloud-testutils",
         "google-cloud-iam",
         "google-cloud-pubsub",
-        "google-cloud-kms",
+        "google-cloud-kms < 2.0dev",
     )
     session.install("-e", ".")
 

--- a/synth.py
+++ b/synth.py
@@ -29,7 +29,8 @@ templated_files = common.py_library(
     system_test_external_dependencies=[
         "google-cloud-iam",
         "google-cloud-pubsub",
-        "google-cloud-kms",
+        # See: https://github.com/googleapis/python-storage/issues/226
+        "google-cloud-kms < 2.0dev",
     ],
 )
 s.move(

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1829,14 +1829,6 @@ class TestAnonymousClient(unittest.TestCase):
             retry_429_503(blob.download_to_file)(stream)
 
 
-_KMS_2_0_BREAKAGE_MESSAGE = """\
-KMS 2.0.0 incompatible with our test setup.
-
-See https://github.com/googleapis/python-storage/issues/226
-"""
-
-
-@unittest.skipIf(six.PY3, reason=_KMS_2_0_BREAKAGE_MESSAGE)
 class TestKMSIntegration(TestStorageFiles):
 
     FILENAMES = ("file01.txt",)


### PR DESCRIPTION
See: #226, PR #227.