### PR TITLE
fix: raise a ValueError in BucketNotification.create() if a topic name is not set

### DIFF
--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -262,9 +262,6 @@ class BucketNotification(object):
                 "Notification already exists w/ id: {}".format(self.notification_id)
             )
 
-        if self.topic_name is None:
-            raise ValueError(_BAD_TOPIC.format(self.topic_name))
-
         client = self._require_client(client)
 
         query_params = {}
@@ -273,7 +270,12 @@ class BucketNotification(object):
 
         path = "/b/{}/notificationConfigs".format(self.bucket.name)
         properties = self._properties.copy()
-        properties["topic"] = _TOPIC_REF_FMT.format(self.topic_project, self.topic_name)
+
+        if self.topic_name is None:
+            properties["topic"] = _TOPIC_REF_FMT.format(self.topic_project, "")
+        else:
+            properties["topic"] = _TOPIC_REF_FMT.format(self.topic_project, self.topic_name)
+
         self._properties = client._post_resource(
             path, properties, query_params=query_params, timeout=timeout, retry=retry,
         )

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -253,11 +253,17 @@ class BucketNotification(object):
         :type retry: google.api_core.retry.Retry or google.cloud.storage.retry.ConditionalRetryPolicy
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
+
+        :raises ValueError: if the notification already exists.
+        :raises ValueError: if the topic name is not set.
         """
         if self.notification_id is not None:
             raise ValueError(
                 "Notification already exists w/ id: {}".format(self.notification_id)
             )
+
+        if self.topic_name is None:
+            raise ValueError(_BAD_TOPIC.format(self.topic_name))
 
         client = self._require_client(client)
 

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -274,7 +274,9 @@ class BucketNotification(object):
         if self.topic_name is None:
             properties["topic"] = _TOPIC_REF_FMT.format(self.topic_project, "")
         else:
-            properties["topic"] = _TOPIC_REF_FMT.format(self.topic_project, self.topic_name)
+            properties["topic"] = _TOPIC_REF_FMT.format(
+                self.topic_project, self.topic_name
+            )
 
         self._properties = client._post_resource(
             path, properties, query_params=query_params, timeout=timeout, retry=retry,

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -255,7 +255,6 @@ class BucketNotification(object):
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
 
         :raises ValueError: if the notification already exists.
-        :raises ValueError: if the topic name is not set.
         """
         if self.notification_id is not None:
             raise ValueError(

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -52,6 +52,7 @@ _CONF_TEST_PROJECT_ID = "my-project-id"
 _CONF_TEST_SERVICE_ACCOUNT_EMAIL = (
     "my-service-account@my-project-id.iam.gserviceaccount.com"
 )
+_CONF_TEST_PUBSUB_TOPIC_NAME = "my-topic-name"
 
 _STRING_CONTENT = "hello world"
 _BYTE_CONTENT = b"12345678"
@@ -190,7 +191,7 @@ def client_get_service_account_email(client, _preconditions, **_):
 
 def notification_create(client, _preconditions, **resources):
     bucket = client.bucket(resources.get("bucket").name)
-    notification = bucket.notification()
+    notification = bucket.notification(topic_name=_CONF_TEST_PUBSUB_TOPIC_NAME)
     notification.create()
 
 
@@ -761,7 +762,9 @@ def object(client, bucket):
 
 @pytest.fixture
 def notification(client, bucket):
-    notification = client.bucket(bucket.name).notification()
+    notification = client.bucket(bucket.name).notification(
+        topic_name=_CONF_TEST_PUBSUB_TOPIC_NAME
+    )
     notification.create()
     notification.reload()
     yield notification

--- a/tests/system/test_notification.py
+++ b/tests/system/test_notification.py
@@ -157,6 +157,8 @@ def test_notification_create_wo_topic_name(
     event_types,
     payload_format,
 ):
+    from google.cloud.exceptions import BadRequest
+
     bucket_name = _helpers.unique_name("notification-wo-name")
     bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)
     buckets_to_delete.append(bucket)
