### PR TITLE
tests: replace spurious googleapis exception w/ api_core

### DIFF
--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,3 +1,2 @@
 google-cloud-pubsub==2.8.0
 google-cloud-storage==1.42.3
-google-api-python-client==2.25.0


### PR DESCRIPTION
Closes #630.

See https://github.com/googleapis/python-storage/pull/626#discussion_r735722629