### PR TITLE
fix: allow metadata keys to be cleared

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3620,13 +3620,16 @@ class Blob(_PropertyMixin):
     def metadata(self, value):
         """Update arbitrary/application specific metadata for the object.
 
+        Values are stored to GCS as strings. To delete a key, set its value to
+        None and call blob.patch().
+
         See https://cloud.google.com/storage/docs/json_api/v1/objects
 
         :type value: dict
         :param value: The blob metadata to set.
         """
         if value is not None:
-            value = {k: str(v) for k, v in value.items()}
+            value = {k: str(v) if v is not None else None for k, v in value.items()}
         self._patch_property("metadata", value)
 
     @property

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -874,6 +874,19 @@ class TestStorageWriteFiles(TestStorageFiles):
         blob.content_type = "image/png"
         self.assertEqual(blob.content_type, "image/png")
 
+        metadata = {"foo": "Foo", "bar": "Bar"}
+        blob.metadata = metadata
+        blob.patch()
+        blob.reload()
+        self.assertEqual(blob.metadata, metadata)
+
+        # Ensure that metadata keys can be deleted by setting equal to None.
+        new_metadata = {"foo": "Foo", "bar": None}
+        blob.metadata = new_metadata
+        blob.patch()
+        blob.reload()
+        self.assertEqual(blob.metadata, {"foo": "Foo"})
+
     def test_direct_write_and_read_into_file(self):
         blob = self.bucket.blob("MyBuffer")
         file_contents = b"Hello World"


### PR DESCRIPTION
Metadata keys can be cleared in the JSON API by setting the value
to null; however this doesn't currently work through this library.
This PR allows users to clear metadata keys by setting the value
to None and documents how users should do this.

Fixes #381

