### PR TITLE
tests: add retry conformance test cases

### DIFF
--- a/tests/conformance/retry_strategy_test_data.json
+++ b/tests/conformance/retry_strategy_test_data.json
@@ -85,13 +85,28 @@
       },
       {
         "id": 4,
-        "description": "non idempotent",
+        "description": "non_idempotent",
         "cases": [
           {
-            "instructions": []
+            "instructions": ["return-503"]
           }
         ],
-        "methods": [],
+        "methods": [
+          {"name": "storage.bucket_acl.delete",             "resources": ["BUCKET"]},
+          {"name": "storage.bucket_acl.insert",             "resources": ["BUCKET"]},
+          {"name": "storage.bucket_acl.patch",              "resources": ["BUCKET"]},
+          {"name": "storage.bucket_acl.update",             "resources": ["BUCKET"]},
+          {"name": "storage.default_object_acl.delete",     "resources": ["BUCKET"]},
+          {"name": "storage.default_object_acl.insert",     "resources": ["BUCKET"]},
+          {"name": "storage.default_object_acl.patch",      "resources": ["BUCKET"]},
+          {"name": "storage.default_object_acl.update",     "resources": ["BUCKET"]},
+          {"name": "storage.hmacKey.create",                "resources": []},
+          {"name": "storage.notifications.insert",          "resources": ["BUCKET"]},
+          {"name": "storage.object_acl.delete",             "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.object_acl.insert",             "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.object_acl.patch",              "resources": ["BUCKET", "OBJECT"]},
+          {"name": "storage.object_acl.update",             "resources": ["BUCKET", "OBJECT"]}
+        ],
         "preconditionProvided": false,
         "expectSuccess": false
       }

--- a/tests/conformance/retry_strategy_test_data.json
+++ b/tests/conformance/retry_strategy_test_data.json
@@ -6,6 +6,12 @@
         "cases": [
           {
             "instructions": ["return-503", "return-503"]
+          },
+          {
+            "instructions": ["return-reset-connection", "return-reset-connection"]
+          },
+          {
+            "instructions": ["return-reset-connection", "return-503"]
           }
         ],
         "methods": [
@@ -41,6 +47,12 @@
         "cases": [
           {
             "instructions": ["return-503", "return-503"]
+          },
+          {
+            "instructions": ["return-reset-connection", "return-reset-connection"]
+          },
+          {
+            "instructions": ["return-reset-connection", "return-503"]
           }
         ],
         "methods": [
@@ -65,6 +77,9 @@
         "cases": [
           {
             "instructions": ["return-503"]
+          },
+          {
+            "instructions": ["return-reset-connection"]
           }
         ],
         "methods": [
@@ -89,6 +104,9 @@
         "cases": [
           {
             "instructions": ["return-503"]
+          },
+          {
+            "instructions": ["return-reset-connection"]
           }
         ],
         "methods": [

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -251,6 +251,16 @@ def client_create_hmac_key(client, _preconditions, **_):
     client.create_hmac_key(service_account_email=_CONF_TEST_SERVICE_ACCOUNT_EMAIL)
 
 
+def hmac_key_update(client, _preconditions, **resources):
+    access_id = resources.get("hmac_key").access_id
+    etag = resources.get("hmac_key").etag
+    hmac_key = HMACKeyMetadata(client, access_id=access_id)
+    if _preconditions:
+        hmac_key.etag = etag
+    hmac_key.state = "INACTIVE"
+    hmac_key.update()
+
+
 def bucket_patch(client, _preconditions, **resources):
     bucket = client.get_bucket(resources.get("bucket").name)
     metageneration = bucket.metageneration
@@ -504,6 +514,7 @@ method_mapping = {
     "storage.buckets.patch": [bucket_patch],  # S2/S3 start
     "storage.buckets.setIamPolicy": [bucket_set_iam_policy],
     "storage.buckets.update": [bucket_update],
+    "storage.hmacKey.update": [hmac_key_update],
     "storage.objects.compose": [blob_compose],
     "storage.objects.copy": [bucket_copy_blob, bucket_rename_blob],
     "storage.objects.delete": [

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -517,7 +517,7 @@ def bucket_acl_save_predefined(client, _preconditions, **resources):
     if _preconditions:
         pytest.skip(_BUCKET_ACL_PATCH_MSG)
     bucket = client.bucket(resources.get("bucket").name)
-    bucket.acl.save("bucketOwnerFullControl")
+    bucket.acl.save_predefined("bucketOwnerFullControl")
 
 
 def bucket_acl_clear(client, _preconditions, **resources):
@@ -546,7 +546,7 @@ def default_object_acl_save_predefined(client, _preconditions, **resources):
     if _preconditions:
         pytest.skip(_DEFAULT_OBJECT_ACL_PATCH_MSG)
     bucket = client.bucket(resources.get("bucket").name)
-    bucket.default_object_acl.save("bucketOwnerFullControl")
+    bucket.default_object_acl.save_predefined("bucketOwnerFullControl")
 
 
 def default_object_acl_clear(client, _preconditions, **resources):
@@ -580,7 +580,7 @@ def object_acl_save_predefined(client, _preconditions, **resources):
     bucket = resources.get("bucket")
     object = resources.get("object")
     blob = client.bucket(bucket.name).blob(object.name)
-    blob.acl.save("bucketOwnerFullControl")
+    blob.acl.save_predefined("bucketOwnerFullControl")
 
 
 def object_acl_clear(client, _preconditions, **resources):

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -911,7 +911,7 @@ for scenario in _CONFORMANCE_TESTS:
     id = scenario["id"]
     methods = scenario["methods"]
     cases = scenario["cases"]
-    for c in cases:
+    for i, c in enumerate(cases):
         for m in methods:
             method_name = m["name"]
             if method_name not in method_mapping:
@@ -919,7 +919,9 @@ for scenario in _CONFORMANCE_TESTS:
                 continue
 
             for lib_func in method_mapping[method_name]:
-                test_name = "test-S{}-{}-{}".format(id, method_name, lib_func.__name__)
+                test_name = "test-S{}-{}-{}-{}".format(
+                    id, method_name, lib_func.__name__, i
+                )
                 globals()[test_name] = functools.partial(
                     run_test_case, id, m, c, lib_func, host
                 )


### PR DESCRIPTION
Update test schema json file and add retry conformance test cases:
- Project-based operations (hmacKey, service account)
- ACL operations
- Scenario 4 never idempotent operations
- Add instructions cases 
`["return-reset-connection", "return-reset-connection"]`
`["return-reset-connection", "return-503"]`
- Update test names

Filed issue #582 to track special cases: The PATCH API requests for ACL in python-storage utilize `storage.buckets.patch` or `storage.objects.patch`, instead of  ACL specific endpoints such as `storage.bucket_acl.patch`  `storage.object_acl.patch` `storage.default_object_acl.patch`


An individual test case is generated for each scenario ID, instruction set, method, and method_invocation_mapping_library_method. Test names are displayed as test-S{scenario_id}-{method}-{client-library-method-name}-{instructions index}, for example, `test-S1-storage.buckets.get-bucket_reload-1`