### PR TITLE
docs update: remove and replace deprecated function download_as_string()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ how to create a bucket.
     bucket = client.get_bucket('bucket-id-here')
     # Then do other things...
     blob = bucket.get_blob('remote/path/to/file.txt')
-    print(blob.download_as_string())
+    print(blob.download_as_bytes())
     blob.upload_from_string('New contents!')
     blob2 = bucket.blob('remote/path/storage.txt')
     blob2.upload_from_filename(filename='/local/path.txt')


### PR DESCRIPTION
Remove deprecated function download_as_string(), replace with download_as_bytes(). [1]
[1] https://github.com/googleapis/python-storage/blob/master/google/cloud/storage/blob.py#L138

Fixes #504 🦕
