### PR TITLE
fix: apply idempotency policies for ACLs

### DIFF
--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -474,9 +474,7 @@ class ACL(object):
         for entry in found.get("items", ()):
             self.add_entity(self.entity_from_dict(entry))
 
-    def _save(
-        self, acl, predefined, client, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY,
-    ):
+    def _save(self, acl, predefined, client, timeout=_DEFAULT_TIMEOUT):
         """Helper for :meth:`save` and :meth:`save_predefined`.
 
         :type acl: :class:`google.cloud.storage.acl.ACL`, or a compatible list.
@@ -524,7 +522,7 @@ class ACL(object):
             {self._URL_PATH_ELEM: list(acl)},
             query_params=query_params,
             timeout=timeout,
-            retry=retry,
+            retry=None,
         )
 
         self.entities.clear()
@@ -534,9 +532,7 @@ class ACL(object):
 
         self.loaded = True
 
-    def save(
-        self, acl=None, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
-    ):
+    def save(self, acl=None, client=None, timeout=_DEFAULT_TIMEOUT):
         """Save this ACL for the current bucket.
 
         If :attr:`user_project` is set, bills the API request to that project.
@@ -555,15 +551,6 @@ class ACL(object):
 
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
-
-        :type retry: :class:`~google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-            A None value will disable retries.
-
-            A google.api_core.retry.Retry value will enable retries,
-            and the object will define retriable response codes and errors
-            and configure backoff and timeout options.
         """
         if acl is None:
             acl = self
@@ -572,11 +559,9 @@ class ACL(object):
             save_to_backend = True
 
         if save_to_backend:
-            self._save(acl, None, client, timeout=timeout, retry=retry)
+            self._save(acl, None, client, timeout=timeout)
 
-    def save_predefined(
-        self, predefined, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY,
-    ):
+    def save_predefined(self, predefined, client=None, timeout=_DEFAULT_TIMEOUT):
         """Save this ACL for the current bucket using a predefined ACL.
 
         If :attr:`user_project` is set, bills the API request to that project.
@@ -598,20 +583,11 @@ class ACL(object):
 
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
-
-        :type retry: :class:`~google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-            A None value will disable retries.
-
-            A google.api_core.retry.Retry value will enable retries,
-            and the object will define retriable response codes and errors
-            and configure backoff and timeout options.
         """
         predefined = self.validate_predefined(predefined)
-        self._save(None, predefined, client, timeout=timeout, retry=retry)
+        self._save(None, predefined, client, timeout=timeout)
 
-    def clear(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
+    def clear(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Remove all ACL entries.
 
         If :attr:`user_project` is set, bills the API request to that project.
@@ -631,17 +607,8 @@ class ACL(object):
 
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
-
-        :type retry: :class:`~google.api_core.retry.Retry`
-        :param retry: (Optional) How to retry the RPC.
-
-            A None value will disable retries.
-
-            A google.api_core.retry.Retry value will enable retries,
-            and the object will define retriable response codes and errors
-            and configure backoff and timeout options.
         """
-        self.save([], client=client, timeout=timeout, retry=retry)
+        self.save([], client=client, timeout=timeout)
 
 
 class BucketACL(ACL):

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2997,9 +2997,7 @@ class Blob(_PropertyMixin):
         self.acl.all().grant_read()
         self.acl.save(client=client, timeout=timeout)
 
