### PR TITLE
fix: pin six as a required dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ dependencies = [
     "google-resumable-media >= 1.3.0, < 3.0dev; python_version>='3.6'",
     "requests >= 2.18.0, < 3.0.0dev",
     "googleapis-common-protos < 1.53.0; python_version<'3.0'",
+    "six",
 ]
 extras = {}
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ dependencies = [
     "google-resumable-media >= 1.3.0, < 2.0dev; python_version<'3.0'",
     "google-resumable-media >= 1.3.0, < 3.0dev; python_version>='3.6'",
     "requests >= 2.18.0, < 3.0.0dev",
+    "protobuf < 3.18.0; python_version<'3.0'",
     "googleapis-common-protos < 1.53.0; python_version<'3.0'",
     "six",
 ]


### PR DESCRIPTION
`six` used to be a transitive dependency through `protobuf`, but now it is not specified in any of the other dependencies thus the tests are failing, and any other installations to the current latest version would fail.

`protobuf` also dropped support for Python 2.7 as of 3.18.0. Pinning it for 2.7.

Fixes #588 🦕
