### PR TITLE
tests: fix unit tests broken by dependency drift

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ dependencies = [
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "google-resumable-media >= 1.2.0, < 2.0dev",
     "requests >= 2.18.0, < 3.0.0dev",
+    "googleapis-common-protos < 1.53.0; python_version<'3.0'",
 ]
 extras = {}
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -39,8 +39,11 @@ _POST_POLICY_TESTS = [test for test in _CONFORMANCE_TESTS if "policyInput" in te
 _FAKE_CREDENTIALS = Credentials.from_service_account_info(_SERVICE_ACCOUNT_JSON)
 
 
-def _make_credentials():
+def _make_credentials(project=None):
     import google.auth.credentials
+
+    if project is not None:
+        return mock.Mock(spec=google.auth.credentials.Credentials, project_id=project)
 
     return mock.Mock(spec=google.auth.credentials.Credentials)
 
@@ -174,14 +177,9 @@ class TestClient(unittest.TestCase):
         from google.cloud.storage._http import Connection
 
         PROJECT = "PROJECT"
-        credentials = _make_credentials()
+        credentials = _make_credentials(project=PROJECT)
 
-        ddp_patch = mock.patch(
-            "google.cloud.client._determine_default_project", return_value=PROJECT
-        )
-
-        with ddp_patch:
-            client = self._make_one(credentials=credentials)
+        client = self._make_one(credentials=credentials)
 
         self.assertEqual(client.project, PROJECT)
         self.assertIsInstance(client._connection, Connection)


### PR DESCRIPTION
Pin `googleapis-common-protos` FBO python2.7

Closes #429

Fix 'TestClient.test_ctor_wo_project', broken by https://github.com/googleapis/python-cloud-core/pull/51

Closes #427