-    def make_private(
-        self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY,
-    ):
+    def make_private(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Update blob's ACL, revoking read access for anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -3014,23 +3012,9 @@ class Blob(_PropertyMixin):
 
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
-
-        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
-        :param retry: (Optional) How to retry the RPC. A None value will disable retries.
-            A google.api_core.retry.Retry value will enable retries, and the object will
-            define retriable response codes and errors and configure backoff and timeout options.
-
-            A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
-            activates it only if certain conditions are met. This class exists to provide safe defaults
-            for RPC calls that are not technically safe to retry normally (due to potential data
-            duplication or other side-effects) but become safe to retry if a condition such as
-            if_metageneration_match is set.
-
-            See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
-            information on retry types and how to configure them.
         """
         self.acl.all().revoke_read()
-        self.acl.save(client=client, timeout=timeout, retry=retry)
+        self.acl.save(client=client, timeout=timeout)
 
     def compose(
         self,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2978,9 +2978,7 @@ class Blob(_PropertyMixin):
 
         return resp.get("permissions", [])
 
-    def make_public(
-        self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY,
-    ):
+    def make_public(self, client=None, timeout=_DEFAULT_TIMEOUT):
         """Update blob's ACL, granting read access to anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -2995,23 +2993,9 @@ class Blob(_PropertyMixin):
 
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
-
-        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
-        :param retry: (Optional) How to retry the RPC. A None value will disable retries.
-            A google.api_core.retry.Retry value will enable retries, and the object will
-            define retriable response codes and errors and configure backoff and timeout options.
-
-            A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
-            activates it only if certain conditions are met. This class exists to provide safe defaults
-            for RPC calls that are not technically safe to retry normally (due to potential data
-            duplication or other side-effects) but become safe to retry if a condition such as
-            if_metageneration_match is set.
-
-            See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
-            information on retry types and how to configure them.
         """
         self.acl.all().grant_read()
-        self.acl.save(client=client, timeout=timeout, retry=retry)
+        self.acl.save(client=client, timeout=timeout)
 
     def make_private(
         self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -3087,12 +3087,7 @@ class Bucket(_PropertyMixin):
                 blob.acl.save(client=client, timeout=timeout)
 
     def make_private(
-        self,
-        recursive=False,
-        future=False,
-        client=None,
-        timeout=_DEFAULT_TIMEOUT,
-        retry=DEFAULT_RETRY,
+        self, recursive=False, future=False, client=None, timeout=_DEFAULT_TIMEOUT,
     ):
         """Update bucket's ACL, revoking read access for anonymous users.
 
@@ -3117,20 +3112,6 @@ class Bucket(_PropertyMixin):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
-        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
-        :param retry: (Optional) How to retry the RPC. A None value will disable retries.
-            A google.api_core.retry.Retry value will enable retries, and the object will
-            define retriable response codes and errors and configure backoff and timeout options.
-
-            A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
-            activates it only if certain conditions are met. This class exists to provide safe defaults
-            for RPC calls that are not technically safe to retry normally (due to potential data
-            duplication or other side-effects) but become safe to retry if a condition such as
-            if_metageneration_match is set.
-
-            See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
-            information on retry types and how to configure them.
-
         :raises ValueError:
             If ``recursive`` is True, and the bucket contains more than 256
             blobs.  This is to prevent extremely long runtime of this
@@ -3140,7 +3121,7 @@ class Bucket(_PropertyMixin):
             for each blob.
         """
         self.acl.all().revoke_read()
-        self.acl.save(client=client, timeout=timeout, retry=retry)
+        self.acl.save(client=client, timeout=timeout)
 
         if future:
             doa = self.default_object_acl
@@ -3156,7 +3137,6 @@ class Bucket(_PropertyMixin):
                     max_results=self._MAX_OBJECTS_FOR_ITERATION + 1,
                     client=client,
                     timeout=timeout,
-                    retry=retry,
                 )
             )
             if len(blobs) > self._MAX_OBJECTS_FOR_ITERATION:
@@ -3171,7 +3151,7 @@ class Bucket(_PropertyMixin):
 
             for blob in blobs:
                 blob.acl.all().revoke_read()
-                blob.acl.save(client=client, timeout=timeout, retry=retry)
+                blob.acl.save(client=client, timeout=timeout)
 
     def generate_upload_policy(self, conditions, expiration=None, client=None):
         """Create a signed upload policy for uploading objects.

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -3021,12 +3021,7 @@ class Bucket(_PropertyMixin):
         return resp.get("permissions", [])
 
     def make_public(
-        self,
-        recursive=False,
-        future=False,
-        client=None,
-        timeout=_DEFAULT_TIMEOUT,
-        retry=DEFAULT_RETRY,
+        self, recursive=False, future=False, client=None, timeout=_DEFAULT_TIMEOUT,
     ):
         """Update bucket's ACL, granting read access to anonymous users.
 
@@ -3050,20 +3045,6 @@ class Bucket(_PropertyMixin):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
-        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
-        :param retry: (Optional) How to retry the RPC. A None value will disable retries.
-            A google.api_core.retry.Retry value will enable retries, and the object will
-            define retriable response codes and errors and configure backoff and timeout options.
-
-            A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a Retry object and
-            activates it only if certain conditions are met. This class exists to provide safe defaults
-            for RPC calls that are not technically safe to retry normally (due to potential data
-            duplication or other side-effects) but become safe to retry if a condition such as
-            if_metageneration_match is set.
-
-            See the retry.py source code and docstrings in this package (google.cloud.storage.retry) for
-            information on retry types and how to configure them.
-
         :raises ValueError:
             If ``recursive`` is True, and the bucket contains more than 256
             blobs.  This is to prevent extremely long runtime of this
@@ -3073,7 +3054,7 @@ class Bucket(_PropertyMixin):
             for each blob.
         """
         self.acl.all().grant_read()
-        self.acl.save(client=client, timeout=timeout, retry=retry)
+        self.acl.save(client=client, timeout=timeout)
 
         if future:
             doa = self.default_object_acl
@@ -3089,7 +3070,6 @@ class Bucket(_PropertyMixin):
                     max_results=self._MAX_OBJECTS_FOR_ITERATION + 1,
                     client=client,
                     timeout=timeout,
-                    retry=retry,
                 )
             )
             if len(blobs) > self._MAX_OBJECTS_FOR_ITERATION:
@@ -3104,7 +3084,7 @@ class Bucket(_PropertyMixin):
 
             for blob in blobs:
                 blob.acl.all().grant_read()
-                blob.acl.save(client=client, timeout=timeout, retry=retry)
+                blob.acl.save(client=client, timeout=timeout)
 
     def make_private(
         self,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1996,7 +1996,7 @@ class Bucket(_PropertyMixin):
         )
 
         if not preserve_acl:
-            new_blob.acl.save(acl={}, client=client, timeout=timeout, retry=retry)
+            new_blob.acl.save(acl={}, client=client, timeout=timeout)
 
         new_blob._set_properties(copy_result)
         return new_blob

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -464,7 +464,7 @@ class Client(ClientWithProject):
         query_params=None,
         headers=None,
         timeout=_DEFAULT_TIMEOUT,
-        retry=DEFAULT_RETRY,
+        retry=None,
         _target_object=None,
     ):
         """Helper for bucket / blob methods making API 'PUT' calls.

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -393,7 +393,7 @@ class Client(ClientWithProject):
         query_params=None,
         headers=None,
         timeout=_DEFAULT_TIMEOUT,
-        retry=DEFAULT_RETRY,
+        retry=None,
         _target_object=None,
     ):
         """Helper for bucket / blob methods making API 'PATCH' calls.

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -646,7 +646,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
     def test_save_no_acl_w_timeout(self):
@@ -673,10 +673,10 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
-    def test_save_w_acl_w_user_project_w_retry(self):
+    def test_save_w_acl_w_user_project(self):
         save_path = "/testing"
         user_project = "user-project-123"
         role1 = "role1"
@@ -690,9 +690,8 @@ class Test_ACL(unittest.TestCase):
         acl.save_path = save_path
         acl.loaded = True
         acl.user_project = user_project
-        retry = mock.Mock(spec=[])
 
-        acl.save(new_acl, client=client, retry=retry)
+        acl.save(new_acl, client=client)
 
         entries = list(acl)
         self.assertEqual(len(entries), 2)
@@ -706,7 +705,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=retry,
+            retry=None,
         )
 
     def test_save_prefefined_invalid(self):
@@ -750,7 +749,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
     def test_save_predefined_w_XML_alias_w_timeout(self):
@@ -780,10 +779,10 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
-    def test_save_predefined_w_alternate_query_param_w_retry(self):
+    def test_save_predefined_w_alternate_query_param(self):
         # Cover case where subclass overrides _PREDEFINED_QUERY_PARAM
         save_path = "/testing"
         predefined = "publicRead"
