### PR TITLE
fix: add preconditions and retry config support to ACL patch operationss

### DIFF
--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -494,12 +494,28 @@ class ACL(object):
         :param client: (Optional) The client to use.  If not passed, falls back
                        to the ``client`` stored on the ACL's parent.
 
+        :type if_generation_match: long
+        :param if_generation_match:
+            (Optional) See :ref:`using-if-generation-match`
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match:
+            (Optional) See :ref:`using-if-generation-not-match`
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match:
+            (Optional) See :ref:`using-if-metageneration-match`
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match:
+            (Optional) See :ref:`using-if-metageneration-not-match`
+
         :type timeout: float or tuple
         :param timeout:
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
 
-        :type retry: :class:`~google.api_core.retry.Retry`
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
@@ -562,10 +578,30 @@ class ACL(object):
         :param client: (Optional) The client to use.  If not passed, falls back
                        to the ``client`` stored on the ACL's parent.
 
+        :type if_generation_match: long
+        :param if_generation_match:
+            (Optional) See :ref:`using-if-generation-match`
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match:
+            (Optional) See :ref:`using-if-generation-not-match`
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match:
+            (Optional) See :ref:`using-if-metageneration-match`
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match:
+            (Optional) See :ref:`using-if-metageneration-not-match`
+
         :type timeout: float or tuple
         :param timeout:
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry:
+            (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
         if acl is None:
             acl = self
@@ -613,10 +649,30 @@ class ACL(object):
         :param client: (Optional) The client to use.  If not passed, falls back
                        to the ``client`` stored on the ACL's parent.
 
+        :type if_generation_match: long
+        :param if_generation_match:
+            (Optional) See :ref:`using-if-generation-match`
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match:
+            (Optional) See :ref:`using-if-generation-not-match`
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match:
+            (Optional) See :ref:`using-if-metageneration-match`
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match:
+            (Optional) See :ref:`using-if-metageneration-not-match`
+
         :type timeout: float or tuple
         :param timeout:
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry:
+            (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
         predefined = self.validate_predefined(predefined)
         self._save(
@@ -655,10 +711,30 @@ class ACL(object):
         :param client: (Optional) The client to use.  If not passed, falls back
                        to the ``client`` stored on the ACL's parent.
 
+        :type if_generation_match: long
+        :param if_generation_match:
+            (Optional) See :ref:`using-if-generation-match`
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match:
+            (Optional) See :ref:`using-if-generation-not-match`
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match:
+            (Optional) See :ref:`using-if-metageneration-match`
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match:
+            (Optional) See :ref:`using-if-metageneration-not-match`
+
         :type timeout: float or tuple
         :param timeout:
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry:
+            (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
         self.save(
             [],

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3249,6 +3249,25 @@ class Blob(_PropertyMixin):
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
 
+        :type if_generation_match: long
+        :param if_generation_match:
+            (Optional) See :ref:`using-if-generation-match`
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match:
+            (Optional) See :ref:`using-if-generation-not-match`
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match:
+            (Optional) See :ref:`using-if-metageneration-match`
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match:
+            (Optional) See :ref:`using-if-metageneration-not-match`
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry:
+            (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
         self.acl.all().grant_read()
         self.acl.save(
@@ -3282,6 +3301,26 @@ class Blob(_PropertyMixin):
         :param timeout:
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
+
+        :type if_generation_match: long
+        :param if_generation_match:
+            (Optional) See :ref:`using-if-generation-match`
+
+        :type if_generation_not_match: long
+        :param if_generation_not_match:
+            (Optional) See :ref:`using-if-generation-not-match`
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match:
+            (Optional) See :ref:`using-if-metageneration-match`
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match:
+            (Optional) See :ref:`using-if-metageneration-not-match`
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry:
+            (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
         self.acl.all().revoke_read()
         self.acl.save(

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -83,6 +83,7 @@ from google.cloud.storage.retry import ConditionalRetryPolicy
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_ETAG_IN_JSON
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_GENERATION_SPECIFIED
+from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
 from google.cloud.storage.fileio import BlobReader
 from google.cloud.storage.fileio import BlobWriter
 
@@ -3226,7 +3227,16 @@ class Blob(_PropertyMixin):
 
         return resp.get("permissions", [])
 
-    def make_public(self, client=None, timeout=_DEFAULT_TIMEOUT):
+    def make_public(
+        self,
+        client=None,
+        timeout=_DEFAULT_TIMEOUT,
+        if_generation_match=None,
+        if_generation_not_match=None,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+    ):
         """Update blob's ACL, granting read access to anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -3241,9 +3251,26 @@ class Blob(_PropertyMixin):
 
         """
         self.acl.all().grant_read()
-        self.acl.save(client=client, timeout=timeout)
+        self.acl.save(
+            client=client,
+            timeout=timeout,
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+            retry=retry,
+        )
 
-    def make_private(self, client=None, timeout=_DEFAULT_TIMEOUT):
+    def make_private(
+        self,
+        client=None,
+        timeout=_DEFAULT_TIMEOUT,
+        if_generation_match=None,
+        if_generation_not_match=None,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+    ):
         """Update blob's ACL, revoking read access for anonymous users.
 
         :type client: :class:`~google.cloud.storage.client.Client` or
@@ -3257,7 +3284,15 @@ class Blob(_PropertyMixin):
             for the server response.  See: :ref:`configuring_timeouts`
         """
         self.acl.all().revoke_read()
-        self.acl.save(client=client, timeout=timeout)
+        self.acl.save(
+            client=client,
+            timeout=timeout,
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+            retry=retry,
+        )
 
     def compose(
         self,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2839,7 +2839,14 @@ class Bucket(_PropertyMixin):
         return resp.get("permissions", [])
 
     def make_public(
-        self, recursive=False, future=False, client=None, timeout=_DEFAULT_TIMEOUT,
+        self,
+        recursive=False,
+        future=False,
+        client=None,
+        timeout=_DEFAULT_TIMEOUT,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
     ):
         """Update bucket's ACL, granting read access to anonymous users.
 
@@ -2869,14 +2876,26 @@ class Bucket(_PropertyMixin):
             for each blob.
         """
         self.acl.all().grant_read()
-        self.acl.save(client=client, timeout=timeout)
+        self.acl.save(
+            client=client,
+            timeout=timeout,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+            retry=retry,
+        )
 
         if future:
             doa = self.default_object_acl
             if not doa.loaded:
                 doa.reload(client=client, timeout=timeout)
             doa.all().grant_read()
-            doa.save(client=client, timeout=timeout)
+            doa.save(
+                client=client,
+                timeout=timeout,
+                if_metageneration_match=if_metageneration_match,
+                if_metageneration_not_match=if_metageneration_not_match,
+                retry=retry,
+            )
 
         if recursive:
             blobs = list(
@@ -2899,10 +2918,19 @@ class Bucket(_PropertyMixin):
 
             for blob in blobs:
                 blob.acl.all().grant_read()
-                blob.acl.save(client=client, timeout=timeout)
+                blob.acl.save(
+                    client=client, timeout=timeout,
+                )
 
     def make_private(
-        self, recursive=False, future=False, client=None, timeout=_DEFAULT_TIMEOUT,
+        self,
+        recursive=False,
+        future=False,
+        client=None,
+        timeout=_DEFAULT_TIMEOUT,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+        retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
     ):
         """Update bucket's ACL, revoking read access for anonymous users.
 
@@ -2933,14 +2961,26 @@ class Bucket(_PropertyMixin):
             for each blob.
         """
         self.acl.all().revoke_read()
-        self.acl.save(client=client, timeout=timeout)
+        self.acl.save(
+            client=client,
+            timeout=timeout,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+            retry=retry,
+        )
 
         if future:
             doa = self.default_object_acl
             if not doa.loaded:
                 doa.reload(client=client, timeout=timeout)
             doa.all().revoke_read()
-            doa.save(client=client, timeout=timeout)
+            doa.save(
+                client=client,
+                timeout=timeout,
+                if_metageneration_match=if_metageneration_match,
+                if_metageneration_not_match=if_metageneration_not_match,
+                retry=retry,
+            )
 
         if recursive:
             blobs = list(

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2867,6 +2867,18 @@ class Bucket(_PropertyMixin):
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
 
+        :type if_metageneration_match: long
+        :param if_metageneration_match: (Optional) Make the operation conditional on whether the
+                                        blob's current metageneration matches the given value.
+
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match: (Optional) Make the operation conditional on whether the
+                                            blob's current metageneration does not match the given value.
+
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry:
+            (Optional) How to retry the RPC. See: :ref:`configuring_retries`
+
         :raises ValueError:
             If ``recursive`` is True, and the bucket contains more than 256
             blobs.  This is to prevent extremely long runtime of this
@@ -2951,6 +2963,16 @@ class Bucket(_PropertyMixin):
         :param timeout:
             (Optional) The amount of time, in seconds, to wait
             for the server response.  See: :ref:`configuring_timeouts`
+
+        :type if_metageneration_match: long
+        :param if_metageneration_match: (Optional) Make the operation conditional on whether the
+                                        blob's current metageneration matches the given value.
+        :type if_metageneration_not_match: long
+        :param if_metageneration_not_match: (Optional) Make the operation conditional on whether the
+                                            blob's current metageneration does not match the given value.
+        :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
+        :param retry:
+            (Optional) How to retry the RPC. See: :ref:`configuring_retries`
 
         :raises ValueError:
             If ``recursive`` is True, and the bucket contains more than 256

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -16,7 +16,10 @@ import unittest
 
 import mock
 
-from google.cloud.storage.retry import DEFAULT_RETRY
+from google.cloud.storage.retry import (
+    DEFAULT_RETRY,
+    DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+)
 
 
 class Test_ACLEntity(unittest.TestCase):
@@ -646,7 +649,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_save_no_acl_w_timeout(self):
@@ -673,7 +676,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_save_w_acl_w_user_project(self):
@@ -705,7 +708,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_save_prefefined_invalid(self):
@@ -749,7 +752,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_save_predefined_w_XML_alias_w_timeout(self):
@@ -779,7 +782,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_save_predefined_w_alternate_query_param(self):
@@ -809,7 +812,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_clear_w_defaults(self):
@@ -842,7 +845,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_clear_w_explicit_client_w_timeout(self):
@@ -872,7 +875,7 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
 

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -711,6 +711,45 @@ class Test_ACL(unittest.TestCase):
             retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
+    def test_save_w_acl_w_preconditions(self):
+        save_path = "/testing"
+        role1 = "role1"
+        role2 = "role2"
+        sticky = {"entity": "allUsers", "role": role2}
+        new_acl = [{"entity": "allUsers", "role": role1}]
+        api_response = {"acl": [sticky] + new_acl}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = self._make_one()
+        acl.save_path = save_path
+        acl.loaded = True
+
+        acl.save(
+            new_acl,
+            client=client,
+            if_metageneration_match=2,
+            if_metageneration_not_match=1,
+        )
+
+        entries = list(acl)
+        self.assertEqual(len(entries), 2)
+        self.assertTrue(sticky in entries)
+        self.assertTrue(new_acl[0] in entries)
+
+        expected_data = {"acl": new_acl}
+        expected_query_params = {
+            "projection": "full",
+            "ifMetagenerationMatch": 2,
+            "ifMetagenerationNotMatch": 1,
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        )
+
     def test_save_prefefined_invalid(self):
         save_path = "/testing"
         client = mock.Mock(spec=["_patch_resource"])
@@ -815,6 +854,41 @@ class Test_ACL(unittest.TestCase):
             retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
+    def test_save_predefined_w_preconditions(self):
+        save_path = "/testing"
+        predefined = "private"
+        api_response = {"acl": []}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = self._make_one()
+        acl.save_path = save_path
+        acl.loaded = True
+
+        acl.save_predefined(
+            predefined,
+            client=client,
+            if_metageneration_match=2,
+            if_metageneration_not_match=1,
+        )
+
+        entries = list(acl)
+        self.assertEqual(len(entries), 0)
+
+        expected_data = {"acl": []}
+        expected_query_params = {
+            "projection": "full",
+            "predefinedAcl": predefined,
+            "ifMetagenerationMatch": 2,
+            "ifMetagenerationNotMatch": 1,
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        )
+
     def test_clear_w_defaults(self):
         class Derived(self._get_target_class()):
             client = None
@@ -875,6 +949,39 @@ class Test_ACL(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=timeout,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        )
+
+    def test_clear_w_explicit_client_w_preconditions(self):
+        save_path = "/testing"
+        role1 = "role1"
+        role2 = "role2"
+        sticky = {"entity": "allUsers", "role": role2}
+        api_response = {"acl": [sticky]}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        acl = self._make_one()
+        acl.save_path = save_path
+        acl.loaded = True
+        acl.entity("allUsers", role1)
+
+        acl.clear(
+            client=client, if_metageneration_match=2, if_metageneration_not_match=1
+        )
+
+        self.assertEqual(list(acl), [sticky])
+
+        expected_data = {"acl": []}
+        expected_query_params = {
+            "projection": "full",
+            "ifMetagenerationMatch": 2,
+            "ifMetagenerationNotMatch": 1,
+        }
+        client._patch_resource.assert_called_once_with(
+            save_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -3969,6 +3969,36 @@ class Test_Blob(unittest.TestCase):
             retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
+    def test_make_public_w_preconditions(self):
+        from google.cloud.storage.acl import _ACLEntity
+
+        blob_name = "blob-name"
+        permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
+        api_response = {"acl": permissive}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        bucket = _Bucket(client=client)
+        blob = self._make_one(blob_name, bucket=bucket)
+        blob.acl.loaded = True
+
+        blob.make_public(if_metageneration_match=2, if_metageneration_not_match=1)
+
+        self.assertEqual(list(blob.acl), permissive)
+
+        expected_patch_data = {"acl": permissive}
+        expected_query_params = {
+            "projection": "full",
+            "ifMetagenerationMatch": 2,
+            "ifMetagenerationNotMatch": 1,
+        }
+        client._patch_resource.assert_called_once_with(
+            blob.path,
+            expected_patch_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        )
+
     def test_make_private_w_defaults(self):
         blob_name = "blob-name"
         no_permissions = []
@@ -4015,6 +4045,34 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=timeout,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        )
+
+    def test_make_private_w_preconditions(self):
+        blob_name = "blob-name"
+        no_permissions = []
+        api_response = {"acl": no_permissions}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        bucket = _Bucket(client=client)
+        blob = self._make_one(blob_name, bucket=bucket)
+        blob.acl.loaded = True
+
+        blob.make_private(if_metageneration_match=2, if_metageneration_not_match=1)
+
+        self.assertEqual(list(blob.acl), no_permissions)
+
+        expected_patch_data = {"acl": no_permissions}
+        expected_query_params = {
+            "projection": "full",
+            "ifMetagenerationMatch": 2,
+            "ifMetagenerationNotMatch": 1,
+        }
+        client._patch_resource.assert_called_once_with(
+            blob.path,
+            expected_patch_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -27,7 +27,10 @@ import six
 from six.moves import http_client
 from six.moves.urllib.parse import urlencode
 
-from google.cloud.storage.retry import DEFAULT_RETRY
+from google.cloud.storage.retry import (
+    DEFAULT_RETRY,
+    DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+)
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_ETAG_IN_JSON
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_GENERATION_SPECIFIED
 
@@ -3936,7 +3939,7 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_make_public_w_timeout(self):
@@ -3963,7 +3966,7 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_make_private_w_defaults(self):
@@ -3987,7 +3990,7 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_make_private_w_timeout(self):
@@ -4012,7 +4015,7 @@ class Test_Blob(unittest.TestCase):
             expected_patch_data,
             query_params=expected_query_params,
             timeout=timeout,
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_compose_wo_content_type_set(self):

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -3202,6 +3202,38 @@ class Test_Bucket(unittest.TestCase):
             retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
+    def test_make_public_w_preconditions(self):
+        from google.cloud.storage.acl import _ACLEntity
+
+        name = "name"
+        permissive = [{"entity": "allUsers", "role": _ACLEntity.READER_ROLE}]
+        api_response = {"acl": permissive, "defaultObjectAcl": []}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        bucket = self._make_one(client=client, name=name)
+        bucket.acl.loaded = True
+        bucket.default_object_acl.loaded = True
+
+        bucket.make_public(if_metageneration_match=2, if_metageneration_not_match=1)
+
+        self.assertEqual(list(bucket.acl), permissive)
+        self.assertEqual(list(bucket.default_object_acl), [])
+
+        expected_path = bucket.path
+        expected_data = {"acl": permissive}
+        expected_query_params = {
+            "projection": "full",
+            "ifMetagenerationMatch": 2,
+            "ifMetagenerationNotMatch": 1,
+        }
+        client._patch_resource.assert_called_once_with(
+            expected_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        )
+
     def _make_public_w_future_helper(self, default_object_acl_loaded=True):
         from google.cloud.storage.acl import _ACLEntity
 
@@ -3375,6 +3407,36 @@ class Test_Bucket(unittest.TestCase):
         expected_path = bucket.path
         expected_data = {"acl": no_permissions}
         expected_query_params = {"projection": "full"}
+        client._patch_resource.assert_called_once_with(
+            expected_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
+        )
+
+    def test_make_private_w_preconditions(self):
+        name = "name"
+        no_permissions = []
+        api_response = {"acl": no_permissions, "defaultObjectAcl": []}
+        client = mock.Mock(spec=["_patch_resource"])
+        client._patch_resource.return_value = api_response
+        bucket = self._make_one(client=client, name=name)
+        bucket.acl.loaded = True
+        bucket.default_object_acl.loaded = True
+
+        bucket.make_private(if_metageneration_match=2, if_metageneration_not_match=1)
+
+        self.assertEqual(list(bucket.acl), no_permissions)
+        self.assertEqual(list(bucket.default_object_acl), [])
+
+        expected_path = bucket.path
+        expected_data = {"acl": no_permissions}
+        expected_query_params = {
+            "projection": "full",
+            "ifMetagenerationMatch": 2,
+            "ifMetagenerationNotMatch": 1,
+        }
         client._patch_resource.assert_called_once_with(
             expected_path,
             expected_data,

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1995,7 +1995,7 @@ class Test_Bucket(unittest.TestCase):
             expected_patch_data,
             query_params=expected_patch_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def test_copy_blob_w_name_and_user_project(self):
@@ -3199,7 +3199,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def _make_public_w_future_helper(self, default_object_acl_loaded=True):
@@ -3232,7 +3232,7 @@ class Test_Bucket(unittest.TestCase):
         expected_kw = {
             "query_params": {"projection": "full"},
             "timeout": self._get_default_timeout(),
-            "retry": None,
+            "retry": DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         }
         client._patch_resource.assert_has_calls(
             [
@@ -3317,7 +3317,7 @@ class Test_Bucket(unittest.TestCase):
             expected_patch_data,
             query_params=expected_patch_query_params,
             timeout=timeout,
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
         client.list_blobs.assert_called_once()
 
@@ -3352,7 +3352,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
         client.list_blobs.assert_called_once()
@@ -3380,7 +3380,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
     def _make_private_w_future_helper(self, default_object_acl_loaded=True):
@@ -3414,7 +3414,7 @@ class Test_Bucket(unittest.TestCase):
         expected_kw = {
             "query_params": {"projection": "full"},
             "timeout": self._get_default_timeout(),
-            "retry": None,
+            "retry": DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         }
         client._patch_resource.assert_has_calls(
             [
@@ -3497,7 +3497,7 @@ class Test_Bucket(unittest.TestCase):
             expected_patch_data,
             query_params=expected_patch_query_params,
             timeout=timeout,
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
         client.list_blobs.assert_called_once()
@@ -3531,7 +3531,7 @@ class Test_Bucket(unittest.TestCase):
             expected_data,
             query_params=expected_query_params,
             timeout=self._get_default_timeout(),
-            retry=None,
+            retry=DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
         )
 
         client.list_blobs.assert_called_once()


### PR DESCRIPTION
Add preconditions and retry config support to the ACL patch operations.  The PATCH API requests for ACL in python-storage utilize `storage.buckets.patch` or `storage.objects.patch`

- ACL patch methods in ACL (`_save` /`save` /`save_predefined` /`clear`)
- ACL patch methods in Bucket (`make_public` /`make_private`)
- ACL patch methods in Blob (`make_public` /`make_private`)
- Add and update tests
- Update doscstrings

Note: IAM configurations storage.buckets.getIamPolicy storage.buckets.setIamPolicy are highly encouraged to control access instead

Fixes #582 