### PR TITLE
chore: drop use of 'pytz' in tests / examples

### DIFF
--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1613,10 +1613,10 @@ class Client(ClientWithProject):
         Example:
             Generate signed POST policy and upload a file.
 
+            >>> import datetime
             >>> from google.cloud import storage
-            >>> import pytz
             >>> client = storage.Client()
-            >>> tz = pytz.timezone('America/New_York')
+            >>> tz = datetime.timezone(datetime.timedelta(hours=1), 'CET')
             >>> policy = client.generate_signed_post_policy_v4(
                 "bucket-name",
                 "blob-name",

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,2 +1,0 @@
-# Allow prerelease requirements
---pre

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,0 +1,2 @@
+# Allow prerelease requirements
+--pre

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -366,10 +366,10 @@ class Test_IAMConfiguration(unittest.TestCase):
 
     def test_ctor_explicit_ubla(self):
         import datetime
-        import pytz
+        from google.cloud._helpers import UTC
 
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
 
         config = self._make_one(
             bucket,
@@ -403,10 +403,10 @@ class Test_IAMConfiguration(unittest.TestCase):
 
     def test_ctor_explicit_bpo(self):
         import datetime
-        import pytz
+        from google.cloud._helpers import UTC
 
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
 
         config = pytest.deprecated_call(
             self._make_one,
@@ -433,10 +433,10 @@ class Test_IAMConfiguration(unittest.TestCase):
 
     def test_ctor_ubla_and_bpo_time(self):
         import datetime
-        import pytz
+        from google.cloud._helpers import UTC
 
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
 
         with self.assertRaises(ValueError):
             self._make_one(
@@ -481,12 +481,12 @@ class Test_IAMConfiguration(unittest.TestCase):
 
     def test_from_api_repr_w_enabled(self):
         import datetime
-        import pytz
+        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_rfc3339
 
         klass = self._get_target_class()
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         resource = {
             "uniformBucketLevelAccess": {
                 "enabled": True,
@@ -2174,11 +2174,11 @@ class Test_Bucket(unittest.TestCase):
 
     def test_iam_configuration_policy_w_entry(self):
         import datetime
-        import pytz
+        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_rfc3339
         from google.cloud.storage.bucket import IAMConfiguration
 
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         NAME = "name"
         properties = {
             "iamConfiguration": {

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1778,7 +1778,7 @@ class TestClient(unittest.TestCase):
         self, explicit_project=None, user_project=None, timeout=None, retry=None,
     ):
         import datetime
-        from pytz import UTC
+        from google.cloud._helpers import UTC
         from google.cloud.storage.hmac_key import HMACKeyMetadata
 
         project = "PROJECT"

--- a/tests/unit/test_hmac_key.py
+++ b/tests/unit/test_hmac_key.py
@@ -173,7 +173,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
     def test_time_created_getter(self):
         import datetime
-        from pytz import UTC
+        from google.cloud._helpers import UTC
 
         metadata = self._make_one()
         now = datetime.datetime.utcnow()
@@ -183,7 +183,7 @@ class TestHMACKeyMetadata(unittest.TestCase):
 
     def test_updated_getter(self):
         import datetime
-        from pytz import UTC
+        from google.cloud._helpers import UTC
 
         metadata = self._make_one()
         now = datetime.datetime.utcnow()


### PR DESCRIPTION
Current (pre-)releases of 'google-api-core' and 'google-cloud-core' no
longer use or depend on 'pytz'.

Add '--pre' to constraints file for Python 3.9, to allow testing
against those versions.

Closes #533.