### PR TITLE
fix: Amend default retry behavior for bucket operations on client

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -597,7 +597,7 @@ class Blob(_PropertyMixin):
         if_generation_not_match=None,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
-        retry=DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
+        retry=DEFAULT_RETRY,
     ):
         """Determines whether or not this blob exists.
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -723,7 +723,7 @@ class Bucket(_PropertyMixin):
         timeout=_DEFAULT_TIMEOUT,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
-        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        retry=DEFAULT_RETRY,
     ):
         """Determines whether or not this bucket exists.
 
@@ -1108,7 +1108,7 @@ class Bucket(_PropertyMixin):
         if_generation_not_match=None,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
-        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        retry=DEFAULT_RETRY,
         **kwargs
     ):
         """Get a blob object by name.

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -52,7 +52,6 @@ from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
-from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
 
 
 _marker = object()
@@ -320,7 +319,7 @@ class Client(ClientWithProject):
         timeout=_DEFAULT_TIMEOUT,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
-        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        retry=DEFAULT_RETRY,
     ):
         """API call: retrieve a bucket via a GET request.
 
@@ -407,7 +406,7 @@ class Client(ClientWithProject):
         timeout=_DEFAULT_TIMEOUT,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
-        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        retry=DEFAULT_RETRY,
     ):
         """Get a bucket by name, returning None if not found.
 
@@ -865,7 +864,7 @@ class Client(ClientWithProject):
 
         path = bucket.path + "/o"
         api_request = functools.partial(
-            self._connection.api_request, timeout=timeout, retry=DEFAULT_RETRY
+            self._connection.api_request, timeout=timeout, retry=retry
         )
         iterator = page_iterator.HTTPIterator(
             client=self,

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -669,7 +669,7 @@ class Test_Blob(unittest.TestCase):
                 "query_params": {"fields": "name"},
                 "_target_object": None,
                 "timeout": 42,
-                "retry": DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
+                "retry": DEFAULT_RETRY,
             },
         )
 
@@ -692,7 +692,7 @@ class Test_Blob(unittest.TestCase):
                 "query_params": {"fields": "name", "userProject": USER_PROJECT},
                 "_target_object": None,
                 "timeout": self._get_default_timeout(),
-                "retry": DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
+                "retry": DEFAULT_RETRY,
             },
         )
 
@@ -715,7 +715,7 @@ class Test_Blob(unittest.TestCase):
                 "query_params": {"fields": "name", "generation": GENERATION},
                 "_target_object": None,
                 "timeout": self._get_default_timeout(),
-                "retry": DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
+                "retry": DEFAULT_RETRY,
             },
         )
 
@@ -749,7 +749,7 @@ class Test_Blob(unittest.TestCase):
                 },
                 "_target_object": None,
                 "timeout": self._get_default_timeout(),
-                "retry": DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
+                "retry": DEFAULT_RETRY,
             },
         )
 

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -672,7 +672,7 @@ class Test_Bucket(unittest.TestCase):
             "query_params": {"fields": "name"},
             "_target_object": None,
             "timeout": 42,
-            "retry": DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+            "retry": DEFAULT_RETRY,
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
@@ -707,7 +707,7 @@ class Test_Bucket(unittest.TestCase):
             },
             "_target_object": None,
             "timeout": 42,
-            "retry": DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+            "retry": DEFAULT_RETRY,
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)
@@ -735,7 +735,7 @@ class Test_Bucket(unittest.TestCase):
             "query_params": {"fields": "name", "userProject": USER_PROJECT},
             "_target_object": None,
             "timeout": self._get_default_timeout(),
-            "retry": DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+            "retry": DEFAULT_RETRY,
         }
         expected_cw = [((), expected_called_kwargs)]
         self.assertEqual(_FakeConnection._called_with, expected_cw)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -575,15 +575,40 @@ class TestClient(unittest.TestCase):
 
         with mock.patch.object(Connection, "api_request") as req:
             client.get_bucket(bucket_obj)
-            req.assert_called_once_with(
-                method="GET",
-                path=mock.ANY,
-                query_params=mock.ANY,
-                headers=mock.ANY,
-                _target_object=bucket_obj,
-                timeout=mock.ANY,
-                retry=DEFAULT_RETRY,
-            )
+
+        req.assert_called_once_with(
+            method="GET",
+            path=mock.ANY,
+            query_params=mock.ANY,
+            headers=mock.ANY,
+            _target_object=bucket_obj,
+            timeout=mock.ANY,
+            retry=DEFAULT_RETRY,
+        )
+
+    def test_get_bucket_respects_retry_override(self):
+        from google.cloud.storage.bucket import Bucket
+        from google.cloud.storage._http import Connection
+
+        PROJECT = "PROJECT"
+        CREDENTIALS = _make_credentials()
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+
+        bucket_name = "bucket-name"
+        bucket_obj = Bucket(client, bucket_name)
+
+        with mock.patch.object(Connection, "api_request") as req:
+            client.get_bucket(bucket_obj, retry=None)
+
+        req.assert_called_once_with(
+            method="GET",
+            path=mock.ANY,
+            query_params=mock.ANY,
+            headers=mock.ANY,
+            _target_object=bucket_obj,
+            timeout=mock.ANY,
+            retry=None,
+        )
 
     def test_lookup_bucket_miss(self):
         PROJECT = "PROJECT"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -562,6 +562,29 @@ class TestClient(unittest.TestCase):
         parms = dict(urlparse.parse_qsl(qs))
         self.assertEqual(parms["projection"], "noAcl")
 
+    def test_get_bucket_default_retry(self):
+        from google.cloud.storage.bucket import Bucket
+        from google.cloud.storage._http import Connection
+
+        PROJECT = "PROJECT"
+        CREDENTIALS = _make_credentials()
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+
+        bucket_name = "bucket-name"
+        bucket_obj = Bucket(client, bucket_name)
+
+        with mock.patch.object(Connection, "api_request") as req:
+            client.get_bucket(bucket_obj)
+            req.assert_called_once_with(
+                method="GET",
+                path=mock.ANY,
+                query_params=mock.ANY,
+                headers=mock.ANY,
+                _target_object=bucket_obj,
+                timeout=mock.ANY,
+                retry=DEFAULT_RETRY,
+            )
+
     def test_lookup_bucket_miss(self):
         PROJECT = "PROJECT"
         CREDENTIALS = _make_credentials()
@@ -657,6 +680,29 @@ class TestClient(unittest.TestCase):
         parms = dict(urlparse.parse_qsl(qs))
         self.assertEqual(parms["projection"], "noAcl")
         self.assertEqual(parms["ifMetagenerationMatch"], str(METAGENERATION_NUMBER))
+
+    def test_lookup_bucket_default_retry(self):
+        from google.cloud.storage.bucket import Bucket
+        from google.cloud.storage._http import Connection
+
+        PROJECT = "PROJECT"
+        CREDENTIALS = _make_credentials()
+        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+
+        bucket_name = "bucket-name"
+        bucket_obj = Bucket(client, bucket_name)
+
+        with mock.patch.object(Connection, "api_request") as req:
+            client.lookup_bucket(bucket_obj)
+            req.assert_called_once_with(
+                method="GET",
+                path=mock.ANY,
+                query_params=mock.ANY,
+                headers=mock.ANY,
+                _target_object=bucket_obj,
+                timeout=mock.ANY,
+                retry=DEFAULT_RETRY,
+            )
 
     def test_create_bucket_w_missing_client_project(self):
         credentials = _make_credentials()


### PR DESCRIPTION
Fixes: #357 

The bug exposed a hole in our testing of the new retry defaults, so this PR also adds some simple tests to verify defaults are correct. It doesn't try to comprehensively validate all defaults throughout the library, but the existence of this bug suggests we might want to audit those to make sure.