### PR TITLE
fix(deps): pin '{api,cloud}-core', 'auth' to allow 2.x versions on Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,12 @@ description = "Google Cloud Storage API client library"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-auth >= 1.24.0, < 2.0dev",
-    "google-cloud-core >= 1.6.0, < 2.0dev",
-    "google-resumable-media >= 1.3.0, < 2.0dev",
+    "google-auth >= 1.24.0, < 2.0dev; python_version<'3.0'",
+    "google-auth >= 1.24.0, < 3.0dev; python_version>='3.6'",
+    "google-cloud-core >= 1.6.0, < 2.0dev; python_version<'3.0'",
+    "google-cloud-core >= 1.6.0, < 3.0dev; python_version>='3.6'",
+    "google-resumable-media >= 1.3.0, < 2.0dev; python_version<'3.0'",
+    "google-resumable-media >= 1.3.0, < 3.0dev; python_version>='3.6'",
     "requests >= 2.18.0, < 3.0.0dev",
     "googleapis-common-protos < 1.53.0; python_version<'3.0'",
 ]


### PR DESCRIPTION
See: https://github.com/googleapis/google-cloud-python/issues/10566

`google-cloud-storage` needs to pin to the `1.x` versions of `google-api-core` / `google-cloud-core` / `google-auth`, but *only for Python 2.7*:  Python 3 users should not need that restriction.