### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "storage",
     "name_pretty": "Google Cloud Storage",
     "product_documentation": "https://cloud.google.com/storage",
-    "client_documentation": "https://googleapis.dev/python/storage/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/storage/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ via direct download.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-storage.svg
    :target: https://pypi.org/project/google-cloud-storage
 .. _Google Cloud Storage: https://cloud.google.com/storage/docs
-.. _Client Library Documentation: https://googleapis.dev/python/storage/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/storage/latest
 .. _Storage API docs: https://cloud.google.com/storage/docs/json_api/v1
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.