### PR TITLE
test: update iam test public bucket visibility

### DIFF
--- a/samples/snippets/iam_test.py
+++ b/samples/snippets/iam_test.py
@@ -137,10 +137,13 @@ def test_remove_bucket_conditional_iam_binding(bucket):
 
 
 def test_set_bucket_public_iam(public_bucket):
-    storage_set_bucket_public_iam.set_bucket_public_iam(public_bucket.name)
+    # The test project has org policy restricting identities by domain.
+    # Testing "domain:google.com" instead of "allUsers"
+    storage_set_bucket_public_iam.set_bucket_public_iam(public_bucket.name, ["domain:google.com"])
     policy = public_bucket.get_iam_policy(requested_policy_version=3)
+
     assert any(
         binding["role"] == "roles/storage.objectViewer"
-        and "allUsers" in binding["members"]
+        and "domain:google.com" in binding["members"]
         for binding in policy.bindings
     )

--- a/samples/snippets/storage_set_bucket_public_iam.py
+++ b/samples/snippets/storage_set_bucket_public_iam.py
@@ -17,10 +17,15 @@
 import sys
 
 # [START storage_set_bucket_public_iam]
+from typing import List
+
 from google.cloud import storage
 
 
-def set_bucket_public_iam(bucket_name):
+def set_bucket_public_iam(
+    bucket_name: str = "your-bucket-name",
+    members: List[str] = ["allUsers"],
+):
     """Set a public IAM Policy to bucket"""
     # bucket_name = "your-bucket-name"
 
@@ -29,7 +34,7 @@ def set_bucket_public_iam(bucket_name):
 
     policy = bucket.get_iam_policy(requested_policy_version=3)
     policy.bindings.append(
-        {"role": "roles/storage.objectViewer", "members": {"allUsers"}}
+        {"role": "roles/storage.objectViewer", "members": members}
     )
 
     bucket.set_iam_policy(policy)


### PR DESCRIPTION
Fixes failing samples tests iam_test. Samples tests project org policy exemption was removed in b/203439385 and currently restricts identities by domain. 

This updates `samples/snippets/iam_test.py` public bucket visibility to google.com domain. Align changes with [PR](https://github.com/GoogleCloudPlatform/python-docs-samples/pull/6951)