### PR TITLE
refactor:  add / use 'Client._patch_resource' method

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -331,10 +331,9 @@ class _PropertyMixin(object):
         update_properties = {key: self._properties[key] for key in self._changes}
 
         # Make the API call.
-        api_response = client._connection.api_request(
-            method="PATCH",
-            path=self.path,
-            data=update_properties,
+        api_response = client._patch_resource(
+            self.path,
+            update_properties,
             query_params=query_params,
             _target_object=self,
             timeout=timeout,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2978,16 +2978,40 @@ class Blob(_PropertyMixin):
 
         return resp.get("permissions", [])
 
-    def make_public(self, client=None):
+    def make_public(
+        self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY,
+    ):
         """Update blob's ACL, granting read access to anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: (Optional) The client to use.  If not passed, falls back
                        to the ``client`` stored on the blob's bucket.
+
+        :type timeout: float or tuple
+        :param timeout: (Optional) The amount of time, in seconds, to wait
+            for the server response. The timeout applies to each underlying
+            request.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry: (Optional) How to retry the RPC. A None value will disable retries.
+            A google.api_core.retry.Retry value will enable retries, and the object will
+            define retriable response codes and errors and configure backoff and timeout options.
+
+            A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
+            activates it only if certain conditions are met. This class exists to provide safe defaults
+            for RPC calls that are not technically safe to retry normally (due to potential data
+            duplication or other side-effects) but become safe to retry if a condition such as
+            if_metageneration_match is set.
+
+            See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
+            information on retry types and how to configure them.
         """
         self.acl.all().grant_read()
-        self.acl.save(client=client)
+        self.acl.save(client=client, timeout=timeout, retry=retry)
 
     def make_private(self, client=None):
         """Update blob's ACL, revoking read access for anonymous users.

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3013,16 +3013,40 @@ class Blob(_PropertyMixin):
         self.acl.all().grant_read()
         self.acl.save(client=client, timeout=timeout, retry=retry)
 
-    def make_private(self, client=None):
+    def make_private(
+        self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY,
+    ):
         """Update blob's ACL, revoking read access for anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
                       ``NoneType``
         :param client: (Optional) The client to use.  If not passed, falls back
                        to the ``client`` stored on the blob's bucket.
+
+        :type timeout: float or tuple
+        :param timeout: (Optional) The amount of time, in seconds, to wait
+            for the server response. The timeout applies to each underlying
+            request.
+
+            Can also be passed as a tuple (connect_timeout, read_timeout).
+            See :meth:`requests.Session.request` documentation for details.
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry: (Optional) How to retry the RPC. A None value will disable retries.
+            A google.api_core.retry.Retry value will enable retries, and the object will
+            define retriable response codes and errors and configure backoff and timeout options.
+
+            A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
+            activates it only if certain conditions are met. This class exists to provide safe defaults
+            for RPC calls that are not technically safe to retry normally (due to potential data
+            duplication or other side-effects) but become safe to retry if a condition such as
+            if_metageneration_match is set.
+
+            See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
+            information on retry types and how to configure them.
         """
         self.acl.all().revoke_read()
-        self.acl.save(client=client)
+        self.acl.save(client=client, timeout=timeout, retry=retry)
 
     def compose(
         self,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -3068,7 +3068,7 @@ class Bucket(_PropertyMixin):
             for each blob.
         """
         self.acl.all().grant_read()
-        self.acl.save(client=client, timeout=timeout)
+        self.acl.save(client=client, timeout=timeout, retry=retry)
 
         if future:
             doa = self.default_object_acl
@@ -3099,7 +3099,7 @@ class Bucket(_PropertyMixin):
 
             for blob in blobs:
                 blob.acl.all().grant_read()
-                blob.acl.save(client=client, timeout=timeout)
+                blob.acl.save(client=client, timeout=timeout, retry=retry)
 
     def make_private(
         self,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1065,9 +1065,9 @@ class Bucket(_PropertyMixin):
         # Call the superclass method.
         super(Bucket, self).patch(
             client=client,
-            timeout=timeout,
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
+            timeout=timeout,
             retry=retry,
         )
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1993,7 +1993,7 @@ class Bucket(_PropertyMixin):
         )
 
         if not preserve_acl:
-            new_blob.acl.save(acl={}, client=client, timeout=timeout)
+            new_blob.acl.save(acl={}, client=client, timeout=timeout, retry=retry)
 
         new_blob._set_properties(copy_result)
         return new_blob

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -3155,7 +3155,7 @@ class Bucket(_PropertyMixin):
             for each blob.
         """
         self.acl.all().revoke_read()
-        self.acl.save(client=client, timeout=timeout)
+        self.acl.save(client=client, timeout=timeout, retry=retry)
 
         if future:
             doa = self.default_object_acl
@@ -3186,7 +3186,7 @@ class Bucket(_PropertyMixin):
 
             for blob in blobs:
                 blob.acl.all().revoke_read()
-                blob.acl.save(client=client, timeout=timeout)
+                blob.acl.save(client=client, timeout=timeout, retry=retry)
 
     def generate_upload_policy(self, conditions, expiration=None, client=None):
         """Create a signed upload policy for uploading objects.

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -396,7 +396,7 @@ class Client(ClientWithProject):
         retry=DEFAULT_RETRY,
         _target_object=None,
     ):
-        """Helper for bucket / blob methods making API 'GET' calls.
+        """Helper for bucket / blob methods making API 'PATCH' calls.
 
         Args:
             path str:

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -386,6 +386,77 @@ class Client(ClientWithProject):
             _target_object=_target_object,
         )
 
