### PR TITLE
fix(blob): extract padding chars from hashes

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -804,7 +804,7 @@ class Blob(_PropertyMixin):
 
         digests = {}
         for encoded_digest in x_goog_hash.split(","):
-            match = re.match(r"(crc32c|md5)=([\w\d]+)==", encoded_digest)
+            match = re.match(r"(crc32c|md5)=([\w\d]+=*)", encoded_digest)
             if match:
                 method, digest = match.groups()
                 digests[method] = digest

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -804,7 +804,7 @@ class Blob(_PropertyMixin):
 
         digests = {}
         for encoded_digest in x_goog_hash.split(","):
-            match = re.match(r"(crc32c|md5)=([\w\d]+=*)", encoded_digest)
+            match = re.match(r"(crc32c|md5)=([\w\d]+={0,3})", encoded_digest)
             if match:
                 method, digest = match.groups()
                 digests[method] = digest

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -1476,8 +1476,8 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.content_encoding, "gzip")
         self.assertEqual(blob.cache_control, "max-age=1337;public")
         self.assertEqual(blob.storage_class, "STANDARD")
-        self.assertEqual(blob.md5_hash, "CS9tHYTtyFntzj7B9nkkJQ")
-        self.assertEqual(blob.crc32c, "4gcgLQ")
+        self.assertEqual(blob.md5_hash, "CS9tHYTtyFntzj7B9nkkJQ==")
+        self.assertEqual(blob.crc32c, "4gcgLQ==")
 
     def test_download_as_string_w_hash_response_header_none(self):
         blob_name = "blob-name"


### PR DESCRIPTION
I didn't previously understand that the "==" at the end of the hash
isn't merely a delimiter, but a padding character for base64 encoding.
It's not strictly necessary to have it, but you have to add it back in
to perform a base64 decode. Base64 encoded strings are padded out to
a multiple of four characters.


https://en.wikipedia.org/wiki/Base64#Output_padding