### PR TITLE
chore: restrict pubsub to  < 2.0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,7 @@ def system(session):
         "pytest",
         "google-cloud-testutils",
         "google-cloud-iam",
-        "google-cloud-pubsub",
+        "google-cloud-pubsub < 2.0.0",
         "google-cloud-kms < 2.0dev",
     )
     session.install("-e", ".")

--- a/synth.py
+++ b/synth.py
@@ -28,7 +28,7 @@ templated_files = common.py_library(
     cov_level=99,
     system_test_external_dependencies=[
         "google-cloud-iam",
-        "google-cloud-pubsub",
+        "google-cloud-pubsub < 2.0.0",
         # See: https://github.com/googleapis/python-storage/issues/226
         "google-cloud-kms < 2.0dev",
     ],


### PR DESCRIPTION
Fixes #272 

For the passing current scenario restrict version in `nox.py` file and for the future added in synth.py file.

`google-cloud-pubsub==2.0.0` version has dropped the support of python2, so once storage will drop the support following changes needs to be done:

-  replace create_topic(self.topic_path) to create_topic(name=self.topic_path)

- replace get_iam_policy(self.topic_path) to get_iam_policy(request={"resource": self.topic_path})

- replace set_iam_policy(self.topic_path, policy) to set_iam_policy(request={"resource": self.topic_path, "policy": policy})

- replace delete_topic(self.topic_path) to delete_topic(request={"topic":self.topic_path})