+    def _patch_resource(
+        self,
+        path,
+        data,
+        query_params=None,
+        headers=None,
+        timeout=_DEFAULT_TIMEOUT,
+        retry=DEFAULT_RETRY,
+        _target_object=None,
+    ):
+        """Helper for bucket / blob methods making API 'GET' calls.
+
+        Args:
+            path str:
+                The path of the resource to fetch.
+
+            data dict:
+                The data to be patched.
+
+            query_params Optional[dict]:
+                HTTP query parameters to be passed
+
+            headers Optional[dict]:
+                HTTP headers to be passed
+
+            timeout (Optional[Union[float, Tuple[float, float]]]):
+                The amount of time, in seconds, to wait for the server response.
+
+                Can also be passed as a tuple (connect_timeout, read_timeout).
+                See :meth:`requests.Session.request` documentation for details.
+
+            retry (Optional[Union[google.api_core.retry.Retry, google.cloud.storage.retry.ConditionalRetryPolicy]]):
+                How to retry the RPC. A None value will disable retries.
+                A google.api_core.retry.Retry value will enable retries, and the object will
+                define retriable response codes and errors and configure backoff and timeout options.
+
+                A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
+                activates it only if certain conditions are met. This class exists to provide safe defaults
+                for RPC calls that are not technically safe to retry normally (due to potential data
+                duplication or other side-effects) but become safe to retry if a condition such as
+                if_metageneration_match is set.
+
+                See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
+                information on retry types and how to configure them.
+
+            _target_object (Union[ \
+                :class:`~google.cloud.storage.bucket.Bucket`, \
+                :class:`~google.cloud.storage.bucket.blob`, \
+            ]):
+                Object to which future data is to be applied -- only relevant
+                in the context of a batch.
+
+        Returns:
+            dict
+                The JSON resource fetched
+
+        Raises:
+            google.cloud.exceptions.NotFound
+                If the bucket is not found.
+        """
+        return self._connection.api_request(
+            method="PATCH",
+            path=path,
+            data=data,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=_target_object,
+        )
+
     def get_bucket(
         self,
         bucket_or_name,

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -613,195 +613,269 @@ class Test_ACL(unittest.TestCase):
         )
 
     def test_save_none_set_none_passed(self):
-        connection = _Connection()
-        client = _Client(connection)
+        save_path = "/testing"
+        client = mock.Mock(spec=["_patch_resource"])
         acl = self._make_one()
-        acl.save_path = "/testing"
-        acl.save(client=client)
-        kw = connection._requested
-        self.assertEqual(len(kw), 0)
+        acl.save_path = save_path
 
-    def test_save_existing_missing_none_passed(self):
-        connection = _Connection({})
-        client = _Client(connection)
-        acl = self._make_one()
-        acl.save_path = "/testing"
+        acl.save(client=client)
+
+        client._patch_resource.assert_not_called()
+
+    def test_save_w_empty_response_w_defaults(self):
+        class Derived(self._get_target_class()):
+            client = None
+
+        save_path = "/testing"
+        api_response = {}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = Derived()
+        acl.client = client
+        acl.save_path = save_path
         acl.loaded = True
-        acl.save(client=client, timeout=42)
+
+        acl.save()
+
         self.assertEqual(list(acl), [])
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]["method"], "PATCH")
-        self.assertEqual(kw[0]["path"], "/testing")
-        self.assertEqual(kw[0]["data"], {"acl": []})
-        self.assertEqual(kw[0]["query_params"], {"projection": "full"})
-        self.assertEqual(kw[0]["timeout"], 42)
 
