### PR TITLE
tests: add retry for 400 from 'Bucket.update' after removing labels

### DIFF
--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -111,7 +111,9 @@ def test_bucket_update_labels(storage_client, buckets_to_delete):
     assert bucket.labels == new_labels
 
     bucket.labels = {}
-    bucket.update()
+    # See https://github.com/googleapis/python-storage/issues/541
+    retry_400 = _helpers.RetryErrors(exceptions.BadRequest)
+    retry_400(bucket.update)()
     assert bucket.labels == {}
 
 


### PR DESCRIPTION
Closes #541.