### PR TITLE
tests: add retry conf test cases for conditionally idempotent operations with no preconditions

### DIFF
--- a/tests/conformance/retry_strategy_test_data.json
+++ b/tests/conformance/retry_strategy_test_data.json
@@ -81,15 +81,15 @@
           },
           {
             "name": "storage.hmacKey.delete",
-            "resources": []
+            "resources": ["HMAC_KEY"]
           },
           {
             "name": "storage.hmacKey.get",
-            "resources": []
+            "resources": ["HMAC_KEY"]
           },
           {
             "name": "storage.hmacKey.list",
-            "resources": []
+            "resources": ["HMAC_KEY"]
           },
           {
             "name": "storage.notifications.delete",
@@ -180,7 +180,7 @@
           },
           {
             "name": "storage.hmacKey.update",
-            "resources": []
+            "resources": ["HMAC_KEY"]
           },
           {
             "name": "storage.objects.compose",
@@ -239,10 +239,83 @@
         "description": "conditionally idempotent no retries when precondition is absent",
         "cases": [
           {
-            "instructions": []
+            "instructions": [
+              "return-503"
+            ]
           }
         ],
-        "methods": [],
+        "methods": [
+          {
+            "name": "storage.buckets.patch",
+            "resources": [
+              "BUCKET"
+            ]
+          },
+          {
+            "name": "storage.buckets.setIamPolicy",
+            "resources": [
+              "BUCKET"
+            ]
+          },
+          {
+            "name": "storage.buckets.update",
+            "resources": [
+              "BUCKET"
+            ]
+          },
+          {
+            "name": "storage.hmacKey.update",
+            "resources": ["HMAC_KEY"]
+          },
+          {
+            "name": "storage.objects.compose",
+            "resources": [
+              "BUCKET",
+              "OBJECT"
+            ]
+          },
+          {
+            "name": "storage.objects.copy",
+            "resources": [
+              "BUCKET",
+              "OBJECT"
+            ]
+          },
+          {
+            "name": "storage.objects.delete",
+            "resources": [
+              "BUCKET",
+              "OBJECT"
+            ]
+          },
+          {
+            "name": "storage.objects.insert",
+            "resources": [
+              "BUCKET"
+            ]
+          },
+          {
+            "name": "storage.objects.patch",
+            "resources": [
+              "BUCKET",
+              "OBJECT"
+            ]
+          },
+          {
+            "name": "storage.objects.rewrite",
+            "resources": [
+              "BUCKET",
+              "OBJECT"
+            ]
+          },
+          {
+            "name": "storage.objects.update",
+            "resources": [
+              "BUCKET",
+              "OBJECT"
+            ]
+          }
+        ],
         "preconditionProvided": false,
         "expectSuccess": false
       },

