### PR TITLE
fix: revise blob.compose query parameters `if_generation_match`

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2986,8 +2986,8 @@ class Blob(_PropertyMixin):
             warnings.warn(
                 "if_generation_match: type list is deprecated and supported for backwards-compatability reasons only."
                 "Use if_source_generation_match instead to match source objects generations.",
-                PendingDeprecationWarning,
-                stacklevel=1,
+                DeprecationWarning,
+                stacklevel=2,
             )
 
             if if_source_generation_match is not None:
@@ -3002,10 +3002,11 @@ class Blob(_PropertyMixin):
 
         if isinstance(if_metageneration_match, list):
             warnings.warn(
-                "if_metageneration_match matches the given value to the destination object's metageneration."
+                "if_metageneration_match: type list is deprecated and supported for backwards-compatability reasons only."
+                "Note that the metageneration to be matched is that of the destination blob."
                 "Please pass in a single value (type long).",
-                PendingDeprecationWarning,
-                stacklevel=1,
+                DeprecationWarning,
+                stacklevel=2,
             )
 
             if_metageneration_match = None

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3056,8 +3056,8 @@ class Blob(_PropertyMixin):
             If a list of long is passed in, makes the operation conditional on whether the
             current generation of each source blob matches the corresponding generation.
             The list must match ``sources`` item-to-item.
-            (Deprecated: type if_generation_match: list of long will be removed in a future release.
-            Use if_source_generation_match instead.)
+            (Deprecated: type(list of long) is supported for backwards-compatability reasons only.
+            Please use if_source_generation_match instead to match source objects generations.)
 
         :type if_metageneration_match: long
         :param if_metageneration_match:
@@ -3066,7 +3066,7 @@ class Blob(_PropertyMixin):
             value.
 
             If a list of long is passed in, no match operation will be performed.
-            (Deprecated: type if_metageneration_match: list of long will be removed in a future release.)
+            (Deprecated: type(list of long) is supported for backwards-compatability reasons only.)
 
         :type if_source_generation_match: list of long
         :param if_source_generation_match:
@@ -3108,8 +3108,8 @@ class Blob(_PropertyMixin):
 
         if isinstance(if_generation_match, list):
             warnings.warn(
-                "if_generation_match: type list is deprecated and will be removed in future."
-                "Use if_source_generation_match instead.",
+                "if_generation_match: type list is deprecated and supported for backwards-compatability reasons only."
+                "Use if_source_generation_match instead to match source objects generations.",
                 PendingDeprecationWarning,
                 stacklevel=1,
             )

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2939,11 +2939,10 @@ class Blob(_PropertyMixin):
             Setting to 0 makes the operation succeed only if there are no live
             versions of the object.
 
-            If a list of long is passed in, makes the operation conditional on whether the
-            current generation of each source blob matches the corresponding generation.
-            The list must match ``sources`` item-to-item.
-            (Deprecated: type(list of long) is supported for backwards-compatability reasons only.
-            Please use if_source_generation_match instead to match source objects generations.)
+            Note: In a previous version, this argument worked identically to the
+            ``if_source_generation_match`` argument. For backwards-compatibility reasons,
+            if a list is passed in, this argument will behave like ``if_source_generation_match``
+            and also issue a DeprecationWarning.
 
         :type if_metageneration_match: long
         :param if_metageneration_match:
@@ -2992,7 +2991,7 @@ class Blob(_PropertyMixin):
 
             if if_source_generation_match is not None:
                 raise ValueError(
-                    "Use if_generation_match to match the generation of the destination object."
+                    "Use if_generation_match to match the generation of the destination object by passing in a generation number, instead of a list."
                     "Use if_source_generation_match to match source objects generations."
                 )
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1723,6 +1723,29 @@ class TestStorageCompose(TestStorageFiles):
         composed = original.download_as_bytes()
         self.assertEqual(composed, BEFORE + TO_APPEND)
 
+    def test_compose_with_source_generation_match(self):
+        BEFORE = b"AAA\n"
+        original = self.bucket.blob("original")
+        original.content_type = "text/plain"
+        original.upload_from_string(BEFORE)
+        self.case_blobs_to_delete.append(original)
+
+        TO_APPEND = b"BBB\n"
+        to_append = self.bucket.blob("to_append")
+        to_append.upload_from_string(TO_APPEND)
+        self.case_blobs_to_delete.append(to_append)
+
+        with self.assertRaises(google.api_core.exceptions.PreconditionFailed):
+            original.compose([original, to_append], if_source_generation_match=[6, 7])
+
+        original.compose(
+            [original, to_append],
+            if_source_generation_match=[original.generation, to_append.generation],
+        )
+
+        composed = original.download_as_bytes()
+        self.assertEqual(composed, BEFORE + TO_APPEND)
+
     def test_compose_with_generation_match(self):
         BEFORE = b"AAA\n"
         original = self.bucket.blob("original")
@@ -1736,17 +1759,9 @@ class TestStorageCompose(TestStorageFiles):
         self.case_blobs_to_delete.append(to_append)
 
         with self.assertRaises(google.api_core.exceptions.PreconditionFailed):
-            original.compose(
-                [original, to_append],
-                if_generation_match=[6, 7],
-                if_metageneration_match=[8, 9],
-            )
+            original.compose([original, to_append], if_generation_match=0)
 
-        original.compose(
-            [original, to_append],
-            if_generation_match=[original.generation, to_append.generation],
-            if_metageneration_match=[original.metageneration, to_append.metageneration],
-        )
+        original.compose([original, to_append], if_generation_match=original.generation)
 
         composed = original.download_as_bytes()
         self.assertEqual(composed, BEFORE + TO_APPEND)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1723,6 +1723,54 @@ class TestStorageCompose(TestStorageFiles):
         composed = original.download_as_bytes()
         self.assertEqual(composed, BEFORE + TO_APPEND)
 