-    def test_save_no_acl(self):
-        ROLE = "role"
-        AFTER = [{"entity": "allUsers", "role": ROLE}]
-        connection = _Connection({"acl": AFTER})
-        client = _Client(connection)
-        acl = self._make_one()
-        acl.save_path = "/testing"
-        acl.loaded = True
-        acl.entity("allUsers").grant(ROLE)
-        acl.save(client=client)
-        self.assertEqual(list(acl), AFTER)
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]["method"], "PATCH")
-        self.assertEqual(kw[0]["path"], "/testing")
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "PATCH",
-                "path": "/testing",
-                "query_params": {"projection": "full"},
-                "data": {"acl": AFTER},
-                "timeout": self._get_default_timeout(),
-            },
+        expected_data = {"acl": []}
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
         )
 
-    def test_save_w_acl_w_user_project(self):
-        ROLE1 = "role1"
-        ROLE2 = "role2"
-        STICKY = {"entity": "allUsers", "role": ROLE2}
-        USER_PROJECT = "user-project-123"
-        new_acl = [{"entity": "allUsers", "role": ROLE1}]
-        connection = _Connection({"acl": [STICKY] + new_acl})
-        client = _Client(connection)
+    def test_save_no_acl_w_timeout(self):
+        save_path = "/testing"
+        role = "role"
+        expected_acl = [{"entity": "allUsers", "role": role}]
+        api_response = {"acl": expected_acl}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
         acl = self._make_one()
-        acl.save_path = "/testing"
+        acl.save_path = save_path
         acl.loaded = True
-        acl.user_project = USER_PROJECT
+        acl.entity("allUsers").grant(role)
+        timeout = 42
 
-        acl.save(new_acl, client=client)
+        acl.save(client=client, timeout=timeout)
+
+        self.assertEqual(list(acl), expected_acl)
+
+        expected_data = api_response
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=DEFAULT_RETRY,
+        )
+
+    def test_save_w_acl_w_user_project_w_retry(self):
+        save_path = "/testing"
+        user_project = "user-project-123"
+        role1 = "role1"
+        role2 = "role2"
+        sticky = {"entity": "allUsers", "role": role2}
+        new_acl = [{"entity": "allUsers", "role": role1}]
+        api_response = {"acl": [sticky] + new_acl}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = self._make_one()
+        acl.save_path = save_path
+        acl.loaded = True
+        acl.user_project = user_project
+        retry = mock.Mock(spec=[])
+
+        acl.save(new_acl, client=client, retry=retry)
 
         entries = list(acl)
         self.assertEqual(len(entries), 2)
-        self.assertTrue(STICKY in entries)
+        self.assertTrue(sticky in entries)
         self.assertTrue(new_acl[0] in entries)
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "PATCH",
-                "path": "/testing",
-                "query_params": {"projection": "full", "userProject": USER_PROJECT},
-                "data": {"acl": new_acl},
-                "timeout": self._get_default_timeout(),
-            },
+
+        expected_data = {"acl": new_acl}
+        expected_query_params = {"projection": "full", "userProject": user_project}
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=retry,
         )
 
     def test_save_prefefined_invalid(self):
-        connection = _Connection()
-        client = _Client(connection)
+        save_path = "/testing"
+        client = mock.Mock(spec=["_patch_resource"])
         acl = self._make_one()
-        acl.save_path = "/testing"
+        acl.save_path = save_path
         acl.loaded = True
+
         with self.assertRaises(ValueError):
             acl.save_predefined("bogus", client=client)
 
-    def test_save_predefined_valid(self):
-        PREDEFINED = "private"
-        connection = _Connection({"acl": []})
-        client = _Client(connection)
-        acl = self._make_one()
-        acl.save_path = "/testing"
+        client._patch_resource.assert_not_called()
+
+    def test_save_predefined_w_defaults(self):
+        class Derived(self._get_target_class()):
+            client = None
+
+        save_path = "/testing"
+        predefined = "private"
+        api_response = {"acl": []}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = Derived()
+        acl.save_path = save_path
         acl.loaded = True
-        acl.save_predefined(PREDEFINED, client=client, timeout=42)
+        acl.client = client
+
+        acl.save_predefined(predefined)
+
         entries = list(acl)
         self.assertEqual(len(entries), 0)
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "PATCH",
-                "path": "/testing",
-                "query_params": {"projection": "full", "predefinedAcl": PREDEFINED},
-                "data": {"acl": []},
-                "timeout": 42,
-            },
+
+        expected_data = {"acl": []}
+        expected_query_params = {
+            "projection": "full",
+            "predefinedAcl": predefined,
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
         )
 
