### PR TITLE
fix: correctly encode bytes for V2 signature

### DIFF
--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -77,7 +77,7 @@ def get_signed_query_params_v2(credentials, expiration, string_to_sign):
               signed payload.
     """
     ensure_signed_credentials(credentials)
-    signature_bytes = credentials.sign_bytes(string_to_sign)
+    signature_bytes = credentials.sign_bytes(string_to_sign.encode("ascii"))
     signature = base64.b64encode(signature_bytes)
     service_account_name = credentials.signer_email
     return {

--- a/tests/unit/test__signing.py
+++ b/tests/unit/test__signing.py
@@ -255,7 +255,7 @@ class Test_get_signed_query_params_v2(unittest.TestCase):
             "Signature": base64.b64encode(sig_bytes),
         }
         self.assertEqual(result, expected)
-        credentials.sign_bytes.assert_called_once_with(string_to_sign)
+        credentials.sign_bytes.assert_called_once_with(bytes(string_to_sign, encoding="ascii"))
 
 
 class Test_get_canonical_headers(unittest.TestCase):
@@ -418,7 +418,7 @@ class Test_generate_signed_url_v2(unittest.TestCase):
         elements.extend(["{}:{}".format(*header) for header in headers])
         elements.append(expected_resource)
 
-        string_to_sign = "\n".join(elements)
+        string_to_sign = bytes("\n".join(elements), encoding="ascii")
 
         credentials.sign_bytes.assert_called_once_with(string_to_sign)
 

--- a/tests/unit/test__signing.py
+++ b/tests/unit/test__signing.py
@@ -255,7 +255,7 @@ class Test_get_signed_query_params_v2(unittest.TestCase):
             "Signature": base64.b64encode(sig_bytes),
         }
         self.assertEqual(result, expected)
-        credentials.sign_bytes.assert_called_once_with(bytes(string_to_sign, encoding="ascii"))
+        credentials.sign_bytes.assert_called_once_with(string_to_sign.encode("ascii"))
 
 
 class Test_get_canonical_headers(unittest.TestCase):
@@ -418,9 +418,9 @@ class Test_generate_signed_url_v2(unittest.TestCase):
         elements.extend(["{}:{}".format(*header) for header in headers])
         elements.append(expected_resource)
 
-        string_to_sign = bytes("\n".join(elements), encoding="ascii")
+        string_to_sign = "\n".join(elements)
 
-        credentials.sign_bytes.assert_called_once_with(string_to_sign)
+        credentials.sign_bytes.assert_called_once_with(string_to_sign.encode("ascii"))
 
         scheme, netloc, path, qs, frag = urllib_parse.urlsplit(url)
         expected_scheme, expected_netloc, _, _, _ = urllib_parse.urlsplit(


### PR DESCRIPTION
V2 signature was passing a string to the sign_bytes function
instead of bytes. This works fine for most credentials (since
their sign_bytes implementations accept strings) but not for
impersonated credentials. V4 signature encodes the string before
calling sign_bytes, so I do the same here.

We should also look into clarifying the contract for the
sign_bytes interface in the auth library.

Fixes #373