--- a/tests/conformance/retry_strategy_test_data.json
+++ b/tests/conformance/retry_strategy_test_data.json
@@ -2,319 +2,83 @@
     "retryStrategyTests": [
       {
         "id": 1,
-        "description": "always idempotent",
+        "description": "always_idempotent",
         "cases": [
           {
-            "instructions": [
-              "return-503",
-              "return-503"
-            ]
+            "instructions": ["return-503", "return-503"]
           }
         ],
         "methods": [
-          {
-            "name": "storage.bucket_acl.get",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.bucket_acl.list",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.delete",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.buckets.get",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.getIamPolicy",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.insert",
-            "resources": []
-          },
-          {
-            "name": "storage.buckets.list",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.lockRetentionPolicy",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.testIamPermissions",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.default_object_acl.get",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.default_object_acl.list",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.hmacKey.delete",
-            "resources": ["HMAC_KEY"]
-          },
-          {
-            "name": "storage.hmacKey.get",
-            "resources": ["HMAC_KEY"]
-          },
-          {
-            "name": "storage.hmacKey.list",
-            "resources": ["HMAC_KEY"]
-          },
-          {
-            "name": "storage.notifications.delete",
-            "resources": [
-              "BUCKET",
-              "NOTIFICATION"
-            ]
-          },
-          {
-            "name": "storage.notifications.get",
-            "resources": [
-              "BUCKET",
-              "NOTIFICATION"
-            ]
-          },
-          {
-            "name": "storage.notifications.list",
-            "resources": [
-              "BUCKET",
-              "NOTIFICATION"
-            ]
-          },
-          {
-            "name": "storage.object_acl.get",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.object_acl.list",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.get",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.list",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.serviceaccount.get",
-            "resources": []
-          }
+          {"name": "storage.bucket_acl.get",                "resources": ["BUCKET"]},
+          {"name": "storage.bucket_acl.list",               "resources": ["BUCKET"]},
+          {"name": "storage.buckets.delete",                "resources": ["BUCKET"]},
+          {"name": "storage.buckets.get",                   "resources": ["BUCKET"]},
+          {"name": "storage.buckets.getIamPolicy",          "resources": ["BUCKET"]},
+          {"name": "storage.buckets.insert",                "resources": []},
+          {"name": "storage.buckets.list",                  "resources": ["BUCKET"]},
+          {"name": "storage.buckets.lockRetentionPolicy",   "resources": ["BUCKET"]},
+          {"name": "storage.buckets.testIamPermissions",    "resources": ["BUCKET"]},
+          {"name": "storage.default_object_acl.get",        "resources": ["BUCKET"]},
+          {"name": "storage.default_object_acl.list",       "resources": ["BUCKET"]},
+          {"name": "storage.hmacKey.delete",                "resources": ["HMAC_KEY"]},
+          {"name": "storage.hmacKey.get",                   "resources": ["HMAC_KEY"]},
+          {"name": "storage.hmacKey.list",                  "resources": ["HMAC_KEY"]},
+          {"name": "storage.notifications.delete",          "resources": ["BUCKET", "NOTIFICATION"]},
+          {"name": "storage.notifications.get",             "resources": ["BUCKET", "NOTIFICATION"]},
+          {"name": "storage.notifications.list",            "resources": ["BUCKET", "NOTIFICATION"]},
+          {"name": "storage.object_acl.get",                "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.object_acl.list",               "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.get",                   "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.list",                  "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.serviceaccount.get",            "resources": []}
         ],
         "preconditionProvided": false,
         "expectSuccess": true
       },
       {
         "id": 2,
-        "description": "conditionally idempotent retries when precondition is present",
+        "description": "conditionally_idempotent_retries_when_precondition_is_present",
         "cases": [
           {
-            "instructions": [
-              "return-503",
-              "return-503"
-            ]
+            "instructions": ["return-503", "return-503"]
           }
         ],
         "methods": [
-          {
-            "name": "storage.buckets.patch",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.setIamPolicy",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.update",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.hmacKey.update",
-            "resources": ["HMAC_KEY"]
-          },
-          {
-            "name": "storage.objects.compose",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.copy",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.delete",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.insert",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.objects.patch",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.rewrite",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.update",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          }
+          {"name": "storage.buckets.patch",         "resources": ["BUCKET"]},
+          {"name": "storage.buckets.setIamPolicy",  "resources": ["BUCKET"]},
+          {"name": "storage.buckets.update",        "resources": ["BUCKET"]},
+          {"name": "storage.hmacKey.update",        "resources": ["HMAC_KEY"]},
+          {"name": "storage.objects.compose",       "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.copy",          "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.delete",        "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.insert",        "resources": ["BUCKET"]},
+          {"name": "storage.objects.patch",         "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.rewrite",       "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.update",        "resources": ["BUCKET", "OBJECT"]}
         ],
         "preconditionProvided": true,
         "expectSuccess": true
       },
       {
         "id": 3,
-        "description": "conditionally idempotent no retries when precondition is absent",
+        "description": "conditionally_idempotent_no_retries_when_precondition_is_absent",
         "cases": [
           {
-            "instructions": [
-              "return-503"
-            ]
+            "instructions": ["return-503"]
           }
         ],
         "methods": [
-          {
-            "name": "storage.buckets.patch",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.setIamPolicy",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.buckets.update",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.hmacKey.update",
-            "resources": ["HMAC_KEY"]
-          },
-          {
-            "name": "storage.objects.compose",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.copy",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.delete",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.insert",
-            "resources": [
-              "BUCKET"
-            ]
-          },
-          {
-            "name": "storage.objects.patch",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.rewrite",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          },
-          {
-            "name": "storage.objects.update",
-            "resources": [
-              "BUCKET",
-              "OBJECT"
-            ]
-          }
+          {"name": "storage.buckets.patch",         "resources": ["BUCKET"]},
+          {"name": "storage.buckets.setIamPolicy",  "resources": ["BUCKET"]},
+          {"name": "storage.buckets.update",        "resources": ["BUCKET"]},
+          {"name": "storage.hmacKey.update",        "resources": ["HMAC_KEY"]},
+          {"name": "storage.objects.compose",       "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.copy",          "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.delete",        "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.insert",        "resources": ["BUCKET"]},
+          {"name": "storage.objects.patch",         "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.rewrite",       "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.objects.update",        "resources": ["BUCKET", "OBJECT"]}
         ],
         "preconditionProvided": false,
         "expectSuccess": false

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -523,7 +523,7 @@ def bucket(client):
 @pytest.fixture
 def object(client, bucket):
     blob = client.bucket(bucket.name).blob(uuid.uuid4().hex)
-    blob.upload_from_string(_STRING_CONTENT, checksum="crc32c")
+    blob.upload_from_string(_STRING_CONTENT)
     blob.reload()
     yield blob
     try:


### PR DESCRIPTION
This adds test cases to the retry strategy conformance tests:

- Scenario 3 - for conditionally idempotent operations with retryable error codes, libraries **don't** retry when preconditions are absent
- Add test schema for scenario 3 and align json file with [conformance-tests/retry_tests.json](https://github.com/googleapis/conformance-tests/blob/master/storage/v1/retry_tests.json)
