### PR TITLE
feat: add support for Etag headers on reads

### DIFF
--- a/docs/generation_metageneration.rst
+++ b/docs/generation_metageneration.rst
@@ -17,7 +17,10 @@ Concepts
 ETag
 ::::::::::::::
 
-An ETag is returned as part of the response header whenever a resource is returned, as well as included in the resource itself. Users should make no assumptions about the value used in an ETag except that it changes whenever the underlying data changes, per the
+An ETag is returned as part of the response header whenever a resource is
+returned, as well as included in the resource itself. Users should make no
+assumptions about the value used in an ETag except that it changes whenever the
+underlying data changes, per the
 `specification <https://tools.ietf.org/html/rfc7232#section-2.3>`_
 
 The ``ETag`` attribute is set by the GCS back-end, and is read-only in the

--- a/docs/generation_metageneration.rst
+++ b/docs/generation_metageneration.rst
@@ -1,16 +1,27 @@
-Conditional Requests Via Generation / Metageneration Preconditions
-==================================================================
+Conditional Requests Via ETag / Generation / Metageneration Preconditions
+=========================================================================
 
 Preconditions tell Cloud Storage to only perform a request if the
-:ref:`generation <concept-generation>` or
+:ref:`ETag <concept-etag>`, :ref:`generation <concept-generation>`, or
 :ref:`metageneration <concept-metageneration>` number of the affected object
-meets your precondition criteria. These checks of the generation and
+meets your precondition criteria. These checks of the ETag, generation, and
 metageneration numbers ensure that the object is in the expected state,
 allowing you to perform safe read-modify-write updates and conditional
 operations on objects
 
 Concepts
 --------
+
+.. _concept-etag:
+
+ETag
+::::::::::::::
+
+An ETag is returned as part of the response header whenever a resource is returned, as well as included in the resource itself. Users should make no assumptions about the value used in an ETag except that it changes whenever the underlying data changes, per the
+`specification <https://tools.ietf.org/html/rfc7232#section-2.3>`_
+
+The ``ETag`` attribute is set by the GCS back-end, and is read-only in the
+client library.
 
 .. _concept-metageneration:
 
@@ -58,6 +69,32 @@ See also
 
 Conditional Parameters
 ----------------------
+
+.. _using-if-etag-match:
+
+Using ``if_etag_match``
+:::::::::::::::::::::::::::::
+
+Passing the ``if_etag_match`` parameter to a method which retrieves a
+blob resource (e.g.,
+:meth:`Blob.reload <google.cloud.storage.blob.Blob.reload>`)
+makes the operation conditional on whether the blob's current ``ETag`` matches
+the given value. This parameter is not supported for modification (e.g.,
+:meth:`Blob.update <google.cloud.storage.blob.Blob.update>`).
+
+
+.. _using-if-etag-not-match:
+
+Using ``if_etag_not_match``
+:::::::::::::::::::::::::::::
+
+Passing the ``if_etag_not_match`` parameter to a method which retrieves a
+blob resource (e.g.,
+:meth:`Blob.reload <google.cloud.storage.blob.Blob.reload>`)
+makes the operation conditional on whether the blob's current ``ETag`` matches
+the given value. This parameter is not supported for modification (e.g.,
+:meth:`Blob.update <google.cloud.storage.blob.Blob.update>`).
+
 
 .. _using-if-generation-match:
 

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -153,6 +153,8 @@ class _PropertyMixin(object):
         self,
         client=None,
         projection="noAcl",
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -173,6 +175,12 @@ class _PropertyMixin(object):
         :param projection: (Optional) If used, must be 'full' or 'noAcl'.
                            Defaults to ``'noAcl'``. Specifies the set of
                            properties to return.
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match: (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]])
+        :param if_etag_not_match: (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -211,10 +219,14 @@ class _PropertyMixin(object):
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
         )
