### PR TITLE
tests: use 120 sec timeout for 'blob.delete' during teardown

### DIFF
--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -79,7 +79,7 @@ def delete_blob(blob):
     errors = (exceptions.Conflict, exceptions.TooManyRequests)
     retry = RetryErrors(errors)
     try:
-        retry(blob.delete)()
+        retry(blob.delete)(timeout=120) # seconds
     except exceptions.NotFound:  # race
         pass
 

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -79,7 +79,7 @@ def delete_blob(blob):
     errors = (exceptions.Conflict, exceptions.TooManyRequests)
     retry = RetryErrors(errors)
     try:
-        retry(blob.delete)(timeout=120) # seconds
+        retry(blob.delete)(timeout=120)  # seconds
     except exceptions.NotFound:  # race
         pass
 


### PR DESCRIPTION
Closes #517