@@ -171,7 +173,7 @@ def test_notification_create_wo_topic_name(
         payload_format=payload_format,
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(BadRequest):
         notification.create()
 
 

--- a/tests/system/test_notification.py
+++ b/tests/system/test_notification.py
@@ -149,6 +149,32 @@ def test_notification_create_w_user_project(
         notification.delete()
 
 
+def test_notification_create_wo_topic_name(
+    storage_client,
+    buckets_to_delete,
+    topic_name,
+    notification_topic,
+    event_types,
+    payload_format,
+):
+    bucket_name = _helpers.unique_name("notification-wo-name")
+    bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)
+    buckets_to_delete.append(bucket)
+
+    assert list(bucket.list_notifications()) == []
+
+    notification = bucket.notification(
+        topic_name=None,
+        custom_attributes=custom_attributes,
+        event_types=event_types,
+        blob_name_prefix=blob_name_prefix,
+        payload_format=payload_format,
+    )
+
+    with pytest.raises(ValueError):
+        notification.create()
+
+
 def test_bucket_get_notification(
     storage_client,
     buckets_to_delete,

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -243,15 +243,31 @@ class TestBucketNotification(unittest.TestCase):
         client._post_resource.assert_not_called()
 
     def test_create_wo_topic_name(self):
+        from google.cloud.exceptions import BadRequest
+        from google.cloud.storage.notification import NONE_PAYLOAD_FORMAT
+
         client = mock.Mock(spec=["_post_resource", "project"])
         client.project = self.BUCKET_PROJECT
+        client._post_resource.side_effect = BadRequest("Invalid Google Cloud Pub/Sub topic.")
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, None)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(BadRequest):
             notification.create()
 
-        client._post_resource.assert_not_called()
+        expected_topic = self.TOPIC_REF_FMT.format(self.BUCKET_PROJECT, "")
+        expected_data = {
+            "topic": expected_topic,
+            "payload_format": NONE_PAYLOAD_FORMAT,
+        }
+        expected_query_params = {}
+        client._post_resource.assert_called_once_with(
+            self.CREATE_PATH,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=None,
+        )
 
     def test_create_w_defaults(self):
         from google.cloud.storage.notification import NONE_PAYLOAD_FORMAT

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -242,6 +242,17 @@ class TestBucketNotification(unittest.TestCase):
 
         client._post_resource.assert_not_called()
 
+    def test_create_wo_topic_name(self):
+        client = mock.Mock(spec=["_post_resource", "project"])
+        client.project = self.BUCKET_PROJECT
+        bucket = self._make_bucket(client)
+        notification = self._make_one(bucket, None)
+
+        with self.assertRaises(ValueError):
+            notification.create()
+
+        client._post_resource.assert_not_called()
+
     def test_create_w_defaults(self):
         from google.cloud.storage.notification import NONE_PAYLOAD_FORMAT
 

--- a/tests/unit/test_notification.py
+++ b/tests/unit/test_notification.py
@@ -248,7 +248,9 @@ class TestBucketNotification(unittest.TestCase):
 
         client = mock.Mock(spec=["_post_resource", "project"])
         client.project = self.BUCKET_PROJECT
-        client._post_resource.side_effect = BadRequest("Invalid Google Cloud Pub/Sub topic.")
+        client._post_resource.side_effect = BadRequest(
+            "Invalid Google Cloud Pub/Sub topic."
+        )
         bucket = self._make_bucket(client)
         notification = self._make_one(bucket, None)
 


### PR DESCRIPTION
A PubSub topic (topic name) is required to insert a `BucketNotification` according to the [JSON API](https://cloud.google.com/storage/docs/json_api/v1/notifications/insert#topic). 

Raise a `ValueError` in `BucketNotification.create()` if `topic_name = None`. This adds a guard check and further prevents requests with invalid NoneType string interpolation. 

Add tests and revise conformance tests.

Fixes #616 🦕