+        headers = self._encryption_headers()
+        _add_etag_match_headers(
+            headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match
+        )
         api_response = client._get_resource(
             self.path,
             query_params=query_params,
-            headers=self._encryption_headers(),
+            headers=headers,
             timeout=timeout,
             retry=retry,
             _target_object=self,

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -474,12 +474,7 @@ def _add_etag_match_headers(headers, **match_parameters):
 
     :type match_parameters: dict
     :param match_parameters: if*etag*match parameters to add.
-
-    :raises: :exc:`ValueError` if ``parameters`` is not a ``dict()``.
     """
-    if not isinstance(headers, dict):
-        raise ValueError("`headers` argument should be a dict() or a list().")
-
     for snakecase_name, header_name in _ETAG_MATCH_PARAMETERS:
         value = match_parameters.get(snakecase_name)
 

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -22,6 +22,7 @@ from hashlib import md5
 from datetime import datetime
 import os
 
+from six import string_types
 from six.moves.urllib.parse import urlsplit
 from google import resumable_media
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
@@ -479,7 +480,7 @@ def _add_etag_match_headers(headers, **match_parameters):
         value = match_parameters.get(snakecase_name)
 
         if value is not None:
-            if isinstance(value, str):
+            if isinstance(value, string_types):
                 value = [value]
             headers[header_name] = ", ".join(value)
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -59,6 +59,7 @@ from google.cloud._helpers import _datetime_to_rfc3339
 from google.cloud._helpers import _rfc3339_nanos_to_datetime
 from google.cloud._helpers import _to_bytes
 from google.cloud.exceptions import NotFound
+from google.cloud.storage._helpers import _add_etag_match_headers
 from google.cloud.storage._helpers import _add_generation_match_parameters
 from google.cloud.storage._helpers import _PropertyMixin
 from google.cloud.storage._helpers import _scalar_property
@@ -634,6 +635,8 @@ class Blob(_PropertyMixin):
     def exists(
         self,
         client=None,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -650,6 +653,14 @@ class Blob(_PropertyMixin):
         :param client:
             (Optional) The client to use.  If not passed, falls back to the
             ``client`` stored on the blob's bucket.
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match:
+            (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]]
+        :param if_etag_not_match:
+            (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -692,12 +703,21 @@ class Blob(_PropertyMixin):
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
         )
+
+        headers = {}
+        _add_etag_match_headers(
+            headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match
+        )
+        if not headers:
+            headers = None
+
         try:
             # We intentionally pass `_target_object=None` since fields=name
             # would limit the local properties.
             client._get_resource(
                 self.path,
                 query_params=query_params,
+                headers=headers,
                 timeout=timeout,
                 retry=retry,
                 _target_object=None,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -997,6 +997,8 @@ class Blob(_PropertyMixin):
         start=None,
         end=None,
         raw_download=False,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -1051,6 +1053,14 @@ class Blob(_PropertyMixin):
         :type raw_download: bool
         :param raw_download:
             (Optional) If true, download the object without any expansion.
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match:
+            (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]]
+        :param if_etag_not_match:
+            (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -1116,6 +1126,8 @@ class Blob(_PropertyMixin):
             start=start,
             end=end,
             raw_download=raw_download,
+            if_etag_match=if_etag_match,
+            if_etag_not_match=if_etag_not_match,
             if_generation_match=if_generation_match,
             if_generation_not_match=if_generation_not_match,
             if_metageneration_match=if_metageneration_match,
@@ -1132,6 +1144,8 @@ class Blob(_PropertyMixin):
         start=None,
         end=None,
         raw_download=False,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -1162,6 +1176,14 @@ class Blob(_PropertyMixin):
         :type raw_download: bool
         :param raw_download:
             (Optional) If true, download the object without any expansion.
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match:
+            (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]]
+        :param if_etag_not_match:
+            (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -1228,6 +1250,8 @@ class Blob(_PropertyMixin):
                     start=start,
                     end=end,
                     raw_download=raw_download,
+                    if_etag_match=if_etag_match,
+                    if_etag_not_match=if_etag_not_match,
                     if_generation_match=if_generation_match,
                     if_generation_not_match=if_generation_not_match,
                     if_metageneration_match=if_metageneration_match,
@@ -1255,6 +1279,8 @@ class Blob(_PropertyMixin):
         start=None,
         end=None,
         raw_download=False,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -1282,6 +1308,14 @@ class Blob(_PropertyMixin):
         :type raw_download: bool
         :param raw_download:
             (Optional) If true, download the object without any expansion.
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match:
+            (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]]
+        :param if_etag_not_match:
+            (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -1350,6 +1384,8 @@ class Blob(_PropertyMixin):
             start=start,
             end=end,
             raw_download=raw_download,
+            if_etag_match=if_etag_match,
+            if_etag_not_match=if_etag_not_match,
             if_generation_match=if_generation_match,
             if_generation_not_match=if_generation_not_match,
             if_metageneration_match=if_metageneration_match,
@@ -1366,6 +1402,8 @@ class Blob(_PropertyMixin):
         start=None,
         end=None,
         raw_download=False,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -1395,6 +1433,14 @@ class Blob(_PropertyMixin):
         :type raw_download: bool
         :param raw_download:
             (Optional) If true, download the object without any expansion.
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match:
+            (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]]
+        :param if_etag_not_match:
+            (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -1455,6 +1501,8 @@ class Blob(_PropertyMixin):
             start=start,
             end=end,
             raw_download=raw_download,
+            if_etag_match=if_etag_match,
+            if_etag_not_match=if_etag_not_match,
             if_generation_match=if_generation_match,
             if_generation_not_match=if_generation_not_match,
             if_metageneration_match=if_metageneration_match,
@@ -1470,6 +1518,8 @@ class Blob(_PropertyMixin):
         end=None,
         raw_download=False,
         encoding=None,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -1501,6 +1551,14 @@ class Blob(_PropertyMixin):
         :param encoding: (Optional) encoding to be used to decode the
             downloaded bytes.  Defaults to the ``charset`` param of
             attr:`content_type`, or else to "utf-8".
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match:
+            (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]]
+        :param if_etag_not_match:
+            (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -1553,6 +1611,8 @@ class Blob(_PropertyMixin):
             start=start,
             end=end,
             raw_download=raw_download,
+            if_etag_match=if_etag_match,
+            if_etag_not_match=if_etag_not_match,
             if_generation_match=if_generation_match,
             if_generation_not_match=if_generation_not_match,
             if_metageneration_match=if_metageneration_match,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -708,8 +708,6 @@ class Blob(_PropertyMixin):
         _add_etag_match_headers(
             headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match
         )
-        if not headers:
-            headers = None
 
         try:
             # We intentionally pass `_target_object=None` since fields=name

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -814,8 +814,6 @@ class Bucket(_PropertyMixin):
         _add_etag_match_headers(
             headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match
         )
-        if not headers:
-            headers = None
 
         try:
             # We intentionally pass `_target_object=None` since fields=name

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -941,6 +941,8 @@ class Bucket(_PropertyMixin):
         client=None,
         projection="noAcl",
         timeout=_DEFAULT_TIMEOUT,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_metageneration_match=None,
         if_metageneration_not_match=None,
         retry=DEFAULT_RETRY,
@@ -964,13 +966,21 @@ class Bucket(_PropertyMixin):
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
 
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match: (Optional) Make the operation conditional on whether the
+                              bucket's current ETag matches the given value.
+
+        :type if_etag_not_match: Union[str, Set[str]])
+        :param if_etag_not_match: (Optional) Make the operation conditional on whether the
+                                  bucket's current ETag does not match the given value.
+
         :type if_metageneration_match: long
         :param if_metageneration_match: (Optional) Make the operation conditional on whether the
-                                        blob's current metageneration matches the given value.
+                                        bucket's current metageneration matches the given value.
 
         :type if_metageneration_not_match: long
         :param if_metageneration_not_match: (Optional) Make the operation conditional on whether the
-                                            blob's current metageneration does not match the given value.
+                                            bucket's current metageneration does not match the given value.
 
         :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
         :param retry:
@@ -980,6 +990,8 @@ class Bucket(_PropertyMixin):
             client=client,
             projection=projection,
             timeout=timeout,
+            if_etag_match=if_etag_match,
+            if_etag_not_match=if_etag_not_match,
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
             retry=retry,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1106,6 +1106,8 @@ class Bucket(_PropertyMixin):
         client=None,
         encryption_key=None,
         generation=None,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -1142,6 +1144,14 @@ class Bucket(_PropertyMixin):
         :type generation: long
         :param generation:
             (Optional) If present, selects a specific revision of this object.
+
+        :type if_etag_match: Union[str, Set[str]]
+        :param if_etag_match:
+            (Optional) See :ref:`using-if-etag-match`
+
+        :type if_etag_not_match: Union[str, Set[str]]
+        :param if_etag_not_match:
+            (Optional) See :ref:`using-if-etag-not-match`
 
         :type if_generation_match: long
         :param if_generation_match:
@@ -1188,6 +1198,8 @@ class Bucket(_PropertyMixin):
             blob.reload(
                 client=client,
                 timeout=timeout,
+                if_etag_match=if_etag_match,
+                if_etag_not_match=if_etag_not_match,
                 if_generation_match=if_generation_match,
                 if_generation_not_match=if_generation_not_match,
                 if_metageneration_match=if_metageneration_match,

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -967,6 +967,8 @@ class Client(ClientWithProject):
         start=None,
         end=None,
         raw_download=False,
+        if_etag_match=None,
+        if_etag_not_match=None,
         if_generation_match=None,
         if_generation_not_match=None,
         if_metageneration_match=None,
@@ -996,16 +998,22 @@ class Client(ClientWithProject):
             raw_download (bool):
                 (Optional) If true, download the object without any expansion.
 
-            if_generation_match: long
+            if_etag_match (Union[str, Set[str]]):
+                (Optional) See :ref:`using-if-etag-match`
+
+            if_etag_not_match (Union[str, Set[str]]):
+                (Optional) See :ref:`using-if-etag-not-match`
+
+            if_generation_match (long):
                 (Optional) See :ref:`using-if-generation-match`
 
-            if_generation_not_match: long
+            if_generation_not_match (long):
                 (Optional) See :ref:`using-if-generation-not-match`
 
-            if_metageneration_match: long
+            if_metageneration_match (long):
                 (Optional) See :ref:`using-if-metageneration-match`
 
-            if_metageneration_not_match: long
+            if_metageneration_not_match (long):
                 (Optional) See :ref:`using-if-metageneration-not-match`
 
             timeout ([Union[float, Tuple[float, float]]]):
@@ -1091,6 +1099,15 @@ class Client(ClientWithProject):
         )
         headers = _get_encryption_headers(blob_or_uri._encryption_key)
         headers["accept-encoding"] = "gzip"
+        if if_etag_match is not None:
+            if isinstance(if_etag_match, str):
+                if_etag_match = [if_etag_match]
+            headers["If-Match"] = ", ".join(if_etag_match)
+
+        if if_etag_not_match is not None:
+            if isinstance(if_etag_not_match, str):
+                if_etag_not_match = [if_etag_not_match]
+            headers["If-None-Match"] = ", ".join(if_etag_not_match)
 
         transport = self._http
         try:

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -34,6 +34,7 @@ from google.cloud.exceptions import NotFound
 from google.cloud.storage._helpers import _get_storage_host
 from google.cloud.storage._helpers import _DEFAULT_STORAGE_HOST
 from google.cloud.storage._helpers import _bucket_bound_hostname_url
+from google.cloud.storage._helpers import _add_etag_match_headers
 from google.cloud.storage._http import Connection
 from google.cloud.storage._signing import (
     get_expiration_seconds_v4,
@@ -1099,15 +1100,11 @@ class Client(ClientWithProject):
         )
         headers = _get_encryption_headers(blob_or_uri._encryption_key)
         headers["accept-encoding"] = "gzip"
-        if if_etag_match is not None:
-            if isinstance(if_etag_match, str):
-                if_etag_match = [if_etag_match]
-            headers["If-Match"] = ", ".join(if_etag_match)
-
-        if if_etag_not_match is not None:
-            if isinstance(if_etag_not_match, str):
-                if_etag_not_match = [if_etag_not_match]
-            headers["If-None-Match"] = ", ".join(if_etag_not_match)
+        _add_etag_match_headers(
+            headers,
+            if_etag_match=if_etag_match,
+            if_etag_not_match=if_etag_not_match,
+        )
 
         transport = self._http
         try:
@@ -1429,7 +1426,11 @@ class Client(ClientWithProject):
             qs_params["userProject"] = user_project
 
         api_response = self._post_resource(
-            path, None, query_params=qs_params, timeout=timeout, retry=retry,
+            path,
+            None,
+            query_params=qs_params,
+            timeout=timeout,
+            retry=retry,
         )
         metadata = HMACKeyMetadata(self)
         metadata._properties = api_response["metadata"]

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1101,9 +1101,7 @@ class Client(ClientWithProject):
         headers = _get_encryption_headers(blob_or_uri._encryption_key)
         headers["accept-encoding"] = "gzip"
         _add_etag_match_headers(
-            headers,
-            if_etag_match=if_etag_match,
-            if_etag_not_match=if_etag_not_match,
+            headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match,
         )
 
         transport = self._http
@@ -1426,11 +1424,7 @@ class Client(ClientWithProject):
             qs_params["userProject"] = user_project
 
         api_response = self._post_resource(
-            path,
-            None,
-            query_params=qs_params,
-            timeout=timeout,
-            retry=retry,
+            path, None, query_params=qs_params, timeout=timeout, retry=retry,
         )
         metadata = HMACKeyMetadata(self)
         metadata._properties = api_response["metadata"]

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -268,8 +268,8 @@ def test_blob_crud_w_etag_match(
     with pytest.raises(exceptions.NotModified):
         blob.reload(if_etag_not_match=etag)
 
-    blob.reload(if_etag_match=etag)
-    blob.reload(if_etag_not_match=wrong_etag)
+    blob.reload(if_etag_match=etag)  # no raise
+    blob.reload(if_etag_not_match=wrong_etag)  # no raise
 
     # Exercise 'objects.get' (media) w/ etag match.
     assert blob.download_as_bytes(if_etag_match=etag) == payload

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -250,35 +250,35 @@ def test_blob_crud_w_etag_match(
     blobs_to_delete.append(blob)
     etag = blob.etag
 
-    blob = shared_bucket.blob("SmallFile")
+    fresh_blob = shared_bucket.blob("SmallFile")
 
     # Exercise 'objects.get' (metadata) w/ etag match.
     with pytest.raises(exceptions.PreconditionFailed):
-        blob.exists(if_etag_match=wrong_etag)
+        fresh_blob.exists(if_etag_match=wrong_etag)
 
     with pytest.raises(exceptions.NotModified):
-        blob.exists(if_etag_not_match=etag)
+        fresh_blob.exists(if_etag_not_match=etag)
 
-    assert blob.exists(if_etag_match=etag)
-    assert blob.exists(if_etag_not_match=wrong_etag)
+    assert fresh_blob.exists(if_etag_match=etag)
+    assert fresh_blob.exists(if_etag_not_match=wrong_etag)
 
     with pytest.raises(exceptions.PreconditionFailed):
-        blob.reload(if_etag_match=wrong_etag)
+        fresh_blob.reload(if_etag_match=wrong_etag)
 
     with pytest.raises(exceptions.NotModified):
-        blob.reload(if_etag_not_match=etag)
+        fresh_blob.reload(if_etag_not_match=etag)
 
-    blob.reload(if_etag_match=etag)  # no raise
-    blob.reload(if_etag_not_match=wrong_etag)  # no raise
+    fresh_blob.reload(if_etag_match=etag)  # no raise
+    fresh_blob.reload(if_etag_not_match=wrong_etag)  # no raise
 
     # Exercise 'objects.get' (media) w/ etag match.
-    assert blob.download_as_bytes(if_etag_match=etag) == payload
+    assert fresh_blob.download_as_bytes(if_etag_match=etag) == payload
 
     with pytest.raises(exceptions.PreconditionFailed):
-        blob.download_as_bytes(if_etag_match=wrong_etag)
+        fresh_blob.download_as_bytes(if_etag_match=wrong_etag)
 
     with pytest.raises(exceptions.NotModified):
-        blob.download_as_bytes(if_etag_not_match=etag)
+        fresh_blob.download_as_bytes(if_etag_not_match=etag)
 
 
 def test_blob_crud_w_generation_match(

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -140,8 +140,6 @@ def test_download_blob_to_file_w_etag(
 
     buffer = io.BytesIO()
     storage_client.download_blob_to_file(
-        "gs://" + shared_bucket.name + "/" + filename,
-        buffer,
-        if_etag_match=blob.etag,
+        "gs://" + shared_bucket.name + "/" + filename, buffer, if_etag_match=blob.etag,
     )
     assert buffer.getvalue() == payload

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -521,6 +521,39 @@ class Test__base64_md5hash(unittest.TestCase):
         self.assertEqual(MD5.hash_obj._blocks, [BYTES_TO_SIGN])
 
 
+class Test__add_etag_match_headers(unittest.TestCase):
+    def _call_fut(self, headers, **match_params):
+        from google.cloud.storage._helpers import _add_etag_match_headers
+
+        return _add_etag_match_headers(headers, **match_params)
+
+    def test_add_etag_match_parameters_str(self):
+        ETAG = "kittens"
+        headers = {"foo": "bar"}
+        EXPECTED_HEADERS = {
+            "foo": "bar",
+            "If-Match": ETAG,
+        }
+        self._call_fut(headers, if_etag_match=ETAG)
+        self.assertEqual(headers, EXPECTED_HEADERS)
+
+    def test_add_generation_match_parameters_list(self):
+        ETAGS = ["kittens", "fluffy"]
+        EXPECTED_HEADERS = {
+            "foo": "bar",
+            "If-Match": ", ".join(ETAGS),
+        }
+        headers = {"foo": "bar"}
+        self._call_fut(headers, if_etag_match=ETAGS)
+        self.assertEqual(headers, EXPECTED_HEADERS)
+
+    def test_add_generation_match_parameters_headers_not_dict(self):
+        ETAG = "kittens"
+        headers = 42
+        with self.assertRaises(ValueError):
+            self._call_fut(headers, if_etag_match=ETAG)
+
+
 class Test__add_generation_match_parameters(unittest.TestCase):
     def _call_fut(self, params, **match_params):
         from google.cloud.storage._helpers import _add_generation_match_parameters

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -148,9 +148,7 @@ class Test_PropertyMixin(unittest.TestCase):
         derived._changes = object()
         derived.client = client
 
-        derived.reload(
-            if_etag_match=etag,
-        )
+        derived.reload(if_etag_match=etag,)
 
         self.assertEqual(derived._properties, response)
         self.assertEqual(derived._changes, set())
@@ -427,8 +425,7 @@ class Test_PropertyMixin(unittest.TestCase):
         timeout = 42
 
         derived.update(
-            if_metageneration_not_match=generation_number,
-            timeout=timeout,
+            if_metageneration_not_match=generation_number, timeout=timeout,
         )
 
         self.assertEqual(derived._properties, {"foo": "Foo"})

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -136,6 +136,41 @@ class Test_PropertyMixin(unittest.TestCase):
             _target_object=derived,
         )
 
+    def test_reload_w_etag_match(self):
+        etag = "kittens"
+        path = "/path"
+        response = {"foo": "Foo"}
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = response
+        derived = self._derivedClass(path)()
+        # Make sure changes is not a set instance before calling reload
+        # (which will clear / replace it with an empty set), checked below.
+        derived._changes = object()
+        derived.client = client
+
+        derived.reload(
+            if_etag_match=etag,
+        )
+
+        self.assertEqual(derived._properties, response)
+        self.assertEqual(derived._changes, set())
+
+        expected_query_params = {
+            "projection": "noAcl",
+        }
+        # no encryption headers by default
+        expected_headers = {
+            "If-Match": etag,
+        }
+        client._get_resource.assert_called_once_with(
+            path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=derived,
+        )
+
     def test_reload_w_generation_match_w_timeout(self):
         generation_number = 9
         metageneration_number = 6
@@ -392,7 +427,8 @@ class Test_PropertyMixin(unittest.TestCase):
         timeout = 42
 
         derived.update(
-            if_metageneration_not_match=generation_number, timeout=timeout,
+            if_metageneration_not_match=generation_number,
+            timeout=timeout,
         )
 
         self.assertEqual(derived._properties, {"foo": "Foo"})

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -580,12 +580,6 @@ class Test__add_etag_match_headers(unittest.TestCase):
         self._call_fut(headers, if_etag_match=ETAGS)
         self.assertEqual(headers, EXPECTED_HEADERS)
 
-    def test_add_generation_match_parameters_headers_not_dict(self):
-        ETAG = "kittens"
-        headers = 42
-        with self.assertRaises(ValueError):
-            self._call_fut(headers, if_etag_match=ETAG)
-
 
 class Test__add_generation_match_parameters(unittest.TestCase):
     def _call_fut(self, params, **match_params):

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -1265,7 +1265,7 @@ class Test_Blob(unittest.TestCase):
     def test__do_download_wo_chunks_w_range_w_raw(self):
         self._do_download_helper_wo_chunks(w_range=True, raw_download=True)
 
-    def test__do_download_wo_chunks_w_range_w_raw(self):
+    def test__do_download_wo_chunks_w_range_w_raw_w_headers(self):
         self._do_download_helper_wo_chunks(
             w_range=True, raw_download=True, headers={"If-Match": "kittens"}
         )

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -702,10 +702,11 @@ class Test_Blob(unittest.TestCase):
         self.assertFalse(blob.exists())
 
         expected_query_params = {"fields": "name"}
+        expected_headers = {}
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
-            headers=None,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -724,10 +725,11 @@ class Test_Blob(unittest.TestCase):
         self.assertTrue(blob.exists(timeout=timeout))
 
         expected_query_params = {"fields": "name", "userProject": user_project}
+        expected_headers = {}
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
-            headers=None,
+            headers=expected_headers,
             timeout=timeout,
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -746,10 +748,11 @@ class Test_Blob(unittest.TestCase):
         self.assertTrue(blob.exists(retry=retry))
 
         expected_query_params = {"fields": "name", "generation": generation}
+        expected_headers = {}
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
-            headers=None,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
             retry=retry,
             _target_object=None,
@@ -804,10 +807,11 @@ class Test_Blob(unittest.TestCase):
             "ifGenerationMatch": generation_number,
             "ifMetagenerationMatch": metageneration_number,
         }
+        expected_headers = {}
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
-            headers=None,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
             retry=None,
             _target_object=None,

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -705,6 +705,7 @@ class Test_Blob(unittest.TestCase):
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
+            headers=None,
             timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -726,6 +727,7 @@ class Test_Blob(unittest.TestCase):
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
+            headers=None,
             timeout=timeout,
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -747,8 +749,40 @@ class Test_Blob(unittest.TestCase):
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
+            headers=None,
             timeout=self._get_default_timeout(),
             retry=retry,
+            _target_object=None,
+        )
+
+    def test_exists_w_etag_match(self):
+        blob_name = "blob-name"
+        etag = "kittens"
+        api_response = {"name": blob_name}
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
+        bucket = _Bucket(client)
+        blob = self._make_one(blob_name, bucket=bucket)
+
+        self.assertTrue(
+            blob.exists(
+                if_etag_match=etag,
+                retry=None,
+            )
+        )
+
+        expected_query_params = {
+            "fields": "name",
+        }
+        expected_headers = {
+            "If-Match": etag,
+        }
+        client._get_resource.assert_called_once_with(
+            blob.path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=None,
             _target_object=None,
         )
 
@@ -778,6 +812,7 @@ class Test_Blob(unittest.TestCase):
         client._get_resource.assert_called_once_with(
             blob.path,
             query_params=expected_query_params,
+            headers=None,
             timeout=self._get_default_timeout(),
             retry=None,
             _target_object=None,

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -764,12 +764,7 @@ class Test_Blob(unittest.TestCase):
         bucket = _Bucket(client)
         blob = self._make_one(blob_name, bucket=bucket)
 
-        self.assertTrue(
-            blob.exists(
-                if_etag_match=etag,
-                retry=None,
-            )
-        )
+        self.assertTrue(blob.exists(if_etag_match=etag, retry=None,))
 
         expected_query_params = {
             "fields": "name",
@@ -1990,26 +1985,22 @@ class Test_Blob(unittest.TestCase):
 
     def test_download_as_text_w_if_etag_match_str(self):
         self._download_as_text_helper(
-            raw_download=False,
-            if_etag_match="kittens",
+            raw_download=False, if_etag_match="kittens",
         )
 
     def test_download_as_text_w_if_etag_match_list(self):
         self._download_as_text_helper(
-            raw_download=False,
-            if_etag_match=["kittens", "fluffy"],
+            raw_download=False, if_etag_match=["kittens", "fluffy"],
         )
 
     def test_download_as_text_w_if_etag_not_match_str(self):
         self._download_as_text_helper(
-            raw_download=False,
-            if_etag_not_match="kittens",
+            raw_download=False, if_etag_not_match="kittens",
         )
 
     def test_download_as_text_w_if_etag_not_match_list(self):
         self._download_as_text_helper(
-            raw_download=False,
-            if_etag_not_match=["kittens", "fluffy"],
+            raw_download=False, if_etag_not_match=["kittens", "fluffy"],
         )
 
     def test_download_as_text_w_if_generation_match(self):
@@ -2027,14 +2018,12 @@ class Test_Blob(unittest.TestCase):
     def test_download_as_text_w_encoding(self):
         encoding = "utf-16"
         self._download_as_text_helper(
-            raw_download=False,
-            encoding=encoding,
+            raw_download=False, encoding=encoding,
         )
 
     def test_download_as_text_w_no_charset(self):
         self._download_as_text_helper(
-            raw_download=False,
-            no_charset=True,
+            raw_download=False, no_charset=True,
         )
 
     def test_download_as_text_w_non_ascii_w_explicit_encoding(self):
@@ -3790,10 +3779,7 @@ class Test_Blob(unittest.TestCase):
         retry = mock.Mock(spec=[])
 
         returned = blob.set_iam_policy(
-            policy,
-            client=client,
-            timeout=timeout,
-            retry=retry,
+            policy, client=client, timeout=timeout, retry=retry,
         )
 
         self.assertEqual(returned.etag, etag)
@@ -4225,8 +4211,7 @@ class Test_Blob(unittest.TestCase):
         destination = self._make_one(destination_name, bucket=bucket)
 
         destination.compose(
-            sources=[source_1, source_2],
-            if_generation_match=generation_number,
+            sources=[source_1, source_2], if_generation_match=generation_number,
         )
 
         expected_path = "/b/name/o/%s/compose" % destination_name
@@ -4265,8 +4250,7 @@ class Test_Blob(unittest.TestCase):
 
         destination = self._make_one(destination_name, bucket=bucket)
         destination.compose(
-            sources=[source_1, source_2],
-            if_generation_match=generation_numbers,
+            sources=[source_1, source_2], if_generation_match=generation_numbers,
         )
 
         expected_path = "/b/name/o/%s/compose" % destination_name
@@ -4300,9 +4284,7 @@ class Test_Blob(unittest.TestCase):
         )
 
         mock_warn.assert_called_with(
-            _COMPOSE_IF_GENERATION_LIST_DEPRECATED,
-            DeprecationWarning,
-            stacklevel=2,
+            _COMPOSE_IF_GENERATION_LIST_DEPRECATED, DeprecationWarning, stacklevel=2,
         )
 
     def test_compose_w_if_generation_match_and_if_s_generation_match(self):
@@ -4342,8 +4324,7 @@ class Test_Blob(unittest.TestCase):
         destination = self._make_one(destination_name, bucket=bucket)
 
         destination.compose(
-            sources=[source_1, source_2],
-            if_metageneration_match=metageneration_number,
+            sources=[source_1, source_2], if_metageneration_match=metageneration_number,
         )
 
         expected_path = "/b/name/o/%s/compose" % destination_name
@@ -4384,8 +4365,7 @@ class Test_Blob(unittest.TestCase):
         destination = self._make_one(destination_name, bucket=bucket)
 
         destination.compose(
-            sources=[source_1, source_2],
-            if_metageneration_match=metageneration_number,
+            sources=[source_1, source_2], if_metageneration_match=metageneration_number,
         )
 
         expected_path = "/b/name/o/%s/compose" % destination_name

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1677,6 +1677,32 @@ class Test_Bucket(unittest.TestCase):
         )
         bucket.delete_blob.assert_has_calls([call_1, call_2])
 
+    def test_reload_w_etag_match(self):
+        name = "name"
+        etag = "kittens"
+        api_response = {"name": name}
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
+        bucket = self._make_one(client, name=name)
+
+        bucket.reload(if_etag_match=etag)
+
+        expected_path = "/b/%s" % (name,)
+        expected_query_params = {
+            "projection": "noAcl",
+        }
+        expected_headers = {
+            "If-Match": etag,
+        }
+        client._get_resource.assert_called_once_with(
+            expected_path,
+            query_params=expected_query_params,
+            headers=expected_headers,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=bucket,
+        )
+
     def test_reload_w_metageneration_match(self):
         name = "name"
         metageneration_number = 9

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -747,10 +747,11 @@ class Test_Bucket(unittest.TestCase):
         self.assertFalse(bucket.exists())
 
         expected_query_params = {"fields": "name"}
+        expected_headers = {}
         client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
-            headers=None,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -798,10 +799,11 @@ class Test_Bucket(unittest.TestCase):
             "fields": "name",
             "ifMetagenerationMatch": metageneration_number,
         }
+        expected_headers = {}
         client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
-            headers=None,
+            headers=expected_headers,
             timeout=timeout,
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -822,10 +824,11 @@ class Test_Bucket(unittest.TestCase):
             "fields": "name",
             "userProject": user_project,
         }
+        expected_headers = {}
         client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
-            headers=None,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
             retry=retry,
             _target_object=None,

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -750,6 +750,32 @@ class Test_Bucket(unittest.TestCase):
         client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
+            headers=None,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=None,
+        )
+
+    def test_exists_w_etag_match(self):
+        bucket_name = "bucket-name"
+        etag = "kittens"
+        api_response = {"name": bucket_name}
+        client = mock.Mock(spec=["_get_resource"])
+        client._get_resource.return_value = api_response
+        bucket = self._make_one(client, name=bucket_name)
+
+        self.assertTrue(bucket.exists(if_etag_match=etag))
+
+        expected_query_params = {
+            "fields": "name",
+        }
+        expected_headers = {
+            "If-Match": etag,
+        }
+        client._get_resource.assert_called_once_with(
+            bucket.path,
+            query_params=expected_query_params,
+            headers=expected_headers,
             timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -775,6 +801,7 @@ class Test_Bucket(unittest.TestCase):
         client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
+            headers=None,
             timeout=timeout,
             retry=DEFAULT_RETRY,
             _target_object=None,
@@ -798,6 +825,7 @@ class Test_Bucket(unittest.TestCase):
         client._get_resource.assert_called_once_with(
             bucket.path,
             query_params=expected_query_params,
+            headers=None,
             timeout=self._get_default_timeout(),
             retry=retry,
             _target_object=None,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -29,7 +29,6 @@ from google.api_core import exceptions
 from google.oauth2.service_account import Credentials
 from . import _read_local_json
 
-from google.cloud.storage import _helpers
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_GENERATION_SPECIFIED
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -482,10 +482,7 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=project, credentials=credentials)
         connection = client._base_connection = _make_connection()
 
-        iterator = client._list_resource(
-            path=path,
-            item_to_value=item_to_value,
-        )
+        iterator = client._list_resource(path=path, item_to_value=item_to_value,)
 
         self.assertIsInstance(iterator, HTTPIterator)
         self.assertIs(iterator.client, client)
@@ -1184,9 +1181,7 @@ class TestClient(unittest.TestCase):
         timeout = 42
 
         bucket = client.create_bucket(
-            bucket_name,
-            predefined_acl="publicRead",
-            timeout=timeout,
+            bucket_name, predefined_acl="publicRead", timeout=timeout,
         )
 
         expected_path = "/b"
@@ -1228,9 +1223,7 @@ class TestClient(unittest.TestCase):
         retry = mock.Mock(spec=[])
 
         bucket = client.create_bucket(
-            bucket_name,
-            predefined_default_object_acl="publicRead",
-            retry=retry,
+            bucket_name, predefined_default_object_acl="publicRead", retry=retry,
         )
 
         expected_path = "/b"
@@ -1461,10 +1454,7 @@ class TestClient(unittest.TestCase):
 
     def test_download_blob_to_file_w_conditional_etag_match_string(self):
         self._download_blob_to_file_helper(
-            use_chunks=True,
-            raw_download=True,
-            retry=None,
-            if_etag_match="kittens",
+            use_chunks=True, raw_download=True, retry=None, if_etag_match="kittens",
         )
 
     def test_download_blob_to_file_w_conditional_etag_match_list(self):
@@ -1477,10 +1467,7 @@ class TestClient(unittest.TestCase):
 
     def test_download_blob_to_file_w_conditional_etag_not_match_string(self):
         self._download_blob_to_file_helper(
-            use_chunks=True,
-            raw_download=True,
-            retry=None,
-            if_etag_not_match="kittens",
+            use_chunks=True, raw_download=True, retry=None, if_etag_not_match="kittens",
         )
 
     def test_download_blob_to_file_w_conditional_etag_not_match_list(self):
@@ -1771,11 +1758,7 @@ class TestClient(unittest.TestCase):
         )
 
     def _create_hmac_key_helper(
-        self,
-        explicit_project=None,
-        user_project=None,
-        timeout=None,
-        retry=None,
+        self, explicit_project=None, user_project=None, timeout=None, retry=None,
     ):
         import datetime
         from pytz import UTC

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1529,11 +1529,16 @@ class TestClient(unittest.TestCase):
             expected_retry = None
 
         headers = {"accept-encoding": "gzip"}
-        _helpers._add_etag_match_headers(
-            headers,
-            if_etag_match=extra_kwargs.get("if_etag_match"),
-            if_etag_not_match=extra_kwargs.get("if_etag_not_match"),
-        )
+        if_etag_match = extra_kwargs.get("if_etag_match")
+        if if_etag_match is not None:
+            if isinstance(if_etag_match, str):
+                if_etag_match = [if_etag_match]
+            headers["If-Match"] = ", ".join(if_etag_match)
+        if_etag_not_match = extra_kwargs.get("if_etag_not_match")
+        if if_etag_not_match is not None:
+            if isinstance(if_etag_not_match, str):
+                if_etag_not_match = [if_etag_not_match]
+            headers["If-None-Match"] = ", ".join(if_etag_not_match)
 
         blob._do_download.assert_called_once_with(
             client._http,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -28,6 +28,7 @@ from google.api_core import exceptions
 from google.oauth2.service_account import Credentials
 from . import _read_local_json
 
+from google.cloud.storage import _helpers
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_GENERATION_SPECIFIED
 
@@ -1541,17 +1542,11 @@ class TestClient(unittest.TestCase):
             expected_retry = None
 
         headers = {"accept-encoding": "gzip"}
-        if_etag_match = extra_kwargs.get("if_etag_match")
-        if if_etag_match is not None:
-            if isinstance(if_etag_match, str):
-                if_etag_match = [if_etag_match]
-            headers["If-Match"] = ", ".join(if_etag_match)
-
-        if_etag_not_match = extra_kwargs.get("if_etag_not_match")
-        if if_etag_not_match is not None:
-            if isinstance(if_etag_not_match, str):
-                if_etag_not_match = [if_etag_not_match]
-            headers["If-None-Match"] = ", ".join(if_etag_not_match)
+        _helpers._add_etag_match_headers(
+            headers,
+            if_etag_match=extra_kwargs.get("if_etag_match"),
+            if_etag_not_match=extra_kwargs.get("if_etag_not_match"),
+        )
 
         blob._do_download.assert_called_once_with(
             client._http,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -20,6 +20,7 @@ import pytest
 import re
 import requests
 import unittest
+from six import string_types
 from six.moves import http_client
 from six.moves.urllib import parse as urlparse
 
@@ -1531,12 +1532,12 @@ class TestClient(unittest.TestCase):
         headers = {"accept-encoding": "gzip"}
         if_etag_match = extra_kwargs.get("if_etag_match")
         if if_etag_match is not None:
-            if isinstance(if_etag_match, str):
+            if isinstance(if_etag_match, string_types):
                 if_etag_match = [if_etag_match]
             headers["If-Match"] = ", ".join(if_etag_match)
         if_etag_not_match = extra_kwargs.get("if_etag_not_match")
         if if_etag_not_match is not None:
-            if isinstance(if_etag_not_match, str):
+            if isinstance(if_etag_not_match, string_types):
                 if_etag_not_match = [if_etag_not_match]
             headers["If-None-Match"] = ", ".join(if_etag_not_match)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -481,7 +481,10 @@ class TestClient(unittest.TestCase):
         client = self._make_one(project=project, credentials=credentials)
         connection = client._base_connection = _make_connection()
 
-        iterator = client._list_resource(path=path, item_to_value=item_to_value,)
+        iterator = client._list_resource(
+            path=path,
+            item_to_value=item_to_value,
+        )
 
         self.assertIsInstance(iterator, HTTPIterator)
         self.assertIs(iterator.client, client)
@@ -1180,7 +1183,9 @@ class TestClient(unittest.TestCase):
         timeout = 42
 
         bucket = client.create_bucket(
-            bucket_name, predefined_acl="publicRead", timeout=timeout,
+            bucket_name,
+            predefined_acl="publicRead",
+            timeout=timeout,
         )
 
         expected_path = "/b"
@@ -1222,7 +1227,9 @@ class TestClient(unittest.TestCase):
         retry = mock.Mock(spec=[])
 
         bucket = client.create_bucket(
-            bucket_name, predefined_default_object_acl="publicRead", retry=retry,
+            bucket_name,
+            predefined_default_object_acl="publicRead",
+            retry=retry,
         )
 
         expected_path = "/b"
@@ -1451,6 +1458,38 @@ class TestClient(unittest.TestCase):
             use_chunks=True, raw_download=True, retry=None
         )
 
+    def test_download_blob_to_file_w_conditional_etag_match_string(self):
+        self._download_blob_to_file_helper(
+            use_chunks=True,
+            raw_download=True,
+            retry=None,
+            if_etag_match="kittens",
+        )
+
+    def test_download_blob_to_file_w_conditional_etag_match_list(self):
+        self._download_blob_to_file_helper(
+            use_chunks=True,
+            raw_download=True,
+            retry=None,
+            if_etag_match=["kittens", "fluffy"],
+        )
+
+    def test_download_blob_to_file_w_conditional_etag_not_match_string(self):
+        self._download_blob_to_file_helper(
+            use_chunks=True,
+            raw_download=True,
+            retry=None,
+            if_etag_not_match="kittens",
+        )
+
+    def test_download_blob_to_file_w_conditional_etag_not_match_list(self):
+        self._download_blob_to_file_helper(
+            use_chunks=True,
+            raw_download=True,
+            retry=None,
+            if_etag_not_match=["kittens", "fluffy"],
+        )
+
     def test_download_blob_to_file_w_conditional_retry_pass(self):
         self._download_blob_to_file_helper(
             use_chunks=True,
@@ -1502,6 +1541,18 @@ class TestClient(unittest.TestCase):
             expected_retry = None
 
         headers = {"accept-encoding": "gzip"}
+        if_etag_match = extra_kwargs.get("if_etag_match")
+        if if_etag_match is not None:
+            if isinstance(if_etag_match, str):
+                if_etag_match = [if_etag_match]
+            headers["If-Match"] = ", ".join(if_etag_match)
+
+        if_etag_not_match = extra_kwargs.get("if_etag_not_match")
+        if if_etag_not_match is not None:
+            if isinstance(if_etag_not_match, str):
+                if_etag_not_match = [if_etag_not_match]
+            headers["If-None-Match"] = ", ".join(if_etag_not_match)
+
         blob._do_download.assert_called_once_with(
             client._http,
             file_obj,
@@ -1725,7 +1776,11 @@ class TestClient(unittest.TestCase):
         )
 
     def _create_hmac_key_helper(
-        self, explicit_project=None, user_project=None, timeout=None, retry=None,
+        self,
+        explicit_project=None,
+        user_project=None,
+        timeout=None,
+        retry=None,
     ):
         import datetime
         from pytz import UTC


### PR DESCRIPTION
Support conditional requests based on ETag for read operations (`reload`, `exists`, `download_*`). My own testing seems to indicate that the JSON API does not support ETag If-Match/If-None-Match headers on modify requests (`patch`, `delete`, etc.), please correct me if I am mistaken.

This part two of #451. Part one in https://github.com/googleapis/python-storage/pull/488.
Fixes #451 🦕
