### PR TITLE
test: add retry for bucket cmek enabled system test

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -2013,6 +2013,7 @@ class TestKMSIntegration(TestStorageFiles):
 
         self.assertEqual(dest.download_as_bytes(), source_data)
 
+    @RetryErrors(unittest.TestCase.failureException)
     def test_upload_new_blob_w_bucket_cmek_enabled(self):
         blob_name = "test-blob"
         payload = b"DEADBEEF"

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -2013,7 +2013,6 @@ class TestKMSIntegration(TestStorageFiles):
 
         self.assertEqual(dest.download_as_bytes(), source_data)
 
-    @RetryErrors(unittest.TestCase.failureException)
     def test_upload_new_blob_w_bucket_cmek_enabled(self):
         blob_name = "test-blob"
         payload = b"DEADBEEF"
@@ -2026,6 +2025,7 @@ class TestKMSIntegration(TestStorageFiles):
 
         blob = self.bucket.blob(blob_name)
         blob.upload_from_string(payload)
+        retry_429_harder(blob.reload)()
         # We don't know the current version of the key.
         self.assertTrue(blob.kms_key_name.startswith(kms_key_name))
 
@@ -2035,7 +2035,7 @@ class TestKMSIntegration(TestStorageFiles):
         self.assertEqual(blob.download_as_bytes(), alt_payload)
 
         self.bucket.default_kms_key_name = None
-        self.bucket.patch()
+        retry_429_harder(self.bucket.patch)()
         self.assertIsNone(self.bucket.default_kms_key_name)
 
 


### PR DESCRIPTION
Fixes #239 

Tried to reproduce locally but no results so far, so adding a retry for the test to avoid flaky failures.