-    def test_save_predefined_w_XML_alias(self):
-        PREDEFINED_XML = "project-private"
-        PREDEFINED_JSON = "projectPrivate"
-        connection = _Connection({"acl": []})
-        client = _Client(connection)
+    def test_save_predefined_w_XML_alias_w_timeout(self):
+        save_path = "/testing"
+        predefined_xml = "project-private"
+        predefined_json = "projectPrivate"
+        api_response = {"acl": []}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
         acl = self._make_one()
-        acl.save_path = "/testing"
+        acl.save_path = save_path
         acl.loaded = True
-        acl.save_predefined(PREDEFINED_XML, client=client)
+        timeout = 42
+
+        acl.save_predefined(predefined_xml, client=client, timeout=timeout)
+
         entries = list(acl)
         self.assertEqual(len(entries), 0)
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "PATCH",
-                "path": "/testing",
-                "query_params": {
-                    "projection": "full",
-                    "predefinedAcl": PREDEFINED_JSON,
-                },
-                "data": {"acl": []},
-                "timeout": self._get_default_timeout(),
-            },
+
+        expected_data = {"acl": []}
+        expected_query_params = {
+            "projection": "full",
+            "predefinedAcl": predefined_json,
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=DEFAULT_RETRY,
         )
 
-    def test_save_predefined_valid_w_alternate_query_param(self):
+    def test_save_predefined_w_alternate_query_param_w_retry(self):
         # Cover case where subclass overrides _PREDEFINED_QUERY_PARAM
-        PREDEFINED = "publicRead"
-        connection = _Connection({"acl": []})
-        client = _Client(connection)
+        save_path = "/testing"
+        predefined = "publicRead"
+        api_response = {"acl": []}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
         acl = self._make_one()
-        acl.save_path = "/testing"
+        acl.save_path = save_path
         acl.loaded = True
         acl._PREDEFINED_QUERY_PARAM = "alternate"
-        acl.save_predefined(PREDEFINED, client=client)
+        retry = mock.Mock(spec=[])
+
+        acl.save_predefined(predefined, client=client, retry=retry)
+
         entries = list(acl)
         self.assertEqual(len(entries), 0)
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "PATCH",
-                "path": "/testing",
-                "query_params": {"projection": "full", "alternate": PREDEFINED},
-                "data": {"acl": []},
-                "timeout": self._get_default_timeout(),
-            },
+
+        expected_data = {"acl": []}
+        expected_query_params = {
+            "projection": "full",
+            "alternate": predefined,
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=retry,
         )
 
-    def test_clear(self):
-        ROLE1 = "role1"
-        ROLE2 = "role2"
-        STICKY = {"entity": "allUsers", "role": ROLE2}
-        connection = _Connection({"acl": [STICKY]})
-        client = _Client(connection)
-        acl = self._make_one()
-        acl.save_path = "/testing"
+    def test_clear_w_defaults(self):
+        class Derived(self._get_target_class()):
+            client = None
+
+        save_path = "/testing"
+        role1 = "role1"
+        role2 = "role2"
+        sticky = {"entity": "allUsers", "role": role2}
+        api_response = {"acl": [sticky]}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = Derived()
+        acl.client = client
+        acl.save_path = save_path
         acl.loaded = True
-        acl.entity("allUsers", ROLE1)
-        acl.clear(client=client, timeout=42)
-        self.assertEqual(list(acl), [STICKY])
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(
-            kw[0],
-            {
-                "method": "PATCH",
-                "path": "/testing",
-                "query_params": {"projection": "full"},
-                "data": {"acl": []},
-                "timeout": 42,
-            },
+        acl.entity("allUsers", role1)
+
+        acl.clear()
+
+        self.assertEqual(list(acl), [sticky])
+
+        expected_data = {"acl": []}
+        expected_query_params = {
+            "projection": "full",
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+        )
+
+    def test_clear_w_explicit_client_w_timeout_w_retry(self):
+        save_path = "/testing"
+        role1 = "role1"
+        role2 = "role2"
+        sticky = {"entity": "allUsers", "role": role2}
+        api_response = {"acl": [sticky]}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = self._make_one()
+        acl.save_path = save_path
+        acl.loaded = True
+        acl.entity("allUsers", role1)
+        timeout = 42
+        retry = mock.Mock(spec=[])
+
+        acl.clear(client=client, timeout=timeout, retry=retry)
+
+        self.assertEqual(list(acl), [sticky])
+
+        expected_data = {"acl": []}
+        expected_query_params = {
+            "projection": "full",
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=retry,
         )
 
 
@@ -913,22 +987,3 @@ class _Bucket(object):
     @property
     def path(self):
         return "/b/%s" % self.name
-
-
-class _Connection(object):
-    _delete_ok = False
-
-    def __init__(self, *responses):
-        self._responses = responses
-        self._requested = []
-        self._deleted = []
-
-    def api_request(self, **kw):
-        self._requested.append(kw)
-        response, self._responses = self._responses[0], self._responses[1:]
-        return response
-
-
-class _Client(object):
-    def __init__(self, connection):
-        self._connection = connection

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -3418,25 +3418,59 @@ class Test_Blob(unittest.TestCase):
             _target_object=None,
         )
 
