### PR TITLE
Adjusting comment for accuracy

### DIFF
--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -277,7 +277,7 @@ def generate_signed_url_v2(
 
         Assumes ``credentials`` implements the
         :class:`google.auth.credentials.Signing` interface. Also assumes
-        ``credentials`` has a ``service_account_email`` property which
+        ``credentials`` has a ``signer_email`` property which
         identifies the credentials.
 
     .. note::
@@ -441,7 +441,7 @@ def generate_signed_url_v4(
 
         Assumes ``credentials`` implements the
         :class:`google.auth.credentials.Signing` interface. Also assumes
-        ``credentials`` has a ``service_account_email`` property which
+        ``credentials`` has a ``signer_email`` property which
         identifies the credentials.
 
     .. note::


### PR DESCRIPTION
The assumed property is `signer_email` and not `service_account_email`.
In nowhere a property called `service_account_email` is read from `credentials`, but `signer_email` is.

Fixes #406 🦕