### PR TITLE
docs: add contributing and authoring guides under samples/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,7 @@
 # The cloud-storage-dpe team is the default owner for anything not
 # explicitly taken by someone else.
 *                               @googleapis/cloud-storage-dpe @googleapis/yoshi-python
+
+# Additionally, the python-samples-owners team is also among 
+# the default owners for samples changes.
+/samples/   @googleapis/cloud-storage-dpe @googleapis/yoshi-python @googleapis/python-samples-owners

--- a/samples/AUTHORING_GUIDE.md
+++ b/samples/AUTHORING_GUIDE.md
@@ -1,0 +1,1 @@
+See https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md

--- a/samples/CONTRIBUTING.md
+++ b/samples/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Under the `samples/` subdirectory
- Add AUTHORING_GUIDE.md
- Add CONTRIBUTING.md
- Update CODEOWNERS for samples changes

Part of #627

