### PR TITLE
refactor: add / use 'Client._get_resource' method

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -215,14 +215,13 @@ class _PropertyMixin(object):
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
         )
-        api_response = client._connection.api_request(
-            method="GET",
-            path=self.path,
+        api_response = client._get_path(
+            self.path,
             query_params=query_params,
             headers=self._encryption_headers(),
-            _target_object=self,
             timeout=timeout,
             retry=retry,
+            _target_object=self,
         )
         self._set_properties(api_response)
 

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -215,7 +215,7 @@ class _PropertyMixin(object):
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
         )
-        api_response = client._get_path(
+        api_response = client._get_resource(
             self.path,
             query_params=query_params,
             headers=self._encryption_headers(),

--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -466,7 +466,7 @@ class ACL(object):
 
         self.entities.clear()
 
-        found = client._get_path(
+        found = client._get_resource(
             path, query_params=query_params, timeout=timeout, retry=retry,
         )
         self.loaded = True

--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -85,6 +85,7 @@ when sending metadata for ACLs to the API.
 """
 
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+from google.cloud.storage.retry import DEFAULT_RETRY
 
 
 class _ACLEntity(object):
@@ -206,6 +207,7 @@ class ACL(object):
 
     # Subclasses must override to provide these attributes (typically,
     # as properties).
+    client = None
     reload_path = None
     save_path = None
     user_project = None
@@ -430,7 +432,7 @@ class ACL(object):
             client = self.client
         return client
 
-    def reload(self, client=None, timeout=_DEFAULT_TIMEOUT):
+    def reload(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Reload the ACL data from Cloud Storage.
 
         If :attr:`user_project` is set, bills the API request to that project.
@@ -445,6 +447,15 @@ class ACL(object):
 
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
+
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry: (Optional) How to retry the RPC.
+
+            A None value will disable retries.
+
+            A google.api_core.retry.Retry value will enable retries,
+            and the object will define retriable response codes and errors
+            and configure backoff and timeout options.
         """
         path = self.reload_path
         client = self._require_client(client)
@@ -455,10 +466,11 @@ class ACL(object):
 
         self.entities.clear()
 
-        found = client._connection.api_request(
-            method="GET", path=path, query_params=query_params, timeout=timeout,
+        found = client._get_path(
+            path, query_params=query_params, timeout=timeout, retry=retry,
         )
         self.loaded = True
+
         for entry in found.get("items", ()):
             self.add_entity(self.entity_from_dict(entry))
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2828,13 +2828,12 @@ class Blob(_PropertyMixin):
         if requested_policy_version is not None:
             query_params["optionsRequestedPolicyVersion"] = requested_policy_version
 
-        info = client._connection.api_request(
-            method="GET",
-            path="%s/iam" % (self.path,),
+        info = client._get_path(
+            "%s/iam" % (self.path,),
             query_params=query_params,
-            _target_object=None,
             timeout=timeout,
             retry=retry,
+            _target_object=None,
         )
         return Policy.from_api_repr(info)
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2968,12 +2968,12 @@ class Blob(_PropertyMixin):
             query_params["userProject"] = self.user_project
 
         path = "%s/iam/testPermissions" % (self.path,)
-        resp = client._connection.api_request(
-            method="GET",
-            path=path,
+        resp = client._get_path(
+            path,
             query_params=query_params,
             timeout=timeout,
             retry=retry,
+            _target_object=None,
         )
 
         return resp.get("permissions", [])

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -704,20 +704,19 @@ class Blob(_PropertyMixin):
         try:
             # We intentionally pass `_target_object=None` since fields=name
             # would limit the local properties.
-            client._connection.api_request(
-                method="GET",
-                path=self.path,
+            client._get_path(
+                self.path,
                 query_params=query_params,
-                _target_object=None,
                 timeout=timeout,
                 retry=retry,
+                _target_object=None,
             )
+        except NotFound:
             # NOTE: This will not fail immediately in a batch. However, when
             #       Batch.finish() is called, the resulting `NotFound` will be
             #       raised.
-            return True
-        except NotFound:
             return False
+        return True
 
     def delete(
         self,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -704,7 +704,7 @@ class Blob(_PropertyMixin):
         try:
             # We intentionally pass `_target_object=None` since fields=name
             # would limit the local properties.
-            client._get_path(
+            client._get_resource(
                 self.path,
                 query_params=query_params,
                 timeout=timeout,
@@ -2828,7 +2828,7 @@ class Blob(_PropertyMixin):
         if requested_policy_version is not None:
             query_params["optionsRequestedPolicyVersion"] = requested_policy_version
 
-        info = client._get_path(
+        info = client._get_resource(
             "%s/iam" % (self.path,),
             query_params=query_params,
             timeout=timeout,
@@ -2968,7 +2968,7 @@ class Blob(_PropertyMixin):
             query_params["userProject"] = self.user_project
 
         path = "%s/iam/testPermissions" % (self.path,)
-        resp = client._get_path(
+        resp = client._get_resource(
             path,
             query_params=query_params,
             timeout=timeout,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2881,13 +2881,12 @@ class Bucket(_PropertyMixin):
         if requested_policy_version is not None:
             query_params["optionsRequestedPolicyVersion"] = requested_policy_version
 
-        info = client._connection.api_request(
-            method="GET",
-            path="%s/iam" % (self.path,),
+        info = client._get_path(
+            "%s/iam" % (self.path,),
             query_params=query_params,
-            _target_object=None,
             timeout=timeout,
             retry=retry,
+            _target_object=None,
         )
         return Policy.from_api_repr(info)
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -3006,12 +3006,12 @@ class Bucket(_PropertyMixin):
             query_params["userProject"] = self.user_project
 
         path = "%s/iam/testPermissions" % (self.path,)
-        resp = client._connection.api_request(
-            method="GET",
-            path=path,
+        resp = client._get_path(
+            path,
             query_params=query_params,
             timeout=timeout,
             retry=retry,
+            _target_object=None,
         )
         return resp.get("permissions", [])
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -786,7 +786,7 @@ class Bucket(_PropertyMixin):
         try:
             # We intentionally pass `_target_object=None` since fields=name
             # would limit the local properties.
-            client._get_path(
+            client._get_resource(
                 self.path,
                 query_params=query_params,
                 timeout=timeout,
@@ -2881,7 +2881,7 @@ class Bucket(_PropertyMixin):
         if requested_policy_version is not None:
             query_params["optionsRequestedPolicyVersion"] = requested_policy_version
 
-        info = client._get_path(
+        info = client._get_resource(
             "%s/iam" % (self.path,),
             query_params=query_params,
             timeout=timeout,
@@ -3006,7 +3006,7 @@ class Bucket(_PropertyMixin):
             query_params["userProject"] = self.user_project
 
         path = "%s/iam/testPermissions" % (self.path,)
-        resp = client._get_path(
+        resp = client._get_resource(
             path,
             query_params=query_params,
             timeout=timeout,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -786,20 +786,19 @@ class Bucket(_PropertyMixin):
         try:
             # We intentionally pass `_target_object=None` since fields=name
             # would limit the local properties.
-            client._connection.api_request(
-                method="GET",
-                path=self.path,
+            client._get_path(
+                self.path,
                 query_params=query_params,
-                _target_object=None,
                 timeout=timeout,
                 retry=retry,
+                _target_object=None,
             )
+        except NotFound:
             # NOTE: This will not fail immediately in a batch. However, when
             #       Batch.finish() is called, the resulting `NotFound` will be
             #       raised.
-            return True
-        except NotFound:
             return False
+        return True
 
     def create(
         self,

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -284,10 +284,9 @@ class Client(ClientWithProject):
         """
         if project is None:
             project = self.project
+
         path = "/projects/%s/serviceAccount" % (project,)
-        api_response = self._base_connection.api_request(
-            method="GET", path=path, timeout=timeout, retry=retry,
-        )
+        api_response = self._get_path(path, timeout=timeout, retry=retry)
         return api_response["email_address"]
 
     def bucket(self, bucket_name, user_project=None):
@@ -320,6 +319,72 @@ class Client(ClientWithProject):
         :returns: The batch object created.
         """
         return Batch(client=self)
+
+    def _get_path(
+        self,
+        path,
+        query_params=None,
+        headers=None,
+        timeout=_DEFAULT_TIMEOUT,
+        retry=DEFAULT_RETRY,
+        _target_object=None,
+    ):
+        """Helper for bucket / blob methods making API 'GET' calls.
+
+        Args:
+            path str:
+                The path of the resource to fetch.
+
+            query_params Optional[dict]:
+                HTTP query parameters to be passed
+
+            headers Optional[dict]:
+                HTTP headers to be passed
+
+            timeout (Optional[Union[float, Tuple[float, float]]]):
+                The amount of time, in seconds, to wait for the server response.
+
+                Can also be passed as a tuple (connect_timeout, read_timeout).
+                See :meth:`requests.Session.request` documentation for details.
+
+            retry (Optional[Union[google.api_core.retry.Retry, google.cloud.storage.retry.ConditionalRetryPolicy]]):
+                How to retry the RPC. A None value will disable retries.
+                A google.api_core.retry.Retry value will enable retries, and the object will
+                define retriable response codes and errors and configure backoff and timeout options.
+
+                A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
+                activates it only if certain conditions are met. This class exists to provide safe defaults
+                for RPC calls that are not technically safe to retry normally (due to potential data
+                duplication or other side-effects) but become safe to retry if a condition such as
+                if_metageneration_match is set.
+
+                See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
+                information on retry types and how to configure them.
+
+            _target_object (Union[ \
+                :class:`~google.cloud.storage.bucket.Bucket`, \
+                :class:`~google.cloud.storage.bucket.blob`, \
+            ]):
+                Object to which future data is to be applied -- only relevant
+                in the context of a batch.
+
+        Returns:
+            dict
+                The JSON resource fetched
+
+        Raises:
+            google.cloud.exceptions.NotFound
+                If the bucket is not found.
+        """
+        return self._connection.api_request(
+            method="GET",
+            path=path,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=_target_object,
+        )
 
     def get_bucket(
         self,

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -286,7 +286,7 @@ class Client(ClientWithProject):
             project = self.project
 
         path = "/projects/%s/serviceAccount" % (project,)
-        api_response = self._get_path(path, timeout=timeout, retry=retry)
+        api_response = self._get_resource(path, timeout=timeout, retry=retry)
         return api_response["email_address"]
 
     def bucket(self, bucket_name, user_project=None):
@@ -320,7 +320,7 @@ class Client(ClientWithProject):
         """
         return Batch(client=self)
 
-    def _get_path(
+    def _get_resource(
         self,
         path,
         query_params=None,

--- a/google/cloud/storage/hmac_key.py
+++ b/google/cloud/storage/hmac_key.py
@@ -222,12 +222,8 @@ class HMACKeyMetadata(object):
             if self.user_project is not None:
                 qs_params["userProject"] = self.user_project
 
-            self._client._connection.api_request(
-                method="GET",
-                path=self.path,
-                query_params=qs_params,
-                timeout=timeout,
-                retry=retry,
+            self._client._get_path(
+                self.path, query_params=qs_params, timeout=timeout, retry=retry,
             )
         except NotFound:
             return False

--- a/google/cloud/storage/hmac_key.py
+++ b/google/cloud/storage/hmac_key.py
@@ -222,7 +222,7 @@ class HMACKeyMetadata(object):
             if self.user_project is not None:
                 qs_params["userProject"] = self.user_project
 
-            self._client._get_path(
+            self._client._get_resource(
                 self.path, query_params=qs_params, timeout=timeout, retry=retry,
             )
         except NotFound:
@@ -262,7 +262,7 @@ class HMACKeyMetadata(object):
         if self.user_project is not None:
             qs_params["userProject"] = self.user_project
 
-        self._properties = self._client._get_path(
+        self._properties = self._client._get_resource(
             self.path, query_params=qs_params, timeout=timeout, retry=retry,
         )
 

--- a/google/cloud/storage/hmac_key.py
+++ b/google/cloud/storage/hmac_key.py
@@ -262,12 +262,8 @@ class HMACKeyMetadata(object):
         if self.user_project is not None:
             qs_params["userProject"] = self.user_project
 
-        self._properties = self._client._connection.api_request(
-            method="GET",
-            path=self.path,
-            query_params=qs_params,
-            timeout=timeout,
-            retry=retry,
+        self._properties = self._client._get_path(
+            self.path, query_params=qs_params, timeout=timeout, retry=retry,
         )
 
     def update(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY_IF_ETAG_IN_JSON):

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -323,7 +323,7 @@ class BucketNotification(object):
             query_params["userProject"] = self.bucket.user_project
 
         try:
-            client._get_path(
+            client._get_resource(
                 self.path, query_params=query_params, timeout=timeout, retry=retry,
             )
         except NotFound:
@@ -377,7 +377,7 @@ class BucketNotification(object):
         if self.bucket.user_project is not None:
             query_params["userProject"] = self.bucket.user_project
 
-        response = client._get_path(
+        response = client._get_resource(
             self.path, query_params=query_params, timeout=timeout, retry=retry,
         )
         self._set_properties(response)

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -323,12 +323,8 @@ class BucketNotification(object):
             query_params["userProject"] = self.bucket.user_project
 
         try:
-            client._connection.api_request(
-                method="GET",
-                path=self.path,
-                query_params=query_params,
-                timeout=timeout,
-                retry=retry,
+            client._get_path(
+                self.path, query_params=query_params, timeout=timeout, retry=retry,
             )
         except NotFound:
             return False

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -377,12 +377,8 @@ class BucketNotification(object):
         if self.bucket.user_project is not None:
             query_params["userProject"] = self.bucket.user_project
 
-        response = client._connection.api_request(
-            method="GET",
-            path=self.path,
-            query_params=query_params,
-            timeout=timeout,
-            retry=retry,
+        response = client._get_path(
+            self.path, query_params=query_params, timeout=timeout, retry=retry,
         )
         self._set_properties(response)
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -66,6 +66,7 @@ class Test_PropertyMixin(unittest.TestCase):
         class Derived(self._get_target_class()):
 
             client = None
+            _actual_encryption_headers = None
 
             @property
             def path(self):
@@ -74,6 +75,9 @@ class Test_PropertyMixin(unittest.TestCase):
             @property
             def user_project(self):
                 return user_project
+
+            def _encryption_headers(self):
+                return self._actual_encryption_headers or {}
 
         return Derived
 
@@ -105,118 +109,129 @@ class Test_PropertyMixin(unittest.TestCase):
         derived = self._derivedClass("/path", user_project)()
         self.assertEqual(derived._query_params, {"userProject": user_project})
 
-    def test_reload(self):
-        connection = _Connection({"foo": "Foo"})
-        client = _Client(connection)
-        derived = self._derivedClass("/path")()
+    def test_reload_w_defaults(self):
+        path = "/path"
+        response = {"foo": "Foo"}
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = response
+        derived = self._derivedClass(path)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
         derived._changes = object()
-        derived.reload(client=client, timeout=42)
-        self.assertEqual(derived._properties, {"foo": "Foo"})
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "GET",
-                "path": "/path",
-                "query_params": {"projection": "noAcl"},
-                "headers": {},
-                "_target_object": derived,
-                "timeout": 42,
-                "retry": DEFAULT_RETRY,
-            },
-        )
+        derived.client = client
+
+        derived.reload()
+
+        self.assertEqual(derived._properties, response)
         self.assertEqual(derived._changes, set())
 
-    def test_reload_with_generation_match(self):
-        GENERATION_NUMBER = 9
-        METAGENERATION_NUMBER = 6
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}  # no encryption headers by default
+        client._get_path.assert_called_once_with(
+            path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=derived,
+        )
 
-        connection = _Connection({"foo": "Foo"})
-        client = _Client(connection)
-        derived = self._derivedClass("/path")()
+    def test_reload_w_generation_match_w_timeout(self):
+        generation_number = 9
+        metageneration_number = 6
+        path = "/path"
+        timeout = 42
+        response = {"foo": "Foo"}
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = response
+        derived = self._derivedClass(path)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
         derived._changes = object()
+        derived.client = client
+
         derived.reload(
-            client=client,
-            timeout=42,
-            if_generation_match=GENERATION_NUMBER,
-            if_metageneration_match=METAGENERATION_NUMBER,
+            if_generation_match=generation_number,
+            if_metageneration_match=metageneration_number,
+            timeout=timeout,
         )
-        self.assertEqual(derived._properties, {"foo": "Foo"})
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "GET",
-                "path": "/path",
-                "query_params": {
-                    "projection": "noAcl",
-                    "ifGenerationMatch": GENERATION_NUMBER,
-                    "ifMetagenerationMatch": METAGENERATION_NUMBER,
-                },
-                "headers": {},
-                "_target_object": derived,
-                "timeout": 42,
-                "retry": DEFAULT_RETRY,
-            },
-        )
+
+        self.assertEqual(derived._properties, response)
         self.assertEqual(derived._changes, set())
 
-    def test_reload_w_user_project(self):
+        expected_query_params = {
+            "projection": "noAcl",
+            "ifGenerationMatch": generation_number,
+            "ifMetagenerationMatch": metageneration_number,
+        }
+        expected_headers = {}  # no encryption headers by default
+        client._get_path.assert_called_once_with(
+            path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=timeout,
+            retry=DEFAULT_RETRY,
+            _target_object=derived,
+        )
+
+    def test_reload_w_user_project_w_retry(self):
         user_project = "user-project-123"
-        connection = _Connection({"foo": "Foo"})
-        client = _Client(connection)
-        derived = self._derivedClass("/path", user_project)()
+        path = "/path"
+        retry = mock.Mock(spec=[])
+        response = {"foo": "Foo"}
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = response
+        derived = self._derivedClass(path, user_project)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
         derived._changes = object()
-        derived.reload(client=client)
-        self.assertEqual(derived._properties, {"foo": "Foo"})
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "GET",
-                "path": "/path",
-                "query_params": {"projection": "noAcl", "userProject": user_project},
-                "headers": {},
-                "_target_object": derived,
-                "timeout": self._get_default_timeout(),
-                "retry": DEFAULT_RETRY,
-            },
-        )
+        derived.client = client
+
+        derived.reload(retry=retry)
+
+        self.assertEqual(derived._properties, response)
         self.assertEqual(derived._changes, set())
 
-    def test_reload_w_projection(self):
-        connection = _Connection({"foo": "Foo"})
-        client = _Client(connection)
-        derived = self._derivedClass("/path")()
+        expected_query_params = {
+            "projection": "noAcl",
+            "userProject": user_project,
+        }
+        expected_headers = {}  # no encryption headers by default
+        client._get_path.assert_called_once_with(
+            path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=retry,
+            _target_object=derived,
+        )
+
+    def test_reload_w_projection_w_explicit_client_w_enc_header(self):
+        path = "/path"
+        response = {"foo": "Foo"}
+        encryption_headers = {"bar": "Bar"}
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = response
+        derived = self._derivedClass(path)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
         derived._changes = object()
-        derived.reload(projection="full", client=client, timeout=42)
-        self.assertEqual(derived._properties, {"foo": "Foo"})
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "GET",
-                "path": "/path",
-                "query_params": {"projection": "full"},
-                "headers": {},
-                "_target_object": derived,
-                "timeout": 42,
-                "retry": DEFAULT_RETRY,
-            },
-        )
+        derived._actual_encryption_headers = encryption_headers
+
+        derived.reload(projection="full", client=client)
+
+        self.assertEqual(derived._properties, response)
         self.assertEqual(derived._changes, set())
+
+        expected_query_params = {"projection": "full"}
+        client._get_path.assert_called_once_with(
+            path,
+            query_params=expected_query_params,
+            headers=encryption_headers,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=derived,
+        )
 
     def test__set_properties(self):
         mixin = self._make_one()

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -112,8 +112,8 @@ class Test_PropertyMixin(unittest.TestCase):
     def test_reload_w_defaults(self):
         path = "/path"
         response = {"foo": "Foo"}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = response
         derived = self._derivedClass(path)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
@@ -127,7 +127,7 @@ class Test_PropertyMixin(unittest.TestCase):
 
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}  # no encryption headers by default
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -142,8 +142,8 @@ class Test_PropertyMixin(unittest.TestCase):
         path = "/path"
         timeout = 42
         response = {"foo": "Foo"}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = response
         derived = self._derivedClass(path)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
@@ -165,7 +165,7 @@ class Test_PropertyMixin(unittest.TestCase):
             "ifMetagenerationMatch": metageneration_number,
         }
         expected_headers = {}  # no encryption headers by default
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -179,8 +179,8 @@ class Test_PropertyMixin(unittest.TestCase):
         path = "/path"
         retry = mock.Mock(spec=[])
         response = {"foo": "Foo"}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = response
         derived = self._derivedClass(path, user_project)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
@@ -197,7 +197,7 @@ class Test_PropertyMixin(unittest.TestCase):
             "userProject": user_project,
         }
         expected_headers = {}  # no encryption headers by default
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -210,8 +210,8 @@ class Test_PropertyMixin(unittest.TestCase):
         path = "/path"
         response = {"foo": "Foo"}
         encryption_headers = {"bar": "Bar"}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = response
         derived = self._derivedClass(path)()
         # Make sure changes is not a set instance before calling reload
         # (which will clear / replace it with an empty set), checked below.
@@ -224,7 +224,7 @@ class Test_PropertyMixin(unittest.TestCase):
         self.assertEqual(derived._changes, set())
 
         expected_query_params = {"projection": "full"}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             path,
             query_params=expected_query_params,
             headers=encryption_headers,

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -14,6 +14,10 @@
 
 import unittest
 
+import mock
+
+from google.cloud.storage.retry import DEFAULT_RETRY
+
 
 class Test_ACLEntity(unittest.TestCase):
     @staticmethod
@@ -530,78 +534,82 @@ class Test_ACL(unittest.TestCase):
         entity = acl.entity(TYPE, ID)
         self.assertEqual(acl.get_entities(), [entity])
 
-    def test_reload_missing(self):
+    def test_reload_missing_w_defaults(self):
         # https://github.com/GoogleCloudPlatform/google-cloud-python/issues/652
-        ROLE = "role"
-        connection = _Connection({})
-        client = _Client(connection)
-        acl = self._make_one()
-        acl.reload_path = "/testing/acl"
+        class Derived(self._get_target_class()):
+            client = None
+
+        role = "role"
+        reload_path = "/testing/acl"
+        api_response = {}
+        acl = Derived()
+        acl.reload_path = reload_path
         acl.loaded = True
-        acl.entity("allUsers", ROLE)
-        acl.reload(client=client, timeout=42)
+        acl.entity("allUsers", role)
+        client = acl.client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = api_response
+
+        acl.reload()
+
         self.assertEqual(list(acl), [])
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "GET",
-                "path": "/testing/acl",
-                "query_params": {},
-                "timeout": 42,
-            },
+
+        expected_query_params = {}
+        client._get_path.assert_called_once_with(
+            reload_path,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
         )
 
-    def test_reload_empty_result_clears_local(self):
-        ROLE = "role"
-        connection = _Connection({"items": []})
-        client = _Client(connection)
+    def test_reload_w_empty_result_w_timeout_w_retry_w_explicit_client(self):
+        role = "role"
+        reload_path = "/testing/acl"
+        timeout = 42
+        retry = mock.Mock(spec=[])
+        api_response = {"items": []}
         acl = self._make_one()
-        acl.reload_path = "/testing/acl"
+        acl.reload_path = reload_path
         acl.loaded = True
-        acl.entity("allUsers", ROLE)
+        acl.entity("allUsers", role)
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = api_response
+
+        acl.reload(client=client, timeout=timeout, retry=retry)
+
+        self.assertTrue(acl.loaded)
+        self.assertEqual(list(acl), [])
+
+        expected_query_params = {}
+        client._get_path.assert_called_once_with(
+            reload_path,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=retry,
+        )
+
+    def test_reload_w_nonempty_result_w_user_project(self):
+        role = "role"
+        reload_path = "/testing/acl"
+        user_project = "user-project-123"
+        api_response = {"items": [{"entity": "allUsers", "role": role}]}
+        acl = self._make_one()
+        acl.reload_path = reload_path
+        acl.loaded = True
+        acl.user_project = user_project
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = api_response
 
         acl.reload(client=client)
 
         self.assertTrue(acl.loaded)
-        self.assertEqual(list(acl), [])
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "GET",
-                "path": "/testing/acl",
-                "query_params": {},
-                "timeout": self._get_default_timeout(),
-            },
-        )
+        self.assertEqual(list(acl), [{"entity": "allUsers", "role": role}])
 
-    def test_reload_nonempty_result_w_user_project(self):
-        ROLE = "role"
-        USER_PROJECT = "user-project-123"
-        connection = _Connection({"items": [{"entity": "allUsers", "role": ROLE}]})
-        client = _Client(connection)
-        acl = self._make_one()
-        acl.reload_path = "/testing/acl"
-        acl.loaded = True
-        acl.user_project = USER_PROJECT
-
-        acl.reload(client=client)
-
-        self.assertTrue(acl.loaded)
-        self.assertEqual(list(acl), [{"entity": "allUsers", "role": ROLE}])
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "GET",
-                "path": "/testing/acl",
-                "query_params": {"userProject": USER_PROJECT},
-                "timeout": self._get_default_timeout(),
-            },
+        expected_query_params = {"userProject": user_project}
+        client._get_path.assert_called_once_with(
+            reload_path,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
         )
 
     def test_save_none_set_none_passed(self):

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -546,15 +546,15 @@ class Test_ACL(unittest.TestCase):
         acl.reload_path = reload_path
         acl.loaded = True
         acl.entity("allUsers", role)
-        client = acl.client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = acl.client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
 
         acl.reload()
 
         self.assertEqual(list(acl), [])
 
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             reload_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -571,8 +571,8 @@ class Test_ACL(unittest.TestCase):
         acl.reload_path = reload_path
         acl.loaded = True
         acl.entity("allUsers", role)
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
 
         acl.reload(client=client, timeout=timeout, retry=retry)
 
@@ -580,7 +580,7 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(list(acl), [])
 
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             reload_path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -596,8 +596,8 @@ class Test_ACL(unittest.TestCase):
         acl.reload_path = reload_path
         acl.loaded = True
         acl.user_project = user_project
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
 
         acl.reload(client=client)
 
@@ -605,7 +605,7 @@ class Test_ACL(unittest.TestCase):
         self.assertEqual(list(acl), [{"entity": "allUsers", "role": role}])
 
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             reload_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -692,15 +692,15 @@ class Test_Blob(unittest.TestCase):
         from google.cloud.exceptions import NotFound
 
         blob_name = "nonesuch"
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.side_effect = NotFound("testing")
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
 
         self.assertFalse(blob.exists())
 
         expected_query_params = {"fields": "name"}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -713,15 +713,15 @@ class Test_Blob(unittest.TestCase):
         user_project = "user-project-123"
         timeout = 42
         api_response = {"name": blob_name}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client, user_project=user_project)
         blob = self._make_one(blob_name, bucket=bucket)
 
         self.assertTrue(blob.exists(timeout=timeout))
 
         expected_query_params = {"fields": "name", "userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -734,15 +734,15 @@ class Test_Blob(unittest.TestCase):
         generation = 123456
         api_response = {"name": blob_name}
         retry = mock.Mock(spec=[])
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket, generation=generation)
 
         self.assertTrue(blob.exists(retry=retry))
 
         expected_query_params = {"fields": "name", "generation": generation}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -755,8 +755,8 @@ class Test_Blob(unittest.TestCase):
         generation_number = 123456
         metageneration_number = 6
         api_response = {"name": blob_name}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
 
@@ -773,7 +773,7 @@ class Test_Blob(unittest.TestCase):
             "ifGenerationMatch": generation_number,
             "ifMetagenerationMatch": metageneration_number,
         }
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -3168,8 +3168,8 @@ class Test_Blob(unittest.TestCase):
             binding["role"]: set(binding["members"])
             for binding in api_response["bindings"]
         }
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client=client)
         blob = self._make_one(blob_name, bucket=bucket)
 
@@ -3182,7 +3182,7 @@ class Test_Blob(unittest.TestCase):
 
         expected_path = "%s/iam" % (path,)
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -3206,8 +3206,8 @@ class Test_Blob(unittest.TestCase):
             "bindings": [],
         }
         expected_policy = {}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client=client, user_project=user_project)
         blob = self._make_one(blob_name, bucket=bucket)
 
@@ -3220,7 +3220,7 @@ class Test_Blob(unittest.TestCase):
 
         expected_path = "%s/iam" % (path,)
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -3243,8 +3243,8 @@ class Test_Blob(unittest.TestCase):
             "version": version,
             "bindings": [{"role": STORAGE_OWNER_ROLE, "members": [owner1, owner2]}],
         }
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client=client)
         blob = self._make_one(blob_name, bucket=bucket)
 
@@ -3254,7 +3254,7 @@ class Test_Blob(unittest.TestCase):
 
         expected_path = "%s/iam" % (path,)
         expected_query_params = {"optionsRequestedPolicyVersion": version}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -3361,8 +3361,8 @@ class Test_Blob(unittest.TestCase):
         ]
         expected = permissions[1:]
         api_response = {"permissions": expected}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client=client)
         blob = self._make_one(blob_name, bucket=bucket)
 
@@ -3372,7 +3372,7 @@ class Test_Blob(unittest.TestCase):
 
         expected_path = "/b/name/o/%s/iam/testPermissions" % (blob_name,)
         expected_query_params = {"permissions": permissions}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -3396,8 +3396,8 @@ class Test_Blob(unittest.TestCase):
         ]
         expected = permissions[1:]
         api_response = {"permissions": expected}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = _Bucket(client=client, user_project=user_project)
         blob = self._make_one(blob_name, bucket=bucket)
 
@@ -3410,7 +3410,7 @@ class Test_Blob(unittest.TestCase):
             "permissions": permissions,
             "userProject": user_project,
         }
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=timeout,

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -783,8 +783,7 @@ class Test_Blob(unittest.TestCase):
 
     def test_delete_wo_generation(self):
         BLOB_NAME = "blob-name"
-        not_found_response = ({"status": http_client.NOT_FOUND}, b"")
-        connection = _Connection(not_found_response)
+        connection = _Connection()  # no requests will be made
         client = _Client(connection)
         bucket = _Bucket(client)
         blob = self._make_one(BLOB_NAME, bucket=bucket)
@@ -812,8 +811,7 @@ class Test_Blob(unittest.TestCase):
     def test_delete_w_generation(self):
         BLOB_NAME = "blob-name"
         GENERATION = 123456
-        not_found_response = ({"status": http_client.NOT_FOUND}, b"")
-        connection = _Connection(not_found_response)
+        connection = _Connection()  # no requests will be made
         client = _Client(connection)
         bucket = _Bucket(client)
         blob = self._make_one(BLOB_NAME, bucket=bucket, generation=GENERATION)
@@ -841,8 +839,7 @@ class Test_Blob(unittest.TestCase):
     def test_delete_w_generation_match(self):
         BLOB_NAME = "blob-name"
         GENERATION = 123456
-        not_found_response = ({"status": http_client.NOT_FOUND}, b"")
-        connection = _Connection(not_found_response)
+        connection = _Connection()  # no requests will be made
         client = _Client(connection)
         bucket = _Bucket(client)
         blob = self._make_one(BLOB_NAME, bucket=bucket, generation=GENERATION)
@@ -4887,11 +4884,7 @@ class _Connection(object):
         return response
 
     def api_request(self, **kw):
-        from google.cloud.exceptions import NotFound
-
         info, content = self._respond(**kw)
-        if info.get("status") == http_client.NOT_FOUND:
-            raise NotFound(info)
         return content
 
 

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -654,14 +654,14 @@ class Test_Bucket(unittest.TestCase):
         from google.cloud.exceptions import NotFound
 
         bucket_name = "bucket-name"
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.side_effect = NotFound("testing")
         bucket = self._make_one(client, name=bucket_name)
 
         self.assertFalse(bucket.exists())
 
         expected_query_params = {"fields": "name"}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -674,8 +674,8 @@ class Test_Bucket(unittest.TestCase):
         metageneration_number = 6
         timeout = 42
         api_response = {"name": bucket_name}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client, name=bucket_name)
 
         self.assertTrue(
@@ -686,7 +686,7 @@ class Test_Bucket(unittest.TestCase):
             "fields": "name",
             "ifMetagenerationMatch": metageneration_number,
         }
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -699,8 +699,8 @@ class Test_Bucket(unittest.TestCase):
         user_project = "user-project-123"
         retry = mock.Mock(spec=[])
         api_response = {"name": bucket_name}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(name=bucket_name, user_project=user_project)
 
         self.assertTrue(bucket.exists(client=client, retry=retry))
@@ -709,7 +709,7 @@ class Test_Bucket(unittest.TestCase):
             "fields": "name",
             "userProject": user_project,
         }
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -748,8 +748,8 @@ class Test_Bucket(unittest.TestCase):
 
         name = "name"
         blob_name = "nonesuch"
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.side_effect = NotFound("testing")
         bucket = self._make_one(client, name=name)
 
         result = bucket.get_blob(blob_name)
@@ -759,7 +759,7 @@ class Test_Bucket(unittest.TestCase):
         expected_path = "/b/%s/o/%s" % (name, blob_name)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -768,7 +768,7 @@ class Test_Bucket(unittest.TestCase):
             _target_object=mock.ANY,
         )
 
-        target = client._get_path.call_args[1]["_target_object"]
+        target = client._get_resource.call_args[1]["_target_object"]
         self.assertIsInstance(target, Blob)
         self.assertIs(target.bucket, bucket)
         self.assertEqual(target.name, blob_name)
@@ -780,8 +780,8 @@ class Test_Bucket(unittest.TestCase):
         blob_name = "blob-name"
         user_project = "user-project-123"
         api_response = {"name": blob_name}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client, name=name, user_project=user_project)
 
         blob = bucket.get_blob(blob_name, client=client)
@@ -796,7 +796,7 @@ class Test_Bucket(unittest.TestCase):
             "projection": "noAcl",
         }
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -813,8 +813,8 @@ class Test_Bucket(unittest.TestCase):
         generation = 1512565576797178
         timeout = 42
         api_response = {"name": blob_name, "generation": generation}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client, name=name)
 
         blob = bucket.get_blob(blob_name, generation=generation, timeout=timeout)
@@ -830,7 +830,7 @@ class Test_Bucket(unittest.TestCase):
             "projection": "noAcl",
         }
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -847,8 +847,8 @@ class Test_Bucket(unittest.TestCase):
         generation = 1512565576797178
         retry = mock.Mock(spec=[])
         api_response = {"name": blob_name, "generation": generation}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client, name=name)
 
         blob = bucket.get_blob(blob_name, if_generation_match=generation, retry=retry)
@@ -864,7 +864,7 @@ class Test_Bucket(unittest.TestCase):
             "projection": "noAcl",
         }
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -882,8 +882,8 @@ class Test_Bucket(unittest.TestCase):
         chunk_size = 1024 * 1024
         key = b"01234567890123456789012345678901"  # 32 bytes
         api_response = {"name": blob_name}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(name=name)
 
         blob = bucket.get_blob(
@@ -901,7 +901,7 @@ class Test_Bucket(unittest.TestCase):
             "projection": "noAcl",
         }
         expected_headers = _get_encryption_headers(key)
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -1042,8 +1042,8 @@ class Test_Bucket(unittest.TestCase):
         name = "name"
         notification_id = "1"
 
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.side_effect = NotFound("testing")
         client.project = project
         bucket = self._make_one(client=client, name=name)
 
@@ -1052,7 +1052,7 @@ class Test_Bucket(unittest.TestCase):
 
         expected_path = "/b/{}/notificationConfigs/{}".format(name, notification_id)
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -1079,8 +1079,8 @@ class Test_Bucket(unittest.TestCase):
         }
         timeout = 42
         retry = mock.Mock(spec=[])
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.return_value = api_response
         client.project = project
         bucket = self._make_one(client=client, name=name, user_project=user_project)
 
@@ -1099,7 +1099,7 @@ class Test_Bucket(unittest.TestCase):
 
         expected_path = "/b/{}/notificationConfigs/{}".format(name, notification_id)
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -1463,8 +1463,8 @@ class Test_Bucket(unittest.TestCase):
         name = "name"
         metageneration_number = 9
         api_response = {"name": name}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client, name=name)
 
         bucket.reload(if_metageneration_match=metageneration_number)
@@ -1475,7 +1475,7 @@ class Test_Bucket(unittest.TestCase):
             "ifMetagenerationMatch": metageneration_number,
         }
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -2535,8 +2535,8 @@ class Test_Bucket(unittest.TestCase):
             binding["role"]: set(binding["members"])
             for binding in api_response["bindings"]
         }
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client=client, name=bucket_name)
 
         policy = bucket.get_iam_policy()
@@ -2548,7 +2548,7 @@ class Test_Bucket(unittest.TestCase):
 
         expected_path = "/b/%s/iam" % (bucket_name,)
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -2572,8 +2572,8 @@ class Test_Bucket(unittest.TestCase):
             "bindings": [],
         }
         expected_policy = {}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(
             client=client, name=bucket_name, user_project=user_project
         )
@@ -2587,7 +2587,7 @@ class Test_Bucket(unittest.TestCase):
 
         expected_path = "/b/%s/iam" % (bucket_name,)
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -2611,8 +2611,8 @@ class Test_Bucket(unittest.TestCase):
             "bindings": [{"role": STORAGE_OWNER_ROLE, "members": [owner1, owner2]}],
         }
         retry = mock.Mock(spec=[])
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client=client, name=bucket_name)
 
         policy = bucket.get_iam_policy(requested_policy_version=3, retry=retry)
@@ -2621,7 +2621,7 @@ class Test_Bucket(unittest.TestCase):
 
         expected_path = "/b/%s/iam" % (bucket_name,)
         expected_query_params = {"optionsRequestedPolicyVersion": version}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -2749,8 +2749,8 @@ class Test_Bucket(unittest.TestCase):
         ]
         expected = permissions[1:]
         api_response = {"permissions": expected}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client=client, name=name)
 
         found = bucket.test_iam_permissions(permissions)
@@ -2760,7 +2760,7 @@ class Test_Bucket(unittest.TestCase):
         expected_path = "/b/%s/iam/testPermissions" % (name,)
         expected_query_params = {}
         expected_query_params = {"permissions": permissions}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -2784,8 +2784,8 @@ class Test_Bucket(unittest.TestCase):
         ]
         expected = permissions[1:]
         api_response = {"permissions": expected}
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
         bucket = self._make_one(client=client, name=name, user_project=user_project)
 
         found = bucket.test_iam_permissions(permissions, timeout=timeout, retry=retry)
@@ -2797,7 +2797,7 @@ class Test_Bucket(unittest.TestCase):
             "permissions": permissions,
             "userProject": user_project,
         }
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -2838,7 +2838,7 @@ class Test_Bucket(unittest.TestCase):
         client = _Client(connection)
 
         # Temporary workaround until we use real mock client
-        client._get_path = mock.Mock(return_value={"items": []})
+        client._get_resource = mock.Mock(return_value={"items": []})
 
         bucket = self._make_one(client=client, name=NAME)
         bucket.acl.loaded = True
@@ -2862,7 +2862,7 @@ class Test_Bucket(unittest.TestCase):
         if not default_object_acl_loaded:
             expected_path = "/b/%s/defaultObjectAcl" % (NAME,)
             expected_query_params = {}
-            client._get_path.assert_called_once_with(
+            client._get_resource.assert_called_once_with(
                 expected_path,
                 query_params=expected_query_params,
                 timeout=self._get_default_timeout(),
@@ -2992,7 +2992,7 @@ class Test_Bucket(unittest.TestCase):
         bucket.default_object_acl.loaded = default_object_acl_loaded
 
         # Temporary workaround until we use real mock client
-        client._get_path = mock.Mock(return_value={"items": []})
+        client._get_resource = mock.Mock(return_value={"items": []})
 
         bucket.make_private(future=True)
         self.assertEqual(list(bucket.acl), no_permissions)
@@ -3013,7 +3013,7 @@ class Test_Bucket(unittest.TestCase):
         if not default_object_acl_loaded:
             expected_path = "/b/%s/defaultObjectAcl" % (NAME,)
             expected_query_params = {}
-            client._get_path.assert_called_once_with(
+            client._get_resource.assert_called_once_with(
                 expected_path,
                 query_params=expected_query_params,
                 timeout=self._get_default_timeout(),

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -409,7 +409,7 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(batch, Batch)
         self.assertIs(batch._client, client)
 
-    def test__get_path_miss_w_defaults(self):
+    def test__get_resource_miss_w_defaults(self):
         from google.cloud.exceptions import NotFound
 
         PROJECT = "PROJECT"
@@ -420,7 +420,7 @@ class TestClient(unittest.TestCase):
         connection = client._base_connection = _make_connection()
 
         with self.assertRaises(NotFound):
-            client._get_path(PATH)
+            client._get_resource(PATH)
 
         connection.api_request.assert_called_once_with(
             method="GET",
@@ -432,7 +432,7 @@ class TestClient(unittest.TestCase):
             _target_object=None,
         )
 
-    def test__get_path_hit_w_explicit(self):
+    def test__get_resource_hit_w_explicit(self):
         PROJECT = "PROJECT"
         PATH = "/path/to/something"
         QUERY_PARAMS = {"foo": "Foo"}
@@ -446,7 +446,7 @@ class TestClient(unittest.TestCase):
         connection = client._base_connection = _make_connection(expected)
         target = mock.Mock(spec={})
 
-        found = client._get_path(
+        found = client._get_resource(
             PATH,
             query_params=QUERY_PARAMS,
             headers=HEADERS,
@@ -474,8 +474,8 @@ class TestClient(unittest.TestCase):
         project = "PROJECT"
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock()
-        client._get_path.side_effect = NotFound("testing")
+        client._get_resource = mock.Mock()
+        client._get_resource.side_effect = NotFound("testing")
         bucket_name = "nonesuch"
 
         with self.assertRaises(NotFound):
@@ -484,7 +484,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -493,7 +493,7 @@ class TestClient(unittest.TestCase):
             _target_object=mock.ANY,
         )
 
-        target = client._get_path.call_args[1]["_target_object"]
+        target = client._get_resource.call_args[1]["_target_object"]
         self.assertIsInstance(target, Bucket)
         self.assertEqual(target.name, bucket_name)
 
@@ -506,7 +506,7 @@ class TestClient(unittest.TestCase):
         api_response = {"name": bucket_name}
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(return_value=api_response)
+        client._get_resource = mock.Mock(return_value=api_response)
 
         bucket = client.get_bucket(bucket_name, timeout=timeout)
 
@@ -516,7 +516,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -534,7 +534,7 @@ class TestClient(unittest.TestCase):
         api_response = {"name": bucket_name}
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(return_value=api_response)
+        client._get_resource = mock.Mock(return_value=api_response)
 
         bucket = client.get_bucket(
             bucket_name, if_metageneration_match=metageneration_number
@@ -549,7 +549,7 @@ class TestClient(unittest.TestCase):
             "ifMetagenerationMatch": metageneration_number,
         }
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -567,7 +567,7 @@ class TestClient(unittest.TestCase):
         retry = mock.Mock(spec=[])
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(side_effect=NotFound("testing"))
+        client._get_resource = mock.Mock(side_effect=NotFound("testing"))
         bucket_obj = Bucket(client, bucket_name)
 
         with self.assertRaises(NotFound):
@@ -576,7 +576,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -585,7 +585,7 @@ class TestClient(unittest.TestCase):
             _target_object=mock.ANY,
         )
 
-        target = client._get_path.call_args[1]["_target_object"]
+        target = client._get_resource.call_args[1]["_target_object"]
         self.assertIsInstance(target, Bucket)
         self.assertEqual(target.name, bucket_name)
 
@@ -597,7 +597,7 @@ class TestClient(unittest.TestCase):
         api_response = {"name": bucket_name}
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(return_value=api_response)
+        client._get_resource = mock.Mock(return_value=api_response)
         bucket_obj = Bucket(client, bucket_name)
 
         bucket = client.get_bucket(bucket_obj)
@@ -608,7 +608,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -625,7 +625,7 @@ class TestClient(unittest.TestCase):
         api_response = {"name": bucket_name}
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(return_value=api_response)
+        client._get_resource = mock.Mock(return_value=api_response)
         bucket_obj = Bucket(client, bucket_name)
 
         bucket = client.get_bucket(bucket_obj, retry=None)
@@ -636,7 +636,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -653,7 +653,7 @@ class TestClient(unittest.TestCase):
         bucket_name = "nonesuch"
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(side_effect=NotFound("testing"))
+        client._get_resource = mock.Mock(side_effect=NotFound("testing"))
 
         bucket = client.lookup_bucket(bucket_name)
 
@@ -662,7 +662,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -671,7 +671,7 @@ class TestClient(unittest.TestCase):
             _target_object=mock.ANY,
         )
 
-        target = client._get_path.call_args[1]["_target_object"]
+        target = client._get_resource.call_args[1]["_target_object"]
         self.assertIsInstance(target, Bucket)
         self.assertEqual(target.name, bucket_name)
 
@@ -684,7 +684,7 @@ class TestClient(unittest.TestCase):
         api_response = {"name": bucket_name}
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(return_value=api_response)
+        client._get_resource = mock.Mock(return_value=api_response)
 
         bucket = client.lookup_bucket(bucket_name, timeout=timeout)
 
@@ -694,7 +694,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -712,7 +712,7 @@ class TestClient(unittest.TestCase):
         credentials = _make_credentials()
         metageneration_number = 6
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(return_value=api_response)
+        client._get_resource = mock.Mock(return_value=api_response)
 
         bucket = client.lookup_bucket(
             bucket_name, if_metageneration_match=metageneration_number
@@ -727,7 +727,7 @@ class TestClient(unittest.TestCase):
             "ifMetagenerationMatch": metageneration_number,
         }
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,
@@ -744,7 +744,7 @@ class TestClient(unittest.TestCase):
         api_response = {"name": bucket_name}
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-        client._get_path = mock.Mock(return_value=api_response)
+        client._get_resource = mock.Mock(return_value=api_response)
         bucket_obj = Bucket(client, bucket_name)
 
         bucket = client.lookup_bucket(bucket_obj, retry=None)
@@ -755,7 +755,7 @@ class TestClient(unittest.TestCase):
         expected_path = "/b/%s" % (bucket_name,)
         expected_query_params = {"projection": "noAcl"}
         expected_headers = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             headers=expected_headers,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -466,340 +466,303 @@ class TestClient(unittest.TestCase):
             retry=RETRY,
             _target_object=target,
         )
-        
-    def test_get_bucket_with_string_miss(self):
+
+    def test_get_bucket_miss_w_string_w_defaults(self):
         from google.cloud.exceptions import NotFound
+        from google.cloud.storage.bucket import Bucket
 
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
-
-        NONESUCH = "nonesuch"
-        http = _make_requests_session(
-            [_make_json_response({}, status=http_client.NOT_FOUND)]
-        )
-        client._http_internal = http
+        project = "PROJECT"
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock()
+        client._get_path.side_effect = NotFound("testing")
+        bucket_name = "nonesuch"
 
         with self.assertRaises(NotFound):
-            client.get_bucket(NONESUCH, timeout=42)
+            client.get_bucket(bucket_name)
 
-        http.request.assert_called_once_with(
-            method="GET", url=mock.ANY, data=mock.ANY, headers=mock.ANY, timeout=42
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=mock.ANY,
         )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", NONESUCH]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["projection"], "noAcl")
 
-    def test_get_bucket_with_string_hit(self):
+        target = client._get_path.call_args[1]["_target_object"]
+        self.assertIsInstance(target, Bucket)
+        self.assertEqual(target.name, bucket_name)
+
+    def test_get_bucket_hit_w_string_w_timeout(self):
         from google.cloud.storage.bucket import Bucket
 
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+        project = "PROJECT"
+        bucket_name = "bucket-name"
+        timeout = 42
+        api_response = {"name": bucket_name}
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock(return_value=api_response)
 
-        BUCKET_NAME = "bucket-name"
-        data = {"name": BUCKET_NAME}
-        http = _make_requests_session([_make_json_response(data)])
-        client._http_internal = http
-
-        bucket = client.get_bucket(BUCKET_NAME)
+        bucket = client.get_bucket(bucket_name, timeout=timeout)
 
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BUCKET_NAME)
-        http.request.assert_called_once_with(
-            method="GET",
-            url=mock.ANY,
-            data=mock.ANY,
-            headers=mock.ANY,
-            timeout=self._get_default_timeout(),
-        )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", BUCKET_NAME]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["projection"], "noAcl")
+        self.assertEqual(bucket.name, bucket_name)
 
-    def test_get_bucket_with_metageneration_match(self):
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=timeout,
+            retry=DEFAULT_RETRY,
+            _target_object=bucket,
+        )
+
+    def test_get_bucket_hit_w_string_w_metageneration_match(self):
         from google.cloud.storage.bucket import Bucket
 
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        METAGENERATION_NUMBER = 6
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
-
-        BUCKET_NAME = "bucket-name"
-        data = {"name": BUCKET_NAME}
-        http = _make_requests_session([_make_json_response(data)])
-        client._http_internal = http
+        project = "PROJECT"
+        bucket_name = "bucket-name"
+        metageneration_number = 6
+        api_response = {"name": bucket_name}
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock(return_value=api_response)
 
         bucket = client.get_bucket(
-            BUCKET_NAME, if_metageneration_match=METAGENERATION_NUMBER
+            bucket_name, if_metageneration_match=metageneration_number
         )
-        self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BUCKET_NAME)
-        http.request.assert_called_once_with(
-            method="GET",
-            url=mock.ANY,
-            data=mock.ANY,
-            headers=mock.ANY,
-            timeout=self._get_default_timeout(),
-        )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", BUCKET_NAME]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["ifMetagenerationMatch"], str(METAGENERATION_NUMBER))
-        self.assertEqual(parms["projection"], "noAcl")
 
-    def test_get_bucket_with_object_miss(self):
+        self.assertIsInstance(bucket, Bucket)
+        self.assertEqual(bucket.name, bucket_name)
+
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {
+            "projection": "noAcl",
+            "ifMetagenerationMatch": metageneration_number,
+        }
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=bucket,
+        )
+
+    def test_get_bucket_miss_w_object_w_retry(self):
         from google.cloud.exceptions import NotFound
         from google.cloud.storage.bucket import Bucket
 
         project = "PROJECT"
+        bucket_name = "nonesuch"
+        retry = mock.Mock(spec=[])
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-
-        nonesuch = "nonesuch"
-        bucket_obj = Bucket(client, nonesuch)
-        http = _make_requests_session(
-            [_make_json_response({}, status=http_client.NOT_FOUND)]
-        )
-        client._http_internal = http
+        client._get_path = mock.Mock(side_effect=NotFound("testing"))
+        bucket_obj = Bucket(client, bucket_name)
 
         with self.assertRaises(NotFound):
-            client.get_bucket(bucket_obj)
+            client.get_bucket(bucket_obj, retry=retry)
 
-        http.request.assert_called_once_with(
-            method="GET",
-            url=mock.ANY,
-            data=mock.ANY,
-            headers=mock.ANY,
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
+            retry=retry,
+            _target_object=mock.ANY,
         )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", nonesuch]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["projection"], "noAcl")
 
-    def test_get_bucket_with_object_hit(self):
+        target = client._get_path.call_args[1]["_target_object"]
+        self.assertIsInstance(target, Bucket)
+        self.assertEqual(target.name, bucket_name)
+
+    def test_get_bucket_hit_w_object_defaults(self):
         from google.cloud.storage.bucket import Bucket
 
         project = "PROJECT"
+        bucket_name = "bucket-name"
+        api_response = {"name": bucket_name}
         credentials = _make_credentials()
         client = self._make_one(project=project, credentials=credentials)
-
-        bucket_name = "bucket-name"
+        client._get_path = mock.Mock(return_value=api_response)
         bucket_obj = Bucket(client, bucket_name)
-        data = {"name": bucket_name}
-        http = _make_requests_session([_make_json_response(data)])
-        client._http_internal = http
 
         bucket = client.get_bucket(bucket_obj)
 
         self.assertIsInstance(bucket, Bucket)
         self.assertEqual(bucket.name, bucket_name)
-        http.request.assert_called_once_with(
-            method="GET",
-            url=mock.ANY,
-            data=mock.ANY,
-            headers=mock.ANY,
+
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
-        )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", bucket_name]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["projection"], "noAcl")
-
-    def test_get_bucket_default_retry(self):
-        from google.cloud.storage.bucket import Bucket
-        from google.cloud.storage._http import Connection
-
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
-
-        bucket_name = "bucket-name"
-        bucket_obj = Bucket(client, bucket_name)
-
-        with mock.patch.object(Connection, "api_request") as req:
-            client.get_bucket(bucket_obj)
-
-        req.assert_called_once_with(
-            method="GET",
-            path=mock.ANY,
-            query_params=mock.ANY,
-            headers=mock.ANY,
-            _target_object=bucket_obj,
-            timeout=mock.ANY,
             retry=DEFAULT_RETRY,
+            _target_object=bucket,
         )
 
-    def test_get_bucket_respects_retry_override(self):
+    def test_get_bucket_hit_w_object_w_retry_none(self):
         from google.cloud.storage.bucket import Bucket
-        from google.cloud.storage._http import Connection
 
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
-
+        project = "PROJECT"
         bucket_name = "bucket-name"
+        api_response = {"name": bucket_name}
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock(return_value=api_response)
         bucket_obj = Bucket(client, bucket_name)
 
-        with mock.patch.object(Connection, "api_request") as req:
-            client.get_bucket(bucket_obj, retry=None)
+        bucket = client.get_bucket(bucket_obj, retry=None)
 
-        req.assert_called_once_with(
-            method="GET",
-            path=mock.ANY,
-            query_params=mock.ANY,
-            headers=mock.ANY,
-            _target_object=bucket_obj,
-            timeout=mock.ANY,
+        self.assertIsInstance(bucket, Bucket)
+        self.assertEqual(bucket.name, bucket_name)
+
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
             retry=None,
+            _target_object=bucket,
         )
 
-    def test_lookup_bucket_miss(self):
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+    def test_lookup_bucket_miss_w_defaults(self):
+        from google.cloud.exceptions import NotFound
+        from google.cloud.storage.bucket import Bucket
 
-        NONESUCH = "nonesuch"
-        http = _make_requests_session(
-            [_make_json_response({}, status=http_client.NOT_FOUND)]
-        )
-        client._http_internal = http
+        project = "PROJECT"
+        bucket_name = "nonesuch"
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock(side_effect=NotFound("testing"))
 
-        bucket = client.lookup_bucket(NONESUCH, timeout=42)
+        bucket = client.lookup_bucket(bucket_name)
 
         self.assertIsNone(bucket)
-        http.request.assert_called_once_with(
-            method="GET", url=mock.ANY, data=mock.ANY, headers=mock.ANY, timeout=42
-        )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", NONESUCH]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["projection"], "noAcl")
 
-    def test_lookup_bucket_hit(self):
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=mock.ANY,
+        )
+
+        target = client._get_path.call_args[1]["_target_object"]
+        self.assertIsInstance(target, Bucket)
+        self.assertEqual(target.name, bucket_name)
+
+    def test_lookup_bucket_hit_w_timeout(self):
         from google.cloud.storage.bucket import Bucket
 
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+        project = "PROJECT"
+        bucket_name = "bucket-name"
+        timeout = 42
+        api_response = {"name": bucket_name}
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock(return_value=api_response)
 
-        BUCKET_NAME = "bucket-name"
-        data = {"name": BUCKET_NAME}
-        http = _make_requests_session([_make_json_response(data)])
-        client._http_internal = http
-
-        bucket = client.lookup_bucket(BUCKET_NAME)
+        bucket = client.lookup_bucket(bucket_name, timeout=timeout)
 
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BUCKET_NAME)
-        http.request.assert_called_once_with(
-            method="GET",
-            url=mock.ANY,
-            data=mock.ANY,
-            headers=mock.ANY,
-            timeout=self._get_default_timeout(),
-        )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", BUCKET_NAME]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["projection"], "noAcl")
+        self.assertEqual(bucket.name, bucket_name)
 
-    def test_lookup_bucket_with_metageneration_match(self):
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=timeout,
+            retry=DEFAULT_RETRY,
+            _target_object=bucket,
+        )
+
+    def test_lookup_bucket_hit_w_metageneration_match(self):
         from google.cloud.storage.bucket import Bucket
 
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        METAGENERATION_NUMBER = 6
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
-
-        BUCKET_NAME = "bucket-name"
-        data = {"name": BUCKET_NAME}
-        http = _make_requests_session([_make_json_response(data)])
-        client._http_internal = http
+        project = "PROJECT"
+        bucket_name = "bucket-name"
+        api_response = {"name": bucket_name}
+        credentials = _make_credentials()
+        metageneration_number = 6
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock(return_value=api_response)
 
         bucket = client.lookup_bucket(
-            BUCKET_NAME, if_metageneration_match=METAGENERATION_NUMBER
+            bucket_name, if_metageneration_match=metageneration_number
         )
+
         self.assertIsInstance(bucket, Bucket)
-        self.assertEqual(bucket.name, BUCKET_NAME)
-        http.request.assert_called_once_with(
-            method="GET",
-            url=mock.ANY,
-            data=mock.ANY,
-            headers=mock.ANY,
+        self.assertEqual(bucket.name, bucket_name)
+
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {
+            "projection": "noAcl",
+            "ifMetagenerationMatch": metageneration_number,
+        }
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=bucket,
         )
-        _, kwargs = http.request.call_args
-        scheme, netloc, path, qs, _ = urlparse.urlsplit(kwargs.get("url"))
-        self.assertEqual("%s://%s" % (scheme, netloc), client._connection.API_BASE_URL)
-        self.assertEqual(
-            path,
-            "/".join(["", "storage", client._connection.API_VERSION, "b", BUCKET_NAME]),
-        )
-        parms = dict(urlparse.parse_qsl(qs))
-        self.assertEqual(parms["projection"], "noAcl")
-        self.assertEqual(parms["ifMetagenerationMatch"], str(METAGENERATION_NUMBER))
 
-    def test_lookup_bucket_default_retry(self):
+    def test_lookup_bucket_hit_w_retry(self):
         from google.cloud.storage.bucket import Bucket
-        from google.cloud.storage._http import Connection
 
-        PROJECT = "PROJECT"
-        CREDENTIALS = _make_credentials()
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
-
+        project = "PROJECT"
         bucket_name = "bucket-name"
+        api_response = {"name": bucket_name}
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_path = mock.Mock(return_value=api_response)
         bucket_obj = Bucket(client, bucket_name)
 
-        with mock.patch.object(Connection, "api_request") as req:
-            client.lookup_bucket(bucket_obj)
-            req.assert_called_once_with(
-                method="GET",
-                path=mock.ANY,
-                query_params=mock.ANY,
-                headers=mock.ANY,
-                _target_object=bucket_obj,
-                timeout=mock.ANY,
-                retry=DEFAULT_RETRY,
-            )
+        bucket = client.lookup_bucket(bucket_obj, retry=None)
+
+        self.assertIsInstance(bucket, Bucket)
+        self.assertEqual(bucket.name, bucket_name)
+
+        expected_path = "/b/%s" % (bucket_name,)
+        expected_query_params = {"projection": "noAcl"}
+        expected_headers = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=None,
+            _target_object=bucket,
+        )
 
     def test_create_bucket_w_missing_client_project(self):
         credentials = _make_credentials()

--- a/tests/unit/test_hmac_key.py
+++ b/tests/unit/test_hmac_key.py
@@ -218,31 +218,29 @@ class TestHMACKeyMetadata(unittest.TestCase):
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
         self.assertEqual(metadata.path, expected_path)
 
-    def test_exists_miss_no_project_set(self):
+    def test_exists_miss_w_defaults(self):
         from google.cloud.exceptions import NotFound
 
         access_id = "ACCESS-ID"
-        connection = mock.Mock(spec=["api_request"])
-        connection.api_request.side_effect = NotFound("testing")
-        client = _Client(connection)
+        project = "PROJECT"
+        client = mock.Mock(spec=["_get_path", "project"])
+        client._get_path.side_effect = NotFound("testing")
+        client.project = project
         metadata = self._make_one(client)
         metadata._properties["accessId"] = access_id
 
-        self.assertFalse(metadata.exists(timeout=42))
+        self.assertFalse(metadata.exists())
 
-        expected_path = "/projects/{}/hmacKeys/{}".format(
-            client.DEFAULT_PROJECT, access_id
+        expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
+        expected_query_params = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
         )
-        expected_kwargs = {
-            "method": "GET",
-            "path": expected_path,
-            "query_params": {},
-            "timeout": 42,
-            "retry": DEFAULT_RETRY,
-        }
-        connection.api_request.assert_called_once_with(**expected_kwargs)
 
-    def test_exists_hit_w_project_set(self):
+    def test_exists_hit_w_user_project_w_timeout_w_retry(self):
         project = "PROJECT-ID"
         access_id = "ACCESS-ID"
         user_project = "billed-project"
@@ -252,24 +250,24 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "accessId": access_id,
             "serviceAccountEmail": email,
         }
-        connection = mock.Mock(spec=["api_request"])
-        connection.api_request.return_value = resource
-        client = _Client(connection)
+        timeout = 42
+        retry = mock.Mock(spec=[])
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = resource
         metadata = self._make_one(client, user_project=user_project)
         metadata._properties["accessId"] = access_id
         metadata._properties["projectId"] = project
 
-        self.assertTrue(metadata.exists())
+        self.assertTrue(metadata.exists(timeout=timeout, retry=retry))
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
-        expected_kwargs = {
-            "method": "GET",
-            "path": expected_path,
-            "query_params": {"userProject": user_project},
-            "timeout": self._get_default_timeout(),
-            "retry": DEFAULT_RETRY,
-        }
-        connection.api_request.assert_called_once_with(**expected_kwargs)
+        expected_query_params = {"userProject": user_project}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=retry,
+        )
 
     def test_reload_miss_no_project_set(self):
         from google.cloud.exceptions import NotFound

--- a/tests/unit/test_hmac_key.py
+++ b/tests/unit/test_hmac_key.py
@@ -240,7 +240,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
             retry=DEFAULT_RETRY,
         )
 
-    def test_exists_hit_w_user_project_w_timeout_w_retry(self):
+    def test_exists_hit_w_explicit_w_user_project(self):
         project = "PROJECT-ID"
         access_id = "ACCESS-ID"
         user_project = "billed-project"
@@ -269,30 +269,28 @@ class TestHMACKeyMetadata(unittest.TestCase):
             retry=retry,
         )
 
-    def test_reload_miss_no_project_set(self):
+    def test_reload_miss_w_defaults(self):
         from google.cloud.exceptions import NotFound
 
         access_id = "ACCESS-ID"
-        connection = mock.Mock(spec=["api_request"])
-        connection.api_request.side_effect = NotFound("testing")
-        client = _Client(connection)
+        project = "PROJECT"
+        client = mock.Mock(spec=["_get_path", "project"])
+        client._get_path.side_effect = NotFound("testing")
+        client.project = project
         metadata = self._make_one(client)
         metadata._properties["accessId"] = access_id
 
         with self.assertRaises(NotFound):
-            metadata.reload(timeout=42)
+            metadata.reload()
 
-        expected_path = "/projects/{}/hmacKeys/{}".format(
-            client.DEFAULT_PROJECT, access_id
+        expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
+        expected_query_params = {}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
         )
-        expected_kwargs = {
-            "method": "GET",
-            "path": expected_path,
-            "query_params": {},
-            "timeout": 42,
-            "retry": DEFAULT_RETRY,
-        }
-        connection.api_request.assert_called_once_with(**expected_kwargs)
 
     def test_reload_hit_w_project_set(self):
         project = "PROJECT-ID"
@@ -304,26 +302,26 @@ class TestHMACKeyMetadata(unittest.TestCase):
             "accessId": access_id,
             "serviceAccountEmail": email,
         }
-        connection = mock.Mock(spec=["api_request"])
-        connection.api_request.return_value = resource
-        client = _Client(connection)
+        timeout = 42
+        retry = mock.Mock(spec=[])
+        client = mock.Mock(spec=["_get_path"])
+        client._get_path.return_value = resource
         metadata = self._make_one(client, user_project=user_project)
         metadata._properties["accessId"] = access_id
         metadata._properties["projectId"] = project
 
-        metadata.reload()
+        metadata.reload(timeout=timeout, retry=retry)
 
         self.assertEqual(metadata._properties, resource)
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
-        expected_kwargs = {
-            "method": "GET",
-            "path": expected_path,
-            "query_params": {"userProject": user_project},
-            "timeout": self._get_default_timeout(),
-            "retry": DEFAULT_RETRY,
-        }
-        connection.api_request.assert_called_once_with(**expected_kwargs)
+        expected_query_params = {"userProject": user_project}
+        client._get_path.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=retry,
+        )
 
     def test_update_miss_no_project_set(self):
         from google.cloud.exceptions import NotFound

--- a/tests/unit/test_hmac_key.py
+++ b/tests/unit/test_hmac_key.py
@@ -223,8 +223,8 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
         access_id = "ACCESS-ID"
         project = "PROJECT"
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.side_effect = NotFound("testing")
         client.project = project
         metadata = self._make_one(client)
         metadata._properties["accessId"] = access_id
@@ -233,7 +233,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -252,8 +252,8 @@ class TestHMACKeyMetadata(unittest.TestCase):
         }
         timeout = 42
         retry = mock.Mock(spec=[])
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = resource
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = resource
         metadata = self._make_one(client, user_project=user_project)
         metadata._properties["accessId"] = access_id
         metadata._properties["projectId"] = project
@@ -262,7 +262,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=timeout,
@@ -274,8 +274,8 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
         access_id = "ACCESS-ID"
         project = "PROJECT"
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.side_effect = NotFound("testing")
         client.project = project
         metadata = self._make_one(client)
         metadata._properties["accessId"] = access_id
@@ -285,7 +285,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -304,8 +304,8 @@ class TestHMACKeyMetadata(unittest.TestCase):
         }
         timeout = 42
         retry = mock.Mock(spec=[])
-        client = mock.Mock(spec=["_get_path"])
-        client._get_path.return_value = resource
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = resource
         metadata = self._make_one(client, user_project=user_project)
         metadata._properties["accessId"] = access_id
         metadata._properties["projectId"] = project
@@ -316,7 +316,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
         expected_path = "/projects/{}/hmacKeys/{}".format(project, access_id)
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             expected_path,
             query_params=expected_query_params,
             timeout=timeout,

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -387,52 +387,58 @@ class TestBucketNotification(unittest.TestCase):
         )
 
     def test_reload_wo_notification_id(self):
-        client = self._make_client()
+        client = mock.Mock(spec=["_get_path", "project"])
+        client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, self.TOPIC_NAME)
 
         with self.assertRaises(ValueError):
             notification.reload()
 
-    def test_reload_miss(self):
+        client._get_path.assert_not_called()
+
+    def test_reload_miss_w_defaults(self):
         from google.cloud.exceptions import NotFound
 
-        client = self._make_client()
+        client = mock.Mock(spec=["_get_path", "project"])
+        client._get_path.side_effect = NotFound("testing")
+        client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, self.TOPIC_NAME)
         notification._properties["id"] = self.NOTIFICATION_ID
-        api_request = client._connection.api_request
-        api_request.side_effect = NotFound("testing")
 
         with self.assertRaises(NotFound):
-            notification.reload(timeout=42)
+            notification.reload()
 
-        api_request.assert_called_once_with(
-            method="GET",
-            path=self.NOTIFICATION_PATH,
-            query_params={},
-            timeout=42,
+        expected_query_params = {}
+        client._get_path.assert_called_once_with(
+            self.NOTIFICATION_PATH,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY,
         )
 
-    def test_reload_hit(self):
+    def test_reload_hit_w_explicit_w_user_project(self):
         from google.cloud.storage.notification import NONE_PAYLOAD_FORMAT
 
-        USER_PROJECT = "user-project-123"
-        client = self._make_client()
-        bucket = self._make_bucket(client, user_project=USER_PROJECT)
-        notification = self._make_one(bucket, self.TOPIC_NAME)
-        notification._properties["id"] = self.NOTIFICATION_ID
-        api_request = client._connection.api_request
-        api_request.return_value = {
+        user_project = "user-project-123"
+        api_response = {
             "topic": self.TOPIC_REF,
             "id": self.NOTIFICATION_ID,
             "etag": self.ETAG,
             "selfLink": self.SELF_LINK,
             "payload_format": NONE_PAYLOAD_FORMAT,
         }
+        client = mock.Mock(spec=["_get_path", "project"])
+        client._get_path.return_value = api_response
+        client.project = self.BUCKET_PROJECT
+        bucket = self._make_bucket(client, user_project=user_project)
+        notification = self._make_one(bucket, self.TOPIC_NAME)
+        notification._properties["id"] = self.NOTIFICATION_ID
+        timeout = 42
+        retry = mock.Mock(spec=[])
 
-        notification.reload(client=client)
+        notification.reload(client=client, timeout=timeout, retry=retry)
 
         self.assertEqual(notification.etag, self.ETAG)
         self.assertEqual(notification.self_link, self.SELF_LINK)
@@ -441,12 +447,12 @@ class TestBucketNotification(unittest.TestCase):
         self.assertIsNone(notification.blob_name_prefix)
         self.assertEqual(notification.payload_format, NONE_PAYLOAD_FORMAT)
 
-        api_request.assert_called_once_with(
-            method="GET",
-            path=self.NOTIFICATION_PATH,
-            query_params={"userProject": USER_PROJECT},
-            timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+        expected_query_params = {"userProject": user_project}
+        client._get_path.assert_called_once_with(
+            self.NOTIFICATION_PATH,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=retry,
         )
 
     def test_delete_wo_notification_id(self):

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -327,7 +327,7 @@ class TestBucketNotification(unittest.TestCase):
         )
 
     def test_exists_wo_notification_id(self):
-        client = mock.Mock(spec=["_get_path", "project"])
+        client = mock.Mock(spec=["_get_resource", "project"])
         client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, self.TOPIC_NAME)
@@ -335,13 +335,13 @@ class TestBucketNotification(unittest.TestCase):
         with self.assertRaises(ValueError):
             notification.exists()
 
-        client._get_path.assert_not_called()
+        client._get_resource.assert_not_called()
 
     def test_exists_miss_w_defaults(self):
         from google.cloud.exceptions import NotFound
 
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.side_effect = NotFound("testing")
         client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, self.TOPIC_NAME)
@@ -350,7 +350,7 @@ class TestBucketNotification(unittest.TestCase):
         self.assertFalse(notification.exists())
 
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             self.NOTIFICATION_PATH,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -365,8 +365,8 @@ class TestBucketNotification(unittest.TestCase):
             "etag": self.ETAG,
             "selfLink": self.SELF_LINK,
         }
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.return_vale = api_response
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.return_vale = api_response
         client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client, user_project=user_project)
         notification = self._make_one(bucket, self.TOPIC_NAME)
@@ -379,7 +379,7 @@ class TestBucketNotification(unittest.TestCase):
         )
 
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             self.NOTIFICATION_PATH,
             query_params=expected_query_params,
             timeout=timeout,
@@ -387,7 +387,7 @@ class TestBucketNotification(unittest.TestCase):
         )
 
     def test_reload_wo_notification_id(self):
-        client = mock.Mock(spec=["_get_path", "project"])
+        client = mock.Mock(spec=["_get_resource", "project"])
         client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, self.TOPIC_NAME)
@@ -395,13 +395,13 @@ class TestBucketNotification(unittest.TestCase):
         with self.assertRaises(ValueError):
             notification.reload()
 
-        client._get_path.assert_not_called()
+        client._get_resource.assert_not_called()
 
     def test_reload_miss_w_defaults(self):
         from google.cloud.exceptions import NotFound
 
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.side_effect = NotFound("testing")
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.side_effect = NotFound("testing")
         client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, self.TOPIC_NAME)
@@ -411,7 +411,7 @@ class TestBucketNotification(unittest.TestCase):
             notification.reload()
 
         expected_query_params = {}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             self.NOTIFICATION_PATH,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
@@ -429,8 +429,8 @@ class TestBucketNotification(unittest.TestCase):
             "selfLink": self.SELF_LINK,
             "payload_format": NONE_PAYLOAD_FORMAT,
         }
-        client = mock.Mock(spec=["_get_path", "project"])
-        client._get_path.return_value = api_response
+        client = mock.Mock(spec=["_get_resource", "project"])
+        client._get_resource.return_value = api_response
         client.project = self.BUCKET_PROJECT
         bucket = self._make_bucket(client, user_project=user_project)
         notification = self._make_one(bucket, self.TOPIC_NAME)
@@ -448,7 +448,7 @@ class TestBucketNotification(unittest.TestCase):
         self.assertEqual(notification.payload_format, NONE_PAYLOAD_FORMAT)
 
         expected_query_params = {"userProject": user_project}
-        client._get_path.assert_called_once_with(
+        client._get_resource.assert_called_once_with(
             self.NOTIFICATION_PATH,
             query_params=expected_query_params,
             timeout=timeout,


### PR DESCRIPTION
Use an explicit helper client method for `GET` requests, rather than manipulating client's private `_connection.api_request`.  As a benefit, tests get *way* clearer.

Toward #38

~~Based on top of the branch from #430.  I will rebase when that PR merges.~~