### PR TITLE
fix: update user_project usage and documentation in bucket/client class methods

### DIFF
--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -611,6 +611,10 @@ class Bucket(_PropertyMixin):
 
         If unset, API requests are billed to the bucket owner.
 
+        A user project is required for all operations on Requester Pays buckets. 
+        
+        See https://cloud.google.com/storage/docs/requester-pays#requirements for details.
+
         :rtype: str
         """
         return self._user_project

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -611,8 +611,8 @@ class Bucket(_PropertyMixin):
 
         If unset, API requests are billed to the bucket owner.
 
-        A user project is required for all operations on Requester Pays buckets. 
-        
+        A user project is required for all operations on Requester Pays buckets.
+
         See https://cloud.google.com/storage/docs/requester-pays#requirements for details.
 
         :rtype: str

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -819,6 +819,10 @@ class Bucket(_PropertyMixin):
         If the bucket already exists, will raise
         :class:`google.cloud.exceptions.Conflict`.
 
+        This implements "storage.buckets.insert".
+
+        If :attr:`user_project` is set, bills the API request to that project.
+
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: (Optional) The client to use. If not passed, falls back

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -828,7 +828,6 @@ class Bucket(_PropertyMixin):
         :param project: (Optional) The project under which the bucket is to
                         be created. If not passed, uses the project set on
                         the client.
-        :raises ValueError: if :attr:`user_project` is set.
         :raises ValueError: if ``project`` is None and client's
                             :attr:`project` is also None.
 
@@ -874,13 +873,12 @@ class Bucket(_PropertyMixin):
             PendingDeprecationWarning,
             stacklevel=1,
         )
-        if self.user_project is not None:
-            raise ValueError("Cannot create bucket with 'user_project' set.")
 
         client = self._require_client(client)
         client.create_bucket(
             bucket_or_name=self,
             project=project,
+            user_project=self.user_project,
             location=location,
             predefined_acl=predefined_acl,
             predefined_default_object_acl=predefined_default_object_acl,
@@ -1331,7 +1329,7 @@ class Bucket(_PropertyMixin):
             >>> from google.cloud import storage
             >>> client = storage.Client()
 
-            >>> bucket = storage.Bucket(client, "my-bucket-name", user_project='my-project')
+            >>> bucket = storage.Bucket(client, "my-bucket-name", user_project="my-project")
             >>> all_blobs = list(client.list_blobs(bucket))
         """
         client = self._require_client(client)

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1328,7 +1328,7 @@ class Bucket(_PropertyMixin):
             >>> from google.cloud import storage
             >>> client = storage.Client()
 
-            >>> bucket = storage.Bucket("my-bucket-name", user_project='my-project')
+            >>> bucket = storage.Bucket(client, "my-bucket-name", user_project='my-project')
             >>> all_blobs = list(client.list_blobs(bucket))
         """
         client = self._require_client(client)

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -809,12 +809,11 @@ class Bucket(_PropertyMixin):
     ):
         """DEPRECATED. Creates current bucket.
 
+        .. note::
+          Direct use of this method is deprecated. Use ``Client.create_bucket()`` instead.
+
         If the bucket already exists, will raise
         :class:`google.cloud.exceptions.Conflict`.
-
-        This implements "storage.buckets.insert".
-
-        If :attr:`user_project` is set, bills the API request to that project.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -397,15 +397,6 @@ class Client(ClientWithProject):
             ... # in the meantime, so you want to get the latest state.
             >>> bucket = client.get_bucket(bucket)  # API request.
 
-            Get a bucket with user_project.
-
-            >>> from google.cloud import storage
-            >>> client = storage.Client()
-
-            >>> # Set user_project on a plain resource object.
-            >>> bucket_obj = storage.Bucket(client, "my-bucket-name", user_project="my-project")
-            >>> bucket = client.get_bucket(bucket_obj)  # API request.
-
         """
         bucket = self._bucket_arg_to_bucket(bucket_or_name)
         bucket.reload(

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -397,6 +397,15 @@ class Client(ClientWithProject):
             ... # in the meantime, so you want to get the latest state.
             >>> bucket = client.get_bucket(bucket)  # API request.
 
+            Get a bucket with user_project.
+
+            >>> from google.cloud import storage
+            >>> client = storage.Client()
+
+            >>> # Set user_project on a plain resource object.
+            >>> bucket_obj = storage.Bucket(client, "my-bucket-name", user_project="my-project")
+            >>> bucket = client.get_bucket(bucket_obj)  # API request.
+
         """
         bucket = self._bucket_arg_to_bucket(bucket_or_name)
         bucket.reload(
@@ -839,7 +848,7 @@ class Client(ClientWithProject):
             >>> from google.cloud import storage
             >>> client = storage.Client()
 
-            >>> bucket = storage.Bucket(client, "my-bucket-name", user_project='my-project')
+            >>> bucket = storage.Bucket(client, "my-bucket-name", user_project="my-project")
             >>> all_blobs = list(client.list_blobs(bucket))
         """
         bucket = self._bucket_arg_to_bucket(bucket_or_name)

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -839,7 +839,7 @@ class Client(ClientWithProject):
             >>> from google.cloud import storage
             >>> client = storage.Client()
 
-            >>> bucket = storage.Bucket("my-bucket-name", user_project='my-project')
+            >>> bucket = storage.Bucket(client, "my-bucket-name", user_project='my-project')
             >>> all_blobs = list(client.list_blobs(bucket))
         """
         bucket = self._bucket_arg_to_bucket(bucket_or_name)


### PR DESCRIPTION
The parameter user_project is the project to be billed for the request; It is required for requests to buckets that have Requester Pays enabled. This PR includes changes with the aim of enhancing consistency and clarity to user_project usage:

- revise user_project description in docstring to be consistent with c.g.c and other language libraries
- correct user_project usage in docstring examples and deprecated Bucket.create()
- add example using user_project in Client.get_bucket(), which is used frequently in the samples

Fixes #148
