### PR TITLE
fix: make 'requests.exceptions.ChunkedEncodingError retryable by default

### DIFF
--- a/google/cloud/storage/retry.py
+++ b/google/cloud/storage/retry.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import requests
+import requests.exceptions as requests_exceptions
 
 from google.api_core import exceptions as api_exceptions
 from google.api_core import retry
@@ -33,6 +34,7 @@ _RETRYABLE_TYPES = _RETRYABLE_STDLIB_TYPES + (
     api_exceptions.ServiceUnavailable,  # 503
     api_exceptions.GatewayTimeout,  # 504
     requests.ConnectionError,
+    requests_exceptions.ChunkedEncodingError,
 )
 
 

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -69,6 +69,12 @@ class Test_should_retry(unittest.TestCase):
         exc = requests.ConnectionError()
         self.assertTrue(self._call_fut(exc))
 
+    def test_w_requests_chunked_encoding_error(self):
+        import requests.exceptions
+
+        exc = requests.exceptions.ChunkedEncodingError()
+        self.assertTrue(self._call_fut(exc))
+
     def test_miss_w_stdlib_error(self):
         exc = ValueError("testing")
         self.assertFalse(self._call_fut(exc))


### PR DESCRIPTION
Closes #525.