-    def test_make_public(self):
+    def test_make_public_w_defaults(self):
         from google.cloud.storage.acl import _ACLEntity
 
-        BLOB_NAME = "blob-name"
+        blob_name = "blob-name"
         permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
-        after = ({"status": http_client.OK}, {"acl": permissive})
-        connection = _Connection(after)
-        client = _Client(connection)
+        api_response = {"acl": permissive}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
         bucket = _Bucket(client=client)
-        blob = self._make_one(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(blob_name, bucket=bucket)
         blob.acl.loaded = True
+
         blob.make_public()
+
         self.assertEqual(list(blob.acl), permissive)
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]["method"], "PATCH")
-        self.assertEqual(kw[0]["path"], "/b/name/o/%s" % BLOB_NAME)
-        self.assertEqual(kw[0]["data"], {"acl": permissive})
-        self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+
+        expected_patch_data = {"acl": permissive}
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            blob.path,
+            expected_patch_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+        )
+
+    def test_make_public_w_timeout_w_retry(self):
+        from google.cloud.storage.acl import _ACLEntity
+
+        blob_name = "blob-name"
+        permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
+        api_response = {"acl": permissive}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        bucket = _Bucket(client=client)
+        blob = self._make_one(blob_name, bucket=bucket)
+        blob.acl.loaded = True
+        timeout = 42
+        retry = mock.Mock(spec=[])
+
+        blob.make_public(timeout=timeout, retry=retry)
+
+        self.assertEqual(list(blob.acl), permissive)
+
+        expected_patch_data = {"acl": permissive}
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            blob.path,
+            expected_patch_data,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=retry,
+        )
 
     def test_make_private(self):
         BLOB_NAME = "blob-name"

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -3472,23 +3472,55 @@ class Test_Blob(unittest.TestCase):
             retry=retry,
         )
 
-    def test_make_private(self):
-        BLOB_NAME = "blob-name"
+    def test_make_private_w_defaults(self):
+        blob_name = "blob-name"
         no_permissions = []
-        after = ({"status": http_client.OK}, {"acl": no_permissions})
-        connection = _Connection(after)
-        client = _Client(connection)
+        api_response = {"acl": no_permissions}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
         bucket = _Bucket(client=client)
-        blob = self._make_one(BLOB_NAME, bucket=bucket)
+        blob = self._make_one(blob_name, bucket=bucket)
         blob.acl.loaded = True
+
         blob.make_private()
+
         self.assertEqual(list(blob.acl), no_permissions)
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]["method"], "PATCH")
-        self.assertEqual(kw[0]["path"], "/b/name/o/%s" % BLOB_NAME)
-        self.assertEqual(kw[0]["data"], {"acl": no_permissions})
-        self.assertEqual(kw[0]["query_params"], {"projection": "full"})
+
+        expected_patch_data = {"acl": no_permissions}
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            blob.path,
+            expected_patch_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+        )
+
+    def test_make_private_w_timeout_w_retry(self):
+        blob_name = "blob-name"
+        no_permissions = []
+        api_response = {"acl": no_permissions}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        bucket = _Bucket(client=client)
+        blob = self._make_one(blob_name, bucket=bucket)
+        blob.acl.loaded = True
+        timeout = 42
+        retry = mock.Mock(spec=[])
+
+        blob.make_private(timeout=timeout, retry=retry)
+
+        self.assertEqual(list(blob.acl), no_permissions)
+
+        expected_patch_data = {"acl": no_permissions}
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            blob.path,
+            expected_patch_data,
+            query_params=expected_query_params,
+            timeout=timeout,
+            retry=retry,
+        )
 
     def test_compose_wo_content_type_set(self):
         SOURCE_1 = "source-1"

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -2808,59 +2808,72 @@ class Test_Bucket(unittest.TestCase):
     def test_make_public_defaults(self):
         from google.cloud.storage.acl import _ACLEntity
 
