### PR TITLE
fix: silence expected errors for routine operations on BlobReader

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3434,6 +3434,10 @@ class Blob(_PropertyMixin):
         latest generation number and set it; or, if the generation is known, set
         it manually, for instance with bucket.blob(generation=123456).
 
+        Checksumming (hashing) to verify data integrity is disabled for reads
+        using this feature because they are implemented using request ranges.
+        See https://cloud.google.com/storage/docs/hashes-etags for details.
+
         :type mode: str
         :param mode:
             (Optional) A mode string, as per standard Python `open()` semantics.The first

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3435,8 +3435,9 @@ class Blob(_PropertyMixin):
         it manually, for instance with bucket.blob(generation=123456).
 
         Checksumming (hashing) to verify data integrity is disabled for reads
-        using this feature because they are implemented using request ranges.
-        See https://cloud.google.com/storage/docs/hashes-etags for details.
+        using this feature because reads are implemented using request ranges,
+        which do not provide checksums to validate. See
+        https://cloud.google.com/storage/docs/hashes-etags for details.
 
         :type mode: str
         :param mode:

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1134,6 +1134,9 @@ class TestStorageWriteFiles(TestStorageFiles):
                     file_obj.read(256 * 1024 * 2), reader.read(256 * 1024 * 2)
                 )
                 self.assertEqual(file_obj.read(), reader.read())
+                # End of file reached; further reads should be blank but not
+                # raise an error.
+                self.assertEqual(b"", reader.read())
 
     def test_blobwriter_and_blobreader_text_mode(self):
         blob = self.bucket.blob("MultibyteTextFile")


### PR DESCRIPTION
Two fixes for BlobReader:
- Checksums are not supported for BlobReader's chunked downloads, so set checksum=None to silence log warnings (and add a note to the docstring explaining this).
- In Python, read() on files at EOF should return an empty result, but not raise an error. Stop BlobReader from emitting RequestRangeNotSatisfiable errors at EOF.

Fixes: https://github.com/googleapis/python-storage/issues/399