### PR TITLE
fix: project can be inferred from the environment and credentials upon client instantiation

### DIFF
--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -57,9 +57,6 @@ from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import ConditionalRetryPolicy
 
 
-_marker = object()
-
-
 class Client(ClientWithProject):
     """Client to bundle configuration needed for API requests.
 
@@ -104,22 +101,13 @@ class Client(ClientWithProject):
 
     def __init__(
         self,
-        project=_marker,
+        project=None,
         credentials=None,
         _http=None,
         client_info=None,
         client_options=None,
     ):
         self._base_connection = None
-
-        if project is None:
-            no_project = True
-            project = "<none>"
-        else:
-            no_project = False
-
-        if project is _marker:
-            project = None
 
         super(Client, self).__init__(
             project=project,
@@ -147,9 +135,6 @@ class Client(ClientWithProject):
             if client_options.api_endpoint:
                 api_endpoint = client_options.api_endpoint
                 kw_args["api_endpoint"] = api_endpoint
-
-        if no_project:
-            self.project = None
 
         self._connection = Connection(self, **kw_args)
         self._batch_stack = _LocalStack()

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -906,9 +906,6 @@ class Client(ClientWithProject):
         if project is None:
             project = self.project
 
-        if project is None:
-            raise ValueError("Client project not set:  pass an explicit project.")
-
         if requester_pays is not None:
             warnings.warn(
                 "requester_pays arg is deprecated. Use Bucket().requester_pays instead.",
@@ -917,7 +914,10 @@ class Client(ClientWithProject):
             )
             bucket.requester_pays = requester_pays
 
-        query_params = {"project": project}
+        query_params = {}
+
+        if project is not None:
+            query_params = {"project": project}
 
         if predefined_acl is not None:
             predefined_acl = BucketACL.validate_predefined(predefined_acl)
@@ -1348,10 +1348,10 @@ class Client(ClientWithProject):
         if project is None:
             project = self.project
 
-        if project is None:
-            raise ValueError("Client project not set:  pass an explicit project.")
+        extra_params = {}
 
-        extra_params = {"project": project}
+        if project is not None:
+            extra_params = {"project": project}
 
         if prefix is not None:
             extra_params["prefix"] = prefix

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -143,3 +143,10 @@ def test_download_blob_to_file_w_etag(
         "gs://" + shared_bucket.name + "/" + filename, buffer, if_etag_match=blob.etag,
     )
     assert buffer.getvalue() == payload
+
+
+def test_client_default_inferred_project():
+    from google.cloud.storage.client import Client
+
+    dp_storage_client = Client(project=None)
+    assert dp_storage_client.project is not None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -183,6 +183,7 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(credentials=credentials)
 
+        # project falls back to the default inferred from credentials
         self.assertEqual(client.project, PROJECT)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, credentials)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -196,7 +196,8 @@ class TestClient(unittest.TestCase):
 
         client = self._make_one(project=None, credentials=credentials)
 
-        self.assertIsNone(client.project)
+        # project falls back to the default inferred from the environment
+        self.assertIsNotNone(client.project)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, credentials)
         self.assertIsNone(client.current_batch)
@@ -213,7 +214,8 @@ class TestClient(unittest.TestCase):
             project=None, credentials=credentials, client_info=client_info
         )
 
-        self.assertIsNone(client.project)
+        # project falls back to the default inferred from the environment
+        self.assertIsNotNone(client.project)
         self.assertIsInstance(client._connection, Connection)
         self.assertIs(client._connection.credentials, credentials)
         self.assertIsNone(client.current_batch)
@@ -1129,7 +1131,9 @@ class TestClient(unittest.TestCase):
 
     def test_create_bucket_w_missing_client_project(self):
         credentials = _make_credentials()
-        client = self._make_one(project=None, credentials=credentials)
+        client = self._make_one(credentials=credentials)
+        # mock client project to be None
+        client.project = None
 
         with self.assertRaises(ValueError):
             client.create_bucket("bucket")
@@ -1729,7 +1733,9 @@ class TestClient(unittest.TestCase):
 
     def test_list_buckets_wo_project(self):
         credentials = _make_credentials()
-        client = self._make_one(project=None, credentials=credentials)
+        client = self._make_one(credentials=credentials)
+        # mock client project to be None
+        client.project = None
 
         with self.assertRaises(ValueError):
             client.list_buckets()


### PR DESCRIPTION
The storage `client` is expected to fall back to the default project inferred from the environment or credentials when a `project` is not explicitly passed in upon instantiation. 

This is the same behavior cited in the [documentation](https://github.com/googleapis/python-storage/blob/5e49e54adbf1fd1457d01df1ae2df63025ac7ae4/google/cloud/storage/client.py#L67-L69) as well as other client libraries (i.e. [BigQuery client](https://github.com/googleapis/python-bigquery/blob/881c081feb248e6a2b0d7ad72667924b959f8120/google/cloud/bigquery/client.py#L223)). The changes will also align with the [guidances](https://github.com/googleapis/python-cloud-core/issues/27) in the google-cloud-client [superclasses](https://github.com/googleapis/python-cloud-core/blob/main/google/cloud/client/__init__.py#L233-L280).

- revise storage.Client constructor
- remove extra client side validations
- update tests

Fixes #653 
Fixes #134 🦕