### PR TITLE
chore: unbundle renovate reports

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -14,8 +14,6 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import re
-
 import synthtool as s
 from synthtool import gcp
 from synthtool.languages import python
@@ -34,15 +32,17 @@ templated_files = common.py_library(
         # See: https://github.com/googleapis/python-storage/issues/226
         "google-cloud-kms < 2.0dev",
     ],
-    intersphinx_dependencies = {
+    intersphinx_dependencies={
         "requests": "https://docs.python-requests.org/en/master/"
     },
 )
 
 s.move(
-    templated_files, excludes=[
+    templated_files,
+    excludes=[
         "docs/multiprocessing.rst",
         "noxfile.py",
+        "renovate.json",  # do not bundle reports
         "CONTRIBUTING.rst",
     ],
 )

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     "config:base",
-    "group:all",
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -706,7 +706,7 @@ def test_new_bucket_w_ubla(
         bucket_acl.reload()
 
     bucket_acl.loaded = True  # Fake that we somehow loaded the ACL
-    bucket_acl.all().grant_read()
+    bucket_acl.group("cloud-developer-relations@google.com").grant_read()
     with pytest.raises(exceptions.BadRequest):
         bucket_acl.save()
 
@@ -724,7 +724,7 @@ def test_new_bucket_w_ubla(
         blob_acl.reload()
 
     blob_acl.loaded = True  # Fake that we somehow loaded the ACL
-    blob_acl.all().grant_read()
+    blob_acl.group("cloud-developer-relations@google.com").grant_read()
     with pytest.raises(exceptions.BadRequest):
         blob_acl.save()
 


### PR DESCRIPTION
We need to be able to close those for the Python 2.7 requirements,
while allowing through the normal Python 3 reports.

Closes #578.