### PR TITLE
fix: update batch connection to request api endpoint info from client

### DIFF
--- a/google/cloud/storage/batch.py
+++ b/google/cloud/storage/batch.py
@@ -147,7 +147,11 @@ class Batch(Connection):
     _MAX_BATCH_SIZE = 1000
 
     def __init__(self, client):
-        super(Batch, self).__init__(client)
+        api_endpoint = client._connection.API_BASE_URL
+        client_info = client._connection._client_info
+        super(Batch, self).__init__(
+            client, client_info=client_info, api_endpoint=api_endpoint
+        )
         self._requests = []
         self._target_objects = []
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -136,7 +136,8 @@ class TestBatch(unittest.TestCase):
         url = "http://example.com/api"
         http = _make_requests_session([])
         connection = _Connection(http=http)
-        batch = self._make_one(connection)
+        client = _Client(connection)
+        batch = self._make_one(client)
         target = _MockObject()
 
         response = batch._make_request("GET", url, target_object=target)
@@ -164,7 +165,8 @@ class TestBatch(unittest.TestCase):
         url = "http://example.com/api"
         http = _make_requests_session([])
         connection = _Connection(http=http)
-        batch = self._make_one(connection)
+        client = _Client(connection)
+        batch = self._make_one(client)
         data = {"foo": 1}
         target = _MockObject()
 
@@ -191,7 +193,8 @@ class TestBatch(unittest.TestCase):
         url = "http://example.com/api"
         http = _make_requests_session([])
         connection = _Connection(http=http)
-        batch = self._make_one(connection)
+        client = _Client(connection)
+        batch = self._make_one(client)
         data = {"foo": 1}
         target = _MockObject()
 
@@ -218,7 +221,8 @@ class TestBatch(unittest.TestCase):
         url = "http://example.com/api"
         http = _make_requests_session([])
         connection = _Connection(http=http)
-        batch = self._make_one(connection)
+        client = _Client(connection)
+        batch = self._make_one(client)
         target = _MockObject()
 
         response = batch._make_request("DELETE", url, target_object=target)
@@ -243,7 +247,8 @@ class TestBatch(unittest.TestCase):
         url = "http://example.com/api"
         http = _make_requests_session([])
         connection = _Connection(http=http)
-        batch = self._make_one(connection)
+        client = _Client(connection)
+        batch = self._make_one(client)
 
         batch._MAX_BATCH_SIZE = 1
         batch._requests.append(("POST", url, {}, {"bar": 2}))
@@ -254,7 +259,8 @@ class TestBatch(unittest.TestCase):
     def test_finish_empty(self):
         http = _make_requests_session([])
         connection = _Connection(http=http)
-        batch = self._make_one(connection)
+        client = _Client(connection)
+        batch = self._make_one(client)
 
         with self.assertRaises(ValueError):
             batch.finish()
@@ -633,6 +639,8 @@ class _Connection(object):
 
     def __init__(self, **kw):
         self.__dict__.update(kw)
+        self._client_info = None
+        self.API_BASE_URL = ""
 
     def _make_request(self, method, url, data=None, headers=None, timeout=None):
         return self.http.request(
@@ -647,3 +655,4 @@ class _MockObject(object):
 class _Client(object):
     def __init__(self, connection):
         self._base_connection = connection
+        self._connection = connection


### PR DESCRIPTION
Instantiating a batch creates a new connection. Since api endpoint and client info were not requested from the client, the batch did not respect client api endpoint (STORAGE_EMULATOR_HOST). This PR updates the batch constructor to request api endpoint and client info from client.

Fixes #376