+    def test_compose_with_generation_match_list(self):
+        BEFORE = b"AAA\n"
+        original = self.bucket.blob("original")
+        original.content_type = "text/plain"
+        original.upload_from_string(BEFORE)
+        self.case_blobs_to_delete.append(original)
+
+        TO_APPEND = b"BBB\n"
+        to_append = self.bucket.blob("to_append")
+        to_append.upload_from_string(TO_APPEND)
+        self.case_blobs_to_delete.append(to_append)
+
+        with self.assertRaises(google.api_core.exceptions.PreconditionFailed):
+            original.compose(
+                [original, to_append],
+                if_generation_match=[6, 7],
+                if_metageneration_match=[8, 9],
+            )
+
+        original.compose(
+            [original, to_append],
+            if_generation_match=[original.generation, to_append.generation],
+            if_metageneration_match=[original.metageneration, to_append.metageneration],
+        )
+
+        composed = original.download_as_bytes()
+        self.assertEqual(composed, BEFORE + TO_APPEND)
+
+    def test_compose_with_generation_match_long(self):
+        BEFORE = b"AAA\n"
+        original = self.bucket.blob("original")
+        original.content_type = "text/plain"
+        original.upload_from_string(BEFORE)
+        self.case_blobs_to_delete.append(original)
+
+        TO_APPEND = b"BBB\n"
+        to_append = self.bucket.blob("to_append")
+        to_append.upload_from_string(TO_APPEND)
+        self.case_blobs_to_delete.append(to_append)
+
+        with self.assertRaises(google.api_core.exceptions.PreconditionFailed):
+            original.compose([original, to_append], if_generation_match=0)
+
+        original.compose([original, to_append], if_generation_match=original.generation)
+
+        composed = original.download_as_bytes()
+        self.assertEqual(composed, BEFORE + TO_APPEND)
+
     def test_compose_with_source_generation_match(self):
         BEFORE = b"AAA\n"
         original = self.bucket.blob("original")
@@ -1742,26 +1790,6 @@ class TestStorageCompose(TestStorageFiles):
             [original, to_append],
             if_source_generation_match=[original.generation, to_append.generation],
         )
-
-        composed = original.download_as_bytes()
-        self.assertEqual(composed, BEFORE + TO_APPEND)
-
-    def test_compose_with_generation_match(self):
-        BEFORE = b"AAA\n"
-        original = self.bucket.blob("original")
-        original.content_type = "text/plain"
-        original.upload_from_string(BEFORE)
-        self.case_blobs_to_delete.append(original)
-
-        TO_APPEND = b"BBB\n"
-        to_append = self.bucket.blob("to_append")
-        to_append.upload_from_string(TO_APPEND)
-        self.case_blobs_to_delete.append(to_append)
-
-        with self.assertRaises(google.api_core.exceptions.PreconditionFailed):
-            original.compose([original, to_append], if_generation_match=0)
-
-        original.compose([original, to_append], if_generation_match=original.generation)
 
         composed = original.download_as_bytes()
         self.assertEqual(composed, BEFORE + TO_APPEND)

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -3786,8 +3786,8 @@ class Test_Blob(unittest.TestCase):
         mock_warn.assert_called_with(
             "if_generation_match: type list is deprecated and supported for backwards-compatability reasons only."
             "Use if_source_generation_match instead to match source objects generations.",
-            PendingDeprecationWarning,
-            stacklevel=1,
+            DeprecationWarning,
+            stacklevel=2,
         )
 
     def test_compose_invalid_generation_match(self):
@@ -3847,10 +3847,11 @@ class Test_Blob(unittest.TestCase):
         )
 
         mock_warn.assert_called_with(
-            "if_metageneration_match matches the given value to the destination object's metageneration."
+            "if_metageneration_match: type list is deprecated and supported for backwards-compatability reasons only."
+            "Note that the metageneration to be matched is that of the destination blob."
             "Please pass in a single value (type long).",
-            PendingDeprecationWarning,
-            stacklevel=1,
+            DeprecationWarning,
+            stacklevel=2,
         )
 
     def test_compose_w_metageneration_match(self):

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -3784,8 +3784,8 @@ class Test_Blob(unittest.TestCase):
         )
 
         mock_warn.assert_called_with(
-            "if_generation_match: type list is deprecated and will be removed in future."
-            "Use if_source_generation_match instead.",
+            "if_generation_match: type list is deprecated and supported for backwards-compatability reasons only."
+            "Use if_source_generation_match instead to match source objects generations.",
             PendingDeprecationWarning,
             stacklevel=1,
         )

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -3813,8 +3813,7 @@ class Test_Blob(unittest.TestCase):
         destination = self._make_one(destination_name, bucket=bucket)
 
         destination.compose(
-            sources=[source_1, source_2],
-            if_metageneration_match=metageneration_number,
+            sources=[source_1, source_2], if_metageneration_match=metageneration_number,
         )
 
         expected_path = "/b/name/o/%s/compose" % destination_name


### PR DESCRIPTION
This changes `if_generation_match`, `if_metageneration_match`, `if_source_generation_match` for  `blob.compose()` to fit API behavior

- Add pending deprecation warning in cases where `if_generation_match` and `if_metageneration_match` is passed in as a list of long. Add conditional handling for backwards compatibility.
-  Update `if_generation_match` to be correctly included within the API request query parameters if it is type long.  This makes the operation conditional on whether the **composed object's** current generation matches the given value. 
- Add `if_source_generation_match` as an optional parameter that serves as sourceObjects preconditions. This is sent with the API request body. When provided, the composition only performs if the generation of the **source object** that would be used matches this value.
- Revise docstring, example and tests

Fixes #453🦕
