### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ via direct download.
 - `Storage API docs`_
 
 .. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-storage.svg
    :target: https://pypi.org/project/google-cloud-storage
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storage.svg


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.