### PR TITLE
fix: populate etag / generation / metageneration properties during download

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -133,13 +133,13 @@ Running System Tests
 
 - To run system tests, you can execute::
 
-   $ nox -s system-3.7
+   $ nox -s system-3.8
    $ nox -s system-2.7
 
   .. note::
 
       System tests are only configured to run under Python 2.7 and
-      Python 3.7. For expediency, we do not run them in older versions
+      Python 3.8. For expediency, we do not run them in older versions
       of Python 3.
 
   This alone will not run the tests. You'll need to change some local

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -858,6 +858,11 @@ class Blob(_PropertyMixin):
         self.cache_control = response.headers.get("Cache-Control", None)
         self.storage_class = response.headers.get("X-Goog-Storage-Class", None)
         self.content_language = response.headers.get("Content-Language", None)
+        self._properties["etag"] = response.headers.get("Etag", None)
+        self._properties["generation"] = response.headers.get("X-goog-generation", None)
+        self._properties["metageneration"] = response.headers.get(
+            "X-goog-metageneration", None
+        )
         #  'X-Goog-Hash': 'crc32c=4gcgLQ==,md5=CS9tHYTtyFntzj7B9nkkJQ==',
         x_goog_hash = response.headers.get("X-Goog-Hash", "")
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -858,7 +858,7 @@ class Blob(_PropertyMixin):
         self.cache_control = response.headers.get("Cache-Control", None)
         self.storage_class = response.headers.get("X-Goog-Storage-Class", None)
         self.content_language = response.headers.get("Content-Language", None)
-        self._properties["etag"] = response.headers.get("Etag", None)
+        self._properties["etag"] = response.headers.get("ETag", None)
         self._properties["generation"] = response.headers.get("X-goog-generation", None)
         self._properties["metageneration"] = response.headers.get(
             "X-goog-metageneration", None

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -1035,8 +1035,11 @@ class Test_Blob(unittest.TestCase):
                 "Content-Language": "ko-kr",
                 "Cache-Control": "max-age=1337;public",
                 "Content-Encoding": "gzip",
+                "Etag": "kittens",
                 "X-Goog-Storage-Class": "STANDARD",
                 "X-Goog-Hash": "crc32c=4gcgLQ==,md5=CS9tHYTtyFntzj7B9nkkJQ==",
+                "X-goog-generation": 42,
+                "X-goog-metageneration": 4,
             },
             # { "x": 5 } gzipped
             content=b"\x1f\x8b\x08\x00\xcfo\x17_\x02\xff\xabVP\xaaP\xb2R0U\xa8\x05\x00\xa1\xcaQ\x93\n\x00\x00\x00",
@@ -1050,6 +1053,9 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.storage_class, "STANDARD")
         self.assertEqual(blob.md5_hash, "CS9tHYTtyFntzj7B9nkkJQ==")
         self.assertEqual(blob.crc32c, "4gcgLQ==")
+        self.assertEqual(blob.etag, "kittens")
+        self.assertEqual(blob.generation, 42)
+        self.assertEqual(blob.metageneration, 4)
 
     def test__extract_headers_from_download_empty(self):
         blob_name = "blob-name"
@@ -1064,8 +1070,11 @@ class Test_Blob(unittest.TestCase):
                 "Content-Language": "en-US",
                 "Cache-Control": "max-age=1337;public",
                 "Content-Encoding": "gzip",
+                "Etag": "kittens",
                 "X-Goog-Storage-Class": "STANDARD",
                 "X-Goog-Hash": "crc32c=4/c+LQ==,md5=CS9tHYTt/+ntzj7B9nkkJQ==",
+                "X-goog-generation": 42,
+                "X-goog-metageneration": 4,
             },
             content=b"",
         )
@@ -1074,6 +1083,9 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.content_language, "en-US")
         self.assertEqual(blob.md5_hash, "CS9tHYTt/+ntzj7B9nkkJQ==")
         self.assertEqual(blob.crc32c, "4/c+LQ==")
+        self.assertEqual(blob.etag, "kittens")
+        self.assertEqual(blob.generation, 42)
+        self.assertEqual(blob.metageneration, 4)
 
     def test__extract_headers_from_download_w_hash_response_header_none(self):
         blob_name = "blob-name"


### PR DESCRIPTION
Populates additional properties (`etag`, `generation`, `metageneration`) from the corresponding headers (`ETag`, `x-goog-generation`, and `x-goog-metageneration`) during download functions via `Blob._extract_headers_from_download`.

Additionally, update documentation for running system tests to use Python 3.8 instead of Python 3.7 to align with nox.

Closes #490.