-        NAME = "name"
+        name = "name"
         permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
-        after = {"acl": permissive, "defaultObjectAcl": []}
-        connection = _Connection(after)
-        client = _Client(connection)
-        bucket = self._make_one(client=client, name=NAME)
+        api_response = {"acl": permissive, "defaultObjectAcl": []}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        bucket = self._make_one(client=client, name=name)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
+
         bucket.make_public()
+
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])
-        kw = connection._requested
-        self.assertEqual(len(kw), 1)
-        self.assertEqual(kw[0]["method"], "PATCH")
-        self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
-        self.assertEqual(kw[0]["data"], {"acl": after["acl"]})
-        self.assertEqual(kw[0]["query_params"], {"projection": "full"})
-        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
+
+        expected_path = bucket.path
+        expected_data = {"acl": permissive}
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            expected_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+        )
 
     def _make_public_w_future_helper(self, default_object_acl_loaded=True):
         from google.cloud.storage.acl import _ACLEntity
 
-        NAME = "name"
+        name = "name"
+        get_api_response = {"items": []}
         permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
-        after1 = {"acl": permissive, "defaultObjectAcl": []}
-        after2 = {"acl": permissive, "defaultObjectAcl": permissive}
-        connection = _Connection(after1, after2)
-        client = _Client(connection)
+        acl_patched_response = {"acl": permissive, "defaultObjectAcl": []}
+        dac_patched_response = {"acl": permissive, "defaultObjectAcl": permissive}
+        client = mock.Mock(spec=["_get_resource", "_patch_resource"])
+        client._get_resource.return_value = get_api_response
+        client._patch_resource.side_effect = [
+            acl_patched_response,
+            dac_patched_response,
+        ]
 
-        # Temporary workaround until we use real mock client
-        client._get_resource = mock.Mock(return_value={"items": []})
-
-        bucket = self._make_one(client=client, name=NAME)
+        bucket = self._make_one(client=client, name=name)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = default_object_acl_loaded
+
         bucket.make_public(future=True)
+
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), permissive)
-        kw = connection._requested
-        self.assertEqual(len(kw), 2)
-        self.assertEqual(kw[0]["method"], "PATCH")
-        self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
-        self.assertEqual(kw[0]["data"], {"acl": permissive})
-        self.assertEqual(kw[0]["query_params"], {"projection": "full"})
-        self.assertEqual(kw[0]["timeout"], self._get_default_timeout())
-        self.assertEqual(kw[1]["method"], "PATCH")
-        self.assertEqual(kw[1]["path"], "/b/%s" % NAME)
-        self.assertEqual(kw[1]["data"], {"defaultObjectAcl": permissive})
-        self.assertEqual(kw[1]["query_params"], {"projection": "full"})
-        self.assertEqual(kw[1]["timeout"], self._get_default_timeout())
+
+        self.assertEqual(len(client._patch_resource.call_args_list), 2)
+        expected_acl_data = {"acl": permissive}
+        expected_dac_data = {"defaultObjectAcl": permissive}
+        expected_kw = {
+            "query_params": {"projection": "full"},
+            "timeout": self._get_default_timeout(),
+            "retry": DEFAULT_RETRY,
+        }
+        client._patch_resource.assert_has_calls(
+            [
+                ((bucket.path, expected_acl_data), expected_kw),
+                ((bucket.path, expected_dac_data), expected_kw),
+            ]
+        )
 
         if not default_object_acl_loaded:
-            expected_path = "/b/%s/defaultObjectAcl" % (NAME,)
+            expected_path = "/b/%s/defaultObjectAcl" % (name,)
             expected_query_params = {}
             client._get_resource.assert_called_once_with(
                 expected_path,
@@ -2868,6 +2881,8 @@ class Test_Bucket(unittest.TestCase):
                 timeout=self._get_default_timeout(),
                 retry=DEFAULT_RETRY,
             )
+        else:
+            client._get_resource.assert_not_called()
 
     def test_make_public_w_future(self):
         self._make_public_w_future_helper(default_object_acl_loaded=True)
@@ -2898,67 +2913,80 @@ class Test_Bucket(unittest.TestCase):
             def grant_read(self):
                 self._granted = True
 