@@ -794,9 +793,8 @@ class Test_ACL(unittest.TestCase):
         acl.save_path = save_path
         acl.loaded = True
         acl._PREDEFINED_QUERY_PARAM = "alternate"
-        retry = mock.Mock(spec=[])
 
-        acl.save_predefined(predefined, client=client, retry=retry)
+        acl.save_predefined(predefined, client=client)
 
         entries = list(acl)
         self.assertEqual(len(entries), 0)
@@ -811,7 +809,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=retry,
+            retry=None,
         )
 
     def test_clear_w_defaults(self):
@@ -844,10 +842,10 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
-    def test_clear_w_explicit_client_w_timeout_w_retry(self):
+    def test_clear_w_explicit_client_w_timeout(self):
         save_path = "/testing"
         role1 = "role1"
         role2 = "role2"
@@ -860,9 +858,8 @@ class Test_ACL(unittest.TestCase):
         acl.loaded = True
         acl.entity("allUsers", role1)
         timeout = 42
-        retry = mock.Mock(spec=[])
 
-        acl.clear(client=client, timeout=timeout, retry=retry)
+        acl.clear(client=client, timeout=timeout)
 
         self.assertEqual(list(acl), [sticky])
 
@@ -875,7 +872,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=retry,
+            retry=None,
         )
 
 

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -3458,10 +3458,10 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
-    def test_make_public_w_timeout_w_retry(self):
+    def test_make_public_w_timeout(self):
         from google.cloud.storage.acl import _ACLEntity
 
         blob_name = "blob-name"
@@ -3473,9 +3473,8 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(blob_name, bucket=bucket)
         blob.acl.loaded = True
         timeout = 42
-        retry = mock.Mock(spec=[])
 
-        blob.make_public(timeout=timeout, retry=retry)
+        blob.make_public(timeout=timeout)
 
         self.assertEqual(list(blob.acl), permissive)
 
@@ -3486,7 +3485,7 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=retry,
+            retry=None,
         )
 
     def test_make_private_w_defaults(self):
@@ -3510,10 +3509,10 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
-    def test_make_private_w_timeout_w_retry(self):
+    def test_make_private_w_timeout(self):
         blob_name = "blob-name"
         no_permissions = []
         api_response = {"acl": no_permissions}
@@ -3523,9 +3522,8 @@ class Test_Blob(unittest.TestCase):
         blob = self._make_one(blob_name, bucket=bucket)
         blob.acl.loaded = True
         timeout = 42
-        retry = mock.Mock(spec=[])
 
-        blob.make_private(timeout=timeout, retry=retry)
+        blob.make_private(timeout=timeout)
 
         self.assertEqual(list(blob.acl), no_permissions)
 
@@ -3536,7 +3534,7 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=retry,
+            retry=None,
         )
 
     def test_compose_wo_content_type_set(self):

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -3177,7 +3177,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
     def _make_private_w_future_helper(self, default_object_acl_loaded=True):
