### PR TITLE
fix: replace python lifecycle action parsing ValueError with warning

### DIFF
--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2362,7 +2362,7 @@ class Bucket(_PropertyMixin):
                 yield LifecycleRuleSetStorageClass.from_api_repr(rule)
             else:
                 warnings.warn(
-                    "Unknown lifecycle rule by the client: {}. Please upgrade your client.".format(
+                    "Unknown lifecycle rule type received: {}. Please upgrade to the latest version of google-cloud-storage.".format(
                         rule
                     ),
                     UserWarning,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2362,7 +2362,11 @@ class Bucket(_PropertyMixin):
                 yield LifecycleRuleSetStorageClass.from_api_repr(rule)
             else:
                 warnings.warn(
-                    "Unknown lifecycle rule: {}".format(rule), UserWarning, stacklevel=1
+                    "Unknown lifecycle rule by the client: {}. Please upgrade your client.".format(
+                        rule
+                    ),
+                    UserWarning,
+                    stacklevel=1,
                 )
 
     @lifecycle_rules.setter

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2361,7 +2361,11 @@ class Bucket(_PropertyMixin):
             elif action_type == "SetStorageClass":
                 yield LifecycleRuleSetStorageClass.from_api_repr(rule)
             else:
-                raise ValueError("Unknown lifecycle rule: {}".format(rule))
+                warnings.warn(
+                    "Unknown lifecycle rule: {}".format(rule),
+                    UserWarning,
+                    stacklevel=1
+                )
 
     @lifecycle_rules.setter
     def lifecycle_rules(self, rules):

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2362,9 +2362,7 @@ class Bucket(_PropertyMixin):
                 yield LifecycleRuleSetStorageClass.from_api_repr(rule)
             else:
                 warnings.warn(
-                    "Unknown lifecycle rule: {}".format(rule),
-                    UserWarning,
-                    stacklevel=1
+                    "Unknown lifecycle rule: {}".format(rule), UserWarning, stacklevel=1
                 )
 
     @lifecycle_rules.setter

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1793,7 +1793,7 @@ class Test_Bucket(unittest.TestCase):
 
         list(bucket.lifecycle_rules)
         mock_warn.assert_called_with(
-            "Unknown lifecycle rule by the client: {}. Please upgrade your client.".format(
+            "Unknown lifecycle rule type received: {}. Please upgrade to the latest version of google-cloud-storage.".format(
                 BOGUS_RULE
             ),
             UserWarning,

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1783,15 +1783,20 @@ class Test_Bucket(unittest.TestCase):
         self.assertTrue(config.uniform_bucket_level_access_enabled)
         self.assertEqual(config.uniform_bucket_level_access_locked_time, now)
 
-    def test_lifecycle_rules_getter_unknown_action_type(self):
+    @mock.patch("warnings.warn")
+    def test_lifecycle_rules_getter_unknown_action_type(self, mock_warn):
         NAME = "name"
         BOGUS_RULE = {"action": {"type": "Bogus"}, "condition": {"age": 42}}
         rules = [BOGUS_RULE]
         properties = {"lifecycle": {"rule": rules}}
         bucket = self._make_one(name=NAME, properties=properties)
 
-        with self.assertRaises(ValueError):
-            list(bucket.lifecycle_rules)
+        list(bucket.lifecycle_rules)
+        mock_warn.assert_called_with(
+            "Unknown lifecycle rule: {}".format(BOGUS_RULE),
+            UserWarning,
+            stacklevel=1,
+        )
 
     def test_lifecycle_rules_getter(self):
         from google.cloud.storage.bucket import (

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1793,9 +1793,7 @@ class Test_Bucket(unittest.TestCase):
 
         list(bucket.lifecycle_rules)
         mock_warn.assert_called_with(
-            "Unknown lifecycle rule: {}".format(BOGUS_RULE),
-            UserWarning,
-            stacklevel=1,
+            "Unknown lifecycle rule: {}".format(BOGUS_RULE), UserWarning, stacklevel=1,
         )
 
     def test_lifecycle_rules_getter(self):

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1793,7 +1793,11 @@ class Test_Bucket(unittest.TestCase):
 
         list(bucket.lifecycle_rules)
         mock_warn.assert_called_with(
-            "Unknown lifecycle rule: {}".format(BOGUS_RULE), UserWarning, stacklevel=1,
+            "Unknown lifecycle rule by the client: {}. Please upgrade your client.".format(
+                BOGUS_RULE
+            ),
+            UserWarning,
+            stacklevel=1,
         )
 
     def test_lifecycle_rules_getter(self):


### PR DESCRIPTION
Replace python Lifecycle action parsing ValueError with a user warning in cases where the client attempts to parse unexpected fields. This will help future proof this feature by preventing runtime errors for parsing unsupported actions. 