-            def save(self, client=None, timeout=None):
+            def save(self, client=None, timeout=None, retry=None):
                 _saved.append(
-                    (self._bucket, self._name, self._granted, client, timeout)
+                    (self._bucket, self._name, self._granted, client, timeout, retry)
                 )
 
-        def item_to_blob(self, item):
-            return _Blob(self.bucket, item["name"])
-
-        NAME = "name"
-        BLOB_NAME = "blob-name"
+        name = "name"
+        blob_name = "blob-name"
         permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
-        after = {"acl": permissive, "defaultObjectAcl": []}
-        connection = _Connection(after, {"items": [{"name": BLOB_NAME}]})
-        client = self._make_client()
-        client._base_connection = connection
-        bucket = self._make_one(client=client, name=NAME)
+
+        patch_acl_response = {"acl": permissive, "defaultObjectAcl": []}
+        client = mock.Mock(spec=["list_blobs", "_patch_resource"])
+        client._patch_resource.return_value = patch_acl_response
+
+        bucket = self._make_one(client=client, name=name)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
 
-        with mock.patch("google.cloud.storage.client._item_to_blob", new=item_to_blob):
-            bucket.make_public(recursive=True, timeout=42, retry=DEFAULT_RETRY)
+        list_blobs_response = iter([_Blob(bucket, blob_name)])
+        client.list_blobs.return_value = list_blobs_response
+
+        timeout = 42
+        retry = mock.Mock(spec=[])
+
+        bucket.make_public(recursive=True, timeout=timeout, retry=retry)
 
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])
-        self.assertEqual(_saved, [(bucket, BLOB_NAME, True, None, 42)])
-        kw = connection._requested
-        self.assertEqual(len(kw), 2)
-        self.assertEqual(kw[0]["method"], "PATCH")
-        self.assertEqual(kw[0]["path"], "/b/%s" % NAME)
-        self.assertEqual(kw[0]["data"], {"acl": permissive})
-        self.assertEqual(kw[0]["query_params"], {"projection": "full"})
-        self.assertEqual(kw[0]["timeout"], 42)
-        self.assertEqual(kw[1]["method"], "GET")
-        self.assertEqual(kw[1]["path"], "/b/%s/o" % NAME)
-        self.assertEqual(kw[1]["retry"], DEFAULT_RETRY)
-        max_results = bucket._MAX_OBJECTS_FOR_ITERATION + 1
-        self.assertEqual(
-            kw[1]["query_params"], {"maxResults": max_results, "projection": "full"}
+        self.assertEqual(_saved, [(bucket, blob_name, True, None, timeout, retry)])
+
+        expected_patch_data = {"acl": permissive}
+        expected_patch_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            bucket.path,
+            expected_patch_data,
+            query_params=expected_patch_query_params,
+            timeout=timeout,
+            retry=retry,
         )
-        self.assertEqual(kw[1]["timeout"], 42)
+        client.list_blobs.assert_called_once()
 
     def test_make_public_recursive_too_many(self):
         from google.cloud.storage.acl import _ACLEntity
 
-        PERMISSIVE = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
-        AFTER = {"acl": PERMISSIVE, "defaultObjectAcl": []}
+        permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
 
-        NAME = "name"
-        BLOB_NAME1 = "blob-name1"
-        BLOB_NAME2 = "blob-name2"
-        GET_BLOBS_RESP = {"items": [{"name": BLOB_NAME1}, {"name": BLOB_NAME2}]}
-        connection = _Connection(AFTER, GET_BLOBS_RESP)
-        client = self._make_client()
-        client._base_connection = connection
-        bucket = self._make_one(client=client, name=NAME)
+        name = "name"
+        blob1 = mock.Mock(spec=[])
+        blob2 = mock.Mock(spec=[])
+        patch_acl_response = {"acl": permissive, "defaultObjectAcl": []}
+        list_blobs_response = iter([blob1, blob2])
+        client = mock.Mock(spec=["list_blobs", "_patch_resource"])
+        client.list_blobs.return_value = list_blobs_response
+        client._patch_resource.return_value = patch_acl_response
+        bucket = self._make_one(client=client, name=name)
         bucket.acl.loaded = True
         bucket.default_object_acl.loaded = True
 
         # Make the Bucket refuse to make_public with 2 objects.
         bucket._MAX_OBJECTS_FOR_ITERATION = 1
-        self.assertRaises(ValueError, bucket.make_public, recursive=True)
+
+        with self.assertRaises(ValueError):
+            bucket.make_public(recursive=True)
+
+        expected_path = bucket.path
+        expected_data = {"acl": permissive}
+        expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            expected_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+        )
+        client.list_blobs.assert_called_once()
 
     def test_make_private_defaults(self):
         NAME = "name"

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -3123,9 +3123,6 @@ class Test_Bucket(unittest.TestCase):
                     (self._bucket, self._name, self._granted, client, timeout, retry)
                 )
 
