### PR TITLE
feat: add raw_download kwarg to BlobReader

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3850,6 +3850,10 @@ class Blob(_PropertyMixin):
             - ``timeout``
             - ``retry``
 
+            For downloads only, the following additional arguments are supported:
+
+            - ``raw_download``
+
             For uploads only, the following additional arguments are supported:
 
             - ``content_type``
@@ -3877,7 +3881,7 @@ class Blob(_PropertyMixin):
             >>> client = storage.Client()
             >>> bucket = client.bucket("bucket-name")
 
-            >>> blob = bucket.get_blob("blob-name.txt")
+            >>> blob = bucket.blob("blob-name.txt")
             >>> with blob.open("rt") as f:
             >>>     print(f.read())
 

--- a/google/cloud/storage/fileio.py
+++ b/google/cloud/storage/fileio.py
@@ -35,6 +35,7 @@ VALID_DOWNLOAD_KWARGS = {
     "if_metageneration_not_match",
     "timeout",
     "retry",
+    "raw_download",
 }
 
 # Valid keyword arguments for upload methods.

--- a/tests/unit/test_fileio.py
+++ b/tests/unit/test_fileio.py
@@ -109,6 +109,24 @@ class TestBlobReaderBinary(unittest.TestCase, _BlobReaderBase):
 
         reader.close()
 
+    def test_read_with_raw_download(self):
+        blob = mock.Mock()
+
+        def read_from_fake_data(start=0, end=None, **_):
+            return TEST_BINARY_DATA[start:end]
+
+        blob.download_as_bytes = mock.Mock(side_effect=read_from_fake_data)
+        download_kwargs = {"raw_download": True}
+        reader = self._make_blob_reader(blob, chunk_size=8, **download_kwargs)
+
+        # Read and trigger the first download of chunk_size.
+        self.assertEqual(reader.read(1), TEST_BINARY_DATA[0:1])
+        blob.download_as_bytes.assert_called_once_with(
+            start=0, end=8, checksum=None, retry=DEFAULT_RETRY, raw_download=True
+        )
+
+        reader.close()
+
     def test_retry_passed_through(self):
         blob = mock.Mock()
 


### PR DESCRIPTION
- Allow `raw_download` kwarg for `BlobReader`
- Add unit test
- Update docstrings for `blob.open()`

Fixes #666 🦕
