### PR TITLE
docs: use writeable streamin example for 'download_blob_to_file'

### DIFF
--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1065,7 +1065,7 @@ class Client(ClientWithProject):
             >>> bucket = client.get_bucket('my-bucket-name')
             >>> blob = storage.Blob('path/to/blob', bucket)
 
-            >>> with open('file-to-download-to') as file_obj:
+            >>> with open('file-to-download-to', 'w') as file_obj:
             >>>     client.download_blob_to_file(blob, file_obj)  # API request.
 
 
@@ -1074,7 +1074,7 @@ class Client(ClientWithProject):
             >>> from google.cloud import storage
             >>> client = storage.Client()
 
-            >>> with open('file-to-download-to') as file_obj:
+            >>> with open('file-to-download-to', 'w') as file_obj:
             >>>     client.download_blob_to_file(
             >>>         'gs://bucket_name/path/to/blob', file_obj)
 


### PR DESCRIPTION
The docstring shows an example of opening a file and passing the file handle to `download_blob_to_file`. However, this example must be untested, as it fails. The default mode for `open` is read-only. Instead, the file needs to be opened in some writeable model. This PR modifies the docstring example accordingly.