@@ -3211,7 +3211,7 @@ class Test_Bucket(unittest.TestCase):
         expected_kw = {
             "query_params": {"projection": "full"},
             "timeout": self._get_default_timeout(),
-            "retry": DEFAULT_RETRY,
+            "retry": None,
         }
         client._patch_resource.assert_has_calls(
             [
@@ -3259,9 +3259,9 @@ class Test_Bucket(unittest.TestCase):
             def revoke_read(self):
                 self._granted = False
 
-            def save(self, client=None, timeout=None, retry=None):
+            def save(self, client=None, timeout=None):
                 _saved.append(
-                    (self._bucket, self._name, self._granted, client, timeout, retry)
+                    (self._bucket, self._name, self._granted, client, timeout)
                 )
 
         name = "name"
@@ -3280,13 +3280,12 @@ class Test_Bucket(unittest.TestCase):
         client.list_blobs.return_value = list_blobs_response
 
         timeout = 42
-        retry = mock.Mock(spec=[])
 
-        bucket.make_private(recursive=True, timeout=42, retry=retry)
+        bucket.make_private(recursive=True, timeout=42)
 
         self.assertEqual(list(bucket.acl), no_permissions)
         self.assertEqual(list(bucket.default_object_acl), [])
-        self.assertEqual(_saved, [(bucket, blob_name, False, None, timeout, retry)])
+        self.assertEqual(_saved, [(bucket, blob_name, False, None, timeout)])
 
         expected_patch_data = {"acl": no_permissions}
         expected_patch_query_params = {"projection": "full"}
@@ -3295,7 +3294,7 @@ class Test_Bucket(unittest.TestCase):
             expected_patch_data,
             query_params=expected_patch_query_params,
             timeout=timeout,
-            retry=retry,
+            retry=None,
         )
 
         client.list_blobs.assert_called_once()
@@ -3329,7 +3328,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
         client.list_blobs.assert_called_once()

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1792,7 +1792,7 @@ class Test_Bucket(unittest.TestCase):
             expected_patch_data,
             query_params=expected_patch_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
+            retry=None,
         )
 
     def test_copy_blob_w_name_and_user_project(self):
@@ -2996,7 +2996,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
     def _make_public_w_future_helper(self, default_object_acl_loaded=True):

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -3029,7 +3029,7 @@ class Test_Bucket(unittest.TestCase):
         expected_kw = {
             "query_params": {"projection": "full"},
             "timeout": self._get_default_timeout(),
-            "retry": DEFAULT_RETRY,
+            "retry": None,
         }
         client._patch_resource.assert_has_calls(
             [
@@ -3079,9 +3079,9 @@ class Test_Bucket(unittest.TestCase):
             def grant_read(self):
                 self._granted = True
 
-            def save(self, client=None, timeout=None, retry=None):
+            def save(self, client=None, timeout=None):
                 _saved.append(
-                    (self._bucket, self._name, self._granted, client, timeout, retry)
+                    (self._bucket, self._name, self._granted, client, timeout)
                 )
 
         name = "name"
@@ -3100,13 +3100,12 @@ class Test_Bucket(unittest.TestCase):
         client.list_blobs.return_value = list_blobs_response
 
         timeout = 42
-        retry = mock.Mock(spec=[])
 
-        bucket.make_public(recursive=True, timeout=timeout, retry=retry)
+        bucket.make_public(recursive=True, timeout=timeout)
 
         self.assertEqual(list(bucket.acl), permissive)
         self.assertEqual(list(bucket.default_object_acl), [])
-        self.assertEqual(_saved, [(bucket, blob_name, True, None, timeout, retry)])
+        self.assertEqual(_saved, [(bucket, blob_name, True, None, timeout)])
 
         expected_patch_data = {"acl": permissive}
         expected_patch_query_params = {"projection": "full"}
@@ -3115,7 +3114,7 @@ class Test_Bucket(unittest.TestCase):
             expected_patch_data,
             query_params=expected_patch_query_params,
             timeout=timeout,
-            retry=retry,
+            retry=None,
         )
         client.list_blobs.assert_called_once()
 
@@ -3150,7 +3149,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
         )
 
         client.list_blobs.assert_called_once()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -488,7 +488,7 @@ class TestClient(unittest.TestCase):
             query_params=None,
             headers=None,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
             _target_object=None,
         )
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -551,7 +551,7 @@ class TestClient(unittest.TestCase):
             query_params=None,
             headers=None,
             timeout=self._get_default_timeout(),
-            retry=DEFAULT_RETRY,
+            retry=None,
             _target_object=None,
         )
 


### PR DESCRIPTION
Toward #38.

- Use `None` as default retry for `Client._patch_resource` and `Client._put_resource` helpers (they can only be idempotent conditionally, so the caller needs to configure the retry).
- Remove `retry` argument from `ACL.save`, `ACL.save_predefined`, and `ACL.clear` (ACLs cannot be saved idempotently).
- Likewise remove `retry` argument from `Bucket.make_public`, `Bucket.make_private`, `Blob.make_public`, and `Blob.make_private`, which only perform saves on ACLs.