-        def item_to_blob(self, item):
-            return _Blob(self.bucket, item["name"])
-
         name = "name"
         blob_name = "blob-name"
         no_permissions = []

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -412,19 +412,19 @@ class TestClient(unittest.TestCase):
     def test__get_resource_miss_w_defaults(self):
         from google.cloud.exceptions import NotFound
 
-        PROJECT = "PROJECT"
-        PATH = "/path/to/something"
-        CREDENTIALS = _make_credentials()
+        project = "PROJECT"
+        path = "/path/to/something"
+        credentials = _make_credentials()
 
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=project, credentials=credentials)
         connection = client._base_connection = _make_connection()
 
         with self.assertRaises(NotFound):
-            client._get_resource(PATH)
+            client._get_resource(path)
 
         connection.api_request.assert_called_once_with(
             method="GET",
-            path=PATH,
+            path=path,
             query_params=None,
             headers=None,
             timeout=self._get_default_timeout(),
@@ -433,25 +433,25 @@ class TestClient(unittest.TestCase):
         )
 
     def test__get_resource_hit_w_explicit(self):
-        PROJECT = "PROJECT"
-        PATH = "/path/to/something"
-        QUERY_PARAMS = {"foo": "Foo"}
-        HEADERS = {"bar": "Bar"}
-        TIMEOUT = 100
-        RETRY = mock.Mock(spec=[])
-        CREDENTIALS = _make_credentials()
+        project = "PROJECT"
+        path = "/path/to/something"
+        query_params = {"foo": "Foo"}
+        headers = {"bar": "Bar"}
+        timeout = 100
+        retry = mock.Mock(spec=[])
+        credentials = _make_credentials()
 
-        client = self._make_one(project=PROJECT, credentials=CREDENTIALS)
+        client = self._make_one(project=project, credentials=credentials)
         expected = mock.Mock(spec={})
         connection = client._base_connection = _make_connection(expected)
         target = mock.Mock(spec={})
 
         found = client._get_resource(
-            PATH,
-            query_params=QUERY_PARAMS,
-            headers=HEADERS,
-            timeout=TIMEOUT,
-            retry=RETRY,
+            path,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
             _target_object=target,
         )
 
@@ -459,11 +459,74 @@ class TestClient(unittest.TestCase):
 
         connection.api_request.assert_called_once_with(
             method="GET",
-            path=PATH,
-            query_params=QUERY_PARAMS,
-            headers=HEADERS,
-            timeout=TIMEOUT,
-            retry=RETRY,
+            path=path,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=target,
+        )
+
+    def test__patch_resource_miss_w_defaults(self):
+        from google.cloud.exceptions import NotFound
+
+        project = "PROJECT"
+        path = "/path/to/something"
+        credentials = _make_credentials()
+        patched = {"baz": "Baz"}
+
+        client = self._make_one(project=project, credentials=credentials)
+        connection = client._base_connection = _make_connection()
+
+        with self.assertRaises(NotFound):
+            client._patch_resource(path, patched)
+
+        connection.api_request.assert_called_once_with(
+            method="PATCH",
+            path=path,
+            data=patched,
+            query_params=None,
+            headers=None,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=None,
+        )
+
+    def test__patch_resource_hit_w_explicit(self):
+        project = "PROJECT"
+        path = "/path/to/something"
+        patched = {"baz": "Baz"}
+        query_params = {"foo": "Foo"}
+        headers = {"bar": "Bar"}
+        timeout = 100
+        retry = mock.Mock(spec=[])
+        credentials = _make_credentials()
+
+        client = self._make_one(project=project, credentials=credentials)
+        expected = mock.Mock(spec={})
+        connection = client._base_connection = _make_connection(expected)
+        target = mock.Mock(spec={})
+
+        found = client._patch_resource(
+            path,
+            patched,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=target,
+        )
+
+        self.assertIs(found, expected)
+
+        connection.api_request.assert_called_once_with(
+            method="PATCH",
+            path=path,
+            data=patched,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
             _target_object=target,
         )
 


### PR DESCRIPTION
Also, add retry support to `ACL.save`, `ACL.save_predefined`, and `ACL.clear`.

Toward #38.

~~Note: this PR is based on 44eeeb4 from PR #431.  I will rebase to master when that PR lands.~~ Done.