### PR TITLE
tests: pre-scrub old HMAC keys before testing creation

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -27,6 +27,7 @@ import unittest
 import mock
 
 import requests
+import pytest
 import six
 
 from google.cloud import exceptions
@@ -148,25 +149,33 @@ class TestClient(unittest.TestCase):
 
         self.assertTrue(any(match for match in matches if match is not None))
 
+    @staticmethod
+    def _get_before_hmac_keys(client):
+        from google.cloud.storage.hmac_key import HMACKeyMetadata
+
+        before_hmac_keys = set(client.list_hmac_keys())
+
+        now = datetime.datetime.utcnow().replace(tzinfo=_helpers.UTC)
+        yesterday = now - datetime.timedelta(days=1)
+
+        # Delete any HMAC keys older than a day.
+        for hmac_key in list(before_hmac_keys):
+            if hmac_key.time_created < yesterday:
+                if hmac_key.state != HMACKeyMetadata.INACTIVE_STATE:
+                    hmac_key.state = HMACKeyMetadata.INACTIVE_STATE
+                    hmac_key.update()
+                hmac_key.delete()
+                before_hmac_keys.remove(hmac_key)
+
+        return before_hmac_keys
+
     def test_hmac_key_crud(self):
         from google.cloud.storage.hmac_key import HMACKeyMetadata
 
         credentials = Config.CLIENT._credentials
         email = credentials.service_account_email
 
-        before_keys = set(Config.CLIENT.list_hmac_keys())
-
-        now = datetime.datetime.utcnow().replace(tzinfo=_helpers.UTC)
-        yesterday = now - datetime.timedelta(days=1)
-
-        # Delete any HMAC keys older than a day.
-        for before_key in list(before_keys):
-            if before_key.time_created < yesterday:
-                if before_key.state != HMACKeyMetadata.INACTIVE_STATE:
-                    before_key.state = HMACKeyMetadata.INACTIVE_STATE
-                    before_key.update()
-                before_key.delete()
-                before_keys.remove(before_key)
+        before_hmac_keys = self._get_before_hmac_keys(Config.CLIENT)
 
         metadata, secret = Config.CLIENT.create_hmac_key(email)
         self.case_hmac_keys_to_delete.append(metadata)
@@ -174,9 +183,9 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(secret, six.text_type)
         self.assertEqual(len(secret), 40)
 
-        after_keys = set(Config.CLIENT.list_hmac_keys())
-        self.assertFalse(metadata in before_keys)
-        self.assertTrue(metadata in after_keys)
+        after_hmac_keys = set(Config.CLIENT.list_hmac_keys())
+        self.assertFalse(metadata in before_hmac_keys)
+        self.assertTrue(metadata in after_hmac_keys)
 
         another = HMACKeyMetadata(Config.CLIENT)
 
@@ -322,7 +331,6 @@ class TestStorageBuckets(unittest.TestCase):
         self.assertEqual(bucket.labels, {})
 
     def test_get_set_iam_policy(self):
-        import pytest
         from google.cloud.storage.iam import STORAGE_OBJECT_VIEWER_ROLE
         from google.api_core.exceptions import BadRequest, PreconditionFailed
 


### PR DESCRIPTION
Avoids hitting 5-key-per-service-account quota.

Closes #334.