### PR TITLE
chore: add py.typed file and ensure mypy passes

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 try:
-    import pkg_resources
+    import pkg_resources  # type: ignore
 
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
 
-    __path__ = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)  # type: ignore

--- a/google/cloud/__init__.py
+++ b/google/cloud/__init__.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 try:
-    import pkg_resources
+    import pkg_resources  # type: ignore
 
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
 
-    __path__ = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)  # type: ignore

--- a/google/cloud/py.typed
+++ b/google/cloud/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# The google-cloud-storage package uses inline types.

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -22,9 +22,9 @@ from hashlib import md5
 from datetime import datetime
 import os
 
-from six import string_types
-from six.moves.urllib.parse import urlsplit
-from google import resumable_media
+from six import string_types  # type: ignore
+from six.moves.urllib.parse import urlsplit  # type: ignore
+from google import resumable_media  # type: ignore
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED

--- a/google/cloud/storage/_http.py
+++ b/google/cloud/storage/_http.py
@@ -16,9 +16,9 @@
 
 import functools
 import os
-import pkg_resources
+import pkg_resources  # type: ignore
 
-from google.cloud import _http
+from google.cloud import _http  # type: ignore
 
 from google.cloud.storage import __version__
 

--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -20,7 +20,7 @@ import datetime
 import hashlib
 import json
 
-import six
+import six  # type: ignore
 
 import google.auth.credentials
 

--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -412,7 +412,7 @@ class ACL(object):
         self._ensure_loaded()
         return list(self.entities.values())
 
-    @property
+    @property  # type: ignore
     def client(self):
         """Abstract getter for the object client."""
         raise NotImplementedError

--- a/google/cloud/storage/batch.py
+++ b/google/cloud/storage/batch.py
@@ -23,8 +23,8 @@ from email.parser import Parser
 import io
 import json
 
-import requests
-import six
+import requests  # type: ignore
+import six  # type: ignore
 
 from google.cloud import _helpers
 from google.cloud import exceptions

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -37,14 +37,14 @@ import os
 import re
 import warnings
 
-import six
-from six.moves.urllib.parse import parse_qsl
+import six  # type: ignore
+from six.moves.urllib.parse import parse_qsl  # type: ignore
 from six.moves.urllib.parse import quote
 from six.moves.urllib.parse import urlencode
 from six.moves.urllib.parse import urlsplit
 from six.moves.urllib.parse import urlunsplit
 
-from google import resumable_media
+from google import resumable_media  # type: ignore
 from google.resumable_media.requests import ChunkedDownload
 from google.resumable_media.requests import Download
 from google.resumable_media.requests import RawDownload

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -20,8 +20,8 @@ import datetime
 import json
 import warnings
 
-import six
-from six.moves.urllib.parse import urlsplit
+import six  # type: ignore
+from six.moves.urllib.parse import urlsplit  # type: ignore
 
 from google.api_core import datetime_helpers
 from google.cloud._helpers import _datetime_to_rfc3339

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -25,7 +25,7 @@ import google.api_core.client_options
 
 from google.auth.credentials import AnonymousCredentials
 
-from google import resumable_media
+from google import resumable_media  # type: ignore
 
 from google.api_core import page_iterator
 from google.cloud._helpers import _LocalStack, _NOW

--- a/google/cloud/storage/retry.py
+++ b/google/cloud/storage/retry.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests
-import requests.exceptions as requests_exceptions
+import requests  # type: ignore
+import requests.exceptions as requests_exceptions  # type: ignore
 
 from google.api_core import exceptions as api_exceptions
 from google.api_core import retry
@@ -24,7 +24,7 @@ from google.auth import exceptions as auth_exceptions
 try:
     _RETRYABLE_STDLIB_TYPES = (ConnectionError,)
 except NameError:
-    _RETRYABLE_STDLIB_TYPES = ()
+    _RETRYABLE_STDLIB_TYPES = ()  # type: ignore
 
 
 _RETRYABLE_TYPES = _RETRYABLE_STDLIB_TYPES + (

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+python_version = 3.6
+namespace_packages = True
+ignore_missing_imports = True
+
+[mypy-google.protobuf]
+ignore_missing_imports = True


### PR DESCRIPTION
[WIP]: Works are in planning to deprecate Python2 this quarter. `py.typed` and `mypy.ini` files can be added to the library after the deprecation

- add py.typed file
- add mypy.ini file
- ensure mypy passes

```
mypy google/cloud/storage
Success: no issues found in 16 source files
```
```
mypy -p google.cloud.storage --no-incremental
Success: no issues found in 16 source files
```

Fixes #621
