### PR TITLE
fix(deps): add explicit ranges for 'google-api-core' and 'google-auth'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,10 @@ description = "Google Cloud Storage API client library"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-auth >= 1.24.0, < 2.0dev; python_version<'3.0'",
-    "google-auth >= 1.24.0, < 3.0dev; python_version>='3.6'",
+    "google-auth >= 1.25.0, < 2.0dev; python_version<'3.0'",
+    "google-auth >= 1.25.0, < 3.0dev; python_version>='3.6'",
+    "google-api-core >= 1.29.0, < 2.0dev; python_version<'3.0'",
+    "google-api-core >= 1.29.0, < 3.0dev; python_version>='3.6'",
     "google-cloud-core >= 1.6.0, < 2.0dev; python_version<'3.0'",
     "google-cloud-core >= 1.6.0, < 3.0dev; python_version>='3.6'",
     "google-resumable-media >= 1.3.0, < 2.0dev; python_version<'3.0'",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,7 +5,8 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-auth==1.24.0
+google-auth==1.25.0
+google-api-core==1.29.0
 google-cloud-core==1.6.0
 google-resumable-media==1.3.0
 requests==2.18.0


### PR DESCRIPTION
Transitive dependency resolution breaks unit tests under Python 3.6
following PR #520.

Pin minima for those ranges explicitly when testing under Python 3.6.

Closes #529.