### PR TITLE
tests: add retry conf s8 test cases and data integrity checks

### DIFF
--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -1,0 +1,127 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import uuid
+
+import pytest
+
+from google.auth.credentials import AnonymousCredentials
+from google.cloud import storage
+from google.cloud.exceptions import NotFound
+from google.cloud.storage._helpers import _base64_md5hash
+
+
+"""Environment variable or default host for Storage testbench emulator."""
+_HOST = os.environ.get("STORAGE_EMULATOR_HOST", "http://localhost:9000")
+
+
+"""Emulated project information for the storage testbench."""
+_CONF_TEST_PROJECT_ID = "my-project-id"
+_CONF_TEST_SERVICE_ACCOUNT_EMAIL = (
+    "my-service-account@my-project-id.iam.gserviceaccount.com"
+)
+_CONF_TEST_PUBSUB_TOPIC_NAME = "my-topic-name"
+
+
+"""Utilize shared test data."""
+dirname = os.path.realpath(os.path.dirname(__file__))
+data_dirname = os.path.abspath(os.path.join(dirname, "..", "data"))
+_filenames = [
+    ("logo", "CloudPlatform_128px_Retina.png"),
+    ("simple", "simple.txt"),
+    ("big", "five-point-one-mb-file.zip"),
+]
+_file_data = {
+    key: {"path": os.path.join(data_dirname, file_name)}
+    for key, file_name in _filenames
+}
+
+_STRING_CONTENT = "hello world"
+
+
+########################################################################################################################################
+### Pytest Fixtures to Populate Retry Conformance Test Resources #######################################################################
+########################################################################################################################################
+
+
+@pytest.fixture
+def client():
+    client = storage.Client(
+        project=_CONF_TEST_PROJECT_ID,
+        credentials=AnonymousCredentials(),
+        client_options={"api_endpoint": _HOST},
+    )
+    return client
+
+
+@pytest.fixture
+def bucket(client):
+    bucket = client.bucket(uuid.uuid4().hex)
+    client.create_bucket(bucket)
+    yield bucket
+    try:
+        bucket.delete(force=True)
+    except NotFound:  # in cases where bucket is deleted within the test
+        pass
+
+
+@pytest.fixture
+def object(client, bucket):
+    blob = client.bucket(bucket.name).blob(uuid.uuid4().hex)
+    blob.upload_from_string(_STRING_CONTENT)
+    blob.reload()
+    yield blob
+    try:
+        blob.delete()
+    except NotFound:  # in cases where object is deleted within the test
+        pass
+
+
+@pytest.fixture
+def notification(client, bucket):
+    notification = client.bucket(bucket.name).notification(
+        topic_name=_CONF_TEST_PUBSUB_TOPIC_NAME
+    )
+    notification.create()
+    notification.reload()
+    yield notification
+    try:
+        notification.delete()
+    except NotFound:  # in cases where notification is deleted within the test
+        pass
+
+
+@pytest.fixture
+def hmac_key(client):
+    hmac_key, _secret = client.create_hmac_key(
+        service_account_email=_CONF_TEST_SERVICE_ACCOUNT_EMAIL,
+        project_id=_CONF_TEST_PROJECT_ID,
+    )
+    yield hmac_key
+    try:
+        hmac_key.state = "INACTIVE"
+        hmac_key.update()
+        hmac_key.delete()
+    except NotFound:  # in cases where hmac_key is deleted within the test
+        pass
+
+
+@pytest.fixture
+def file_data():
+    for file_data in _file_data.values():
+        with open(file_data["path"], "rb") as file_obj:
+            file_data["hash"] = _base64_md5hash(file_obj)
+
+    return _file_data

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -38,11 +38,11 @@ _CONF_TEST_PUBSUB_TOPIC_NAME = "my-topic-name"
 
 def _create_block(desired_kib):
     line = "abc123XYZ" * 14 + "!" + "\n"
-    return int(desired_kib / len(line)) * line
+    return 1024 * int(desired_kib / len(line)) * line
 
 
 _STRING_CONTENT = "hello world"
-_SIZE_16MB = 16 * 1024 * 1024
+_SIZE_16MB = 16384  # 16*1024 KiB
 
 
 ########################################################################################################################################

--- a/tests/conformance/retry_strategy_test_data.json
+++ b/tests/conformance/retry_strategy_test_data.json
@@ -254,10 +254,13 @@
         "cases": [
           {
             "instructions": ["return-broken-stream", "return-broken-stream"]
+          },
+          {
+            "instructions": ["return-broken-stream-after-256K"]
           }
         ],
         "methods": [
-          {"name": "storage.objects.get",                   "resources": ["BUCKET", "OBJECT"]}
+          {"name": "storage.objects.download",              "resources": ["BUCKET", "OBJECT"]}
         ],
         "preconditionProvided": false,
         "expectSuccess": true

--- a/tests/conformance/retry_strategy_test_data.json
+++ b/tests/conformance/retry_strategy_test_data.json
@@ -239,6 +239,28 @@
         ],
         "preconditionProvided": true,
         "expectSuccess": false
+      },
+      {
+        "id": 7,
+        "description": "resumable_uploads_handle_complex_retries",
+        "cases": [],
+        "methods": [],
+        "preconditionProvided": true,
+        "expectSuccess": true
+      },
+      {
+        "id": 8,
+        "description": "downloads_handle_complex_retries",
+        "cases": [
+          {
+            "instructions": ["return-broken-stream", "return-broken-stream"]
+          }
+        ],
+        "methods": [
+          {"name": "storage.objects.get",                   "resources": ["BUCKET", "OBJECT"]}
+        ],
+        "preconditionProvided": false,
+        "expectSuccess": true
       }
     ]
   }

--- a/tests/conformance/retry_strategy_test_data.json
+++ b/tests/conformance/retry_strategy_test_data.json
@@ -260,7 +260,7 @@
           }
         ],
         "methods": [
-          {"name": "storage.objects.download",              "resources": ["BUCKET", "OBJECT"]}
+          {"name": "storage.objects.get", "group": "storage.objects.download", "resources": ["BUCKET", "OBJECT"]}
         ],
         "preconditionProvided": false,
         "expectSuccess": true

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -944,11 +944,12 @@ with subprocess.Popen(_RUN_CMD) as proc:
         for i, c in enumerate(cases):
             for m in methods:
                 method_name = m["name"]
-                if method_name not in method_mapping:
+                method_group = m["group"] if m.get("group", None) else m["name"]
+                if method_group not in method_mapping:
                     logging.info("No tests for operation {}".format(method_name))
                     continue
 
-                for lib_func in method_mapping[method_name]:
+                for lib_func in method_mapping[method_group]:
                     test_name = "test-S{}-{}-{}-{}".format(
                         id, method_name, lib_func.__name__, i
                     )

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -24,12 +24,10 @@ import uuid
 
 import pytest
 import requests
-
-from six.moves.urllib import parse as urlparse
+import urllib
 
 from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
-from google.cloud.exceptions import NotFound
 from google.cloud.storage.hmac_key import HMACKeyMetadata
 
 from . import _read_local_json
@@ -39,7 +37,7 @@ _CONFORMANCE_TESTS = _read_local_json("retry_strategy_test_data.json")["retryTes
 
 """Environment variable or default host for Storage testbench emulator."""
 _HOST = os.environ.get("STORAGE_EMULATOR_HOST", "http://localhost:9000")
-_PORT = urlparse.urlsplit(_HOST).port
+_PORT = urllib.parse.urlsplit(_HOST).port
 
 """The storage testbench docker image info and commands."""
 _DEFAULT_IMAGE_NAME = "gcr.io/cloud-devrel-public-resources/storage-testbench"
@@ -79,39 +77,117 @@ def blob_exists(client, _preconditions, **resources):
 
 def blob_download_as_bytes(client, _preconditions, **resources):
     bucket = resources.get("bucket")
-    object = resources.get("object")
-    blob = client.bucket(bucket.name).blob(object.name)
-    blob.download_as_bytes()
+    file_data = resources.get("file_data")
+
+    for filename in ["simple", "logo"]:
+        info = file_data[filename]
+        payload = _read_payload(info["path"])
+
+        # upload test data file to the storage testbench bucket first
+        to_upload = client.bucket(bucket.name).blob(filename)
+        to_upload.upload_from_filename(info["path"])
+
+        # download the file and assert data integrity
+        blob = client.bucket(bucket.name).blob(filename)
+        stored_contents = blob.download_as_bytes()
+        assert stored_contents == payload
 
 
 def blob_download_as_text(client, _preconditions, **resources):
     bucket = resources.get("bucket")
     object = resources.get("object")
     blob = client.bucket(bucket.name).blob(object.name)
-    blob.download_as_text()
+    stored_contents = blob.download_as_text()
+    assert stored_contents == _STRING_CONTENT
 
 
 def blob_download_to_filename(client, _preconditions, **resources):
     bucket = resources.get("bucket")
-    object = resources.get("object")
-    blob = client.bucket(bucket.name).blob(object.name)
-    with tempfile.NamedTemporaryFile() as temp_f:
-        blob.download_to_filename(temp_f.name)
+    file_data = resources.get("file_data")
+
+    for filename in ["simple", "logo"]:
+        info = file_data[filename]
+        payload = _read_payload(info["path"])
+
+        # upload test data file to the storage testbench bucket first
+        to_upload = client.bucket(bucket.name).blob(filename)
+        to_upload.upload_from_filename(info["path"])
+
+        # download the file and assert data integrity
+        blob = client.bucket(bucket.name).blob(filename)
+        with tempfile.NamedTemporaryFile() as temp_f:
+            blob.download_to_filename(temp_f.name)
+            with open(temp_f.name, "rb") as file_obj:
+                stored_contents = file_obj.read()
+        assert stored_contents == payload
+
+
+def blob_download_to_filename_chunked(client, _preconditions, **resources):
+    bucket = resources.get("bucket")
+    file_data = resources.get("file_data")
+
+    for filename in ["simple", "logo"]:
+        info = file_data[filename]
+        payload = _read_payload(info["path"])
+
+        # upload test data file to the storage testbench bucket first
+        to_upload = client.bucket(bucket.name).blob(filename)
+        to_upload.upload_from_filename(info["path"])
+
+        # chunked download the file and assert data integrity
+        blob = client.bucket(bucket.name).blob(filename, chunk_size=256 * 1024)
+        with tempfile.NamedTemporaryFile() as temp_f:
+            blob.download_to_filename(temp_f.name)
+            with open(temp_f.name, "rb") as file_obj:
+                stored_contents = file_obj.read()
+        assert stored_contents == payload
 
 
 def client_download_blob_to_file(client, _preconditions, **resources):
-    object = resources.get("object")
-    with tempfile.NamedTemporaryFile() as temp_f:
-        with open(temp_f.name, "wb") as file_obj:
-            client.download_blob_to_file(object, file_obj)
+    bucket = resources.get("bucket")
+    file_data = resources.get("file_data")
+
+    for filename in ["simple", "logo"]:
+        info = file_data[filename]
+        payload = _read_payload(info["path"])
+
+        # upload test data file to the storage testbench bucket first
+        to_upload = client.bucket(bucket.name).blob(filename)
+        to_upload.upload_from_filename(info["path"])
+
+        # download the file and assert data integrity
+        blob = client.bucket(bucket.name).blob(filename)
+        with tempfile.NamedTemporaryFile() as temp_f:
+            with open(temp_f.name, "wb") as file_obj:
+                client.download_blob_to_file(blob, file_obj)
+            with open(temp_f.name, "rb") as to_read:
+                stored_contents = to_read.read()
+        assert stored_contents == payload
 
 
 def blobreader_read(client, _preconditions, **resources):
     bucket = resources.get("bucket")
-    object = resources.get("object")
-    blob = client.bucket(bucket.name).blob(object.name)
-    with blob.open() as reader:
-        reader.read()
+    file_data = resources.get("file_data")
+
+    for filename in ["simple", "logo"]:
+        info = file_data[filename]
+        payload = _read_payload(info["path"])
+        # upload test data file to the storage testbench bucket first
+        to_upload = client.bucket(bucket.name).blob(filename)
+        to_upload.upload_from_filename(info["path"])
+
+        # download the file and assert data integrity
+        blob = client.bucket(bucket.name).blob(filename)
+        with blob.open(mode="rb") as reader:
+            stored_contents = reader.read()
+        assert stored_contents == payload
+
+
+def _read_payload(file_path, mode="rb"):
+    """Helper method to read test data file payload."""
+    with open(file_path, mode=mode) as to_read:
+        payload = to_read.read()
+    return payload
 
 
 def client_list_blobs(client, _preconditions, **resources):
@@ -672,6 +748,7 @@ method_mapping = {
         blob_exists,
         client_download_blob_to_file,
         blob_download_to_filename,
+        blob_download_to_filename_chunked,
         blob_download_as_bytes,
         blob_download_as_text,
         blobreader_read,
@@ -723,73 +800,6 @@ method_mapping = {
 
 
 ########################################################################################################################################
-### Pytest Fixtures to Populate Resources ##############################################################################################
-########################################################################################################################################
-
-
-@pytest.fixture
-def client():
-    client = storage.Client(
-        project=_CONF_TEST_PROJECT_ID,
-        credentials=AnonymousCredentials(),
-        client_options={"api_endpoint": _HOST},
-    )
-    return client
-
-
-@pytest.fixture
-def bucket(client):
-    bucket = client.bucket(uuid.uuid4().hex)
-    client.create_bucket(bucket)
-    yield bucket
-    try:
-        bucket.delete(force=True)
-    except NotFound:  # in cases where bucket is deleted within the test
-        pass
-
-
-@pytest.fixture
-def object(client, bucket):
-    blob = client.bucket(bucket.name).blob(uuid.uuid4().hex)
-    blob.upload_from_string(_STRING_CONTENT)
-    blob.reload()
-    yield blob
-    try:
-        blob.delete()
-    except NotFound:  # in cases where object is deleted within the test
-        pass
-
-
-@pytest.fixture
-def notification(client, bucket):
-    notification = client.bucket(bucket.name).notification(
-        topic_name=_CONF_TEST_PUBSUB_TOPIC_NAME
-    )
-    notification.create()
-    notification.reload()
-    yield notification
-    try:
-        notification.delete()
-    except NotFound:  # in cases where notification is deleted within the test
-        pass
-
-
-@pytest.fixture
-def hmac_key(client):
-    hmac_key, _secret = client.create_hmac_key(
-        service_account_email=_CONF_TEST_SERVICE_ACCOUNT_EMAIL,
-        project_id=_CONF_TEST_PROJECT_ID,
-    )
-    yield hmac_key
-    try:
-        hmac_key.state = "INACTIVE"
-        hmac_key.update()
-        hmac_key.delete()
-    except NotFound:  # in cases where hmac_key is deleted within the test
-        pass
-
-
-########################################################################################################################################
 ### Helper Methods for Testbench Retry Test API ########################################################################################
 ########################################################################################################################################
 
@@ -833,7 +843,15 @@ def _get_retry_test(host, id):
 
 
 def _run_retry_test(
-    host, id, lib_func, _preconditions, bucket, object, notification, hmac_key
+    host,
+    id,
+    lib_func,
+    _preconditions,
+    bucket,
+    object,
+    notification,
+    hmac_key,
+    file_data,
 ):
     """
     To execute tests against the list of instrucions sent to the Retry Test API,
@@ -855,6 +873,7 @@ def _run_retry_test(
         object=object,
         notification=notification,
         hmac_key=hmac_key,
+        file_data=file_data,
     )
 
 
@@ -874,7 +893,16 @@ def _delete_retry_test(host, id):
 
 
 def run_test_case(
-    scenario_id, method, case, lib_func, host, bucket, object, notification, hmac_key
+    scenario_id,
+    method,
+    case,
+    lib_func,
+    host,
+    bucket,
+    object,
+    notification,
+    hmac_key,
+    file_data,
 ):
     scenario = _CONFORMANCE_TESTS[scenario_id - 1]
     expect_success = scenario["expectSuccess"]
@@ -901,6 +929,7 @@ def run_test_case(
             object,
             notification,
             hmac_key,
+            file_data,
         )
     except Exception as e:
         logging.exception(


### PR DESCRIPTION
This adds scenario 8 and data integrity checks to the retry conformance tests
- add s8 to test schema - tests downloads handle complex retries
- instruction cases `return-broken-stream` and `return-broken-stream-after-256K` simulate interrupted media mid-stream
- move fixtures to newly added `conftest.py` file
- create a 16MB payload/object fixture `file_data` to test large file complex downloads (and later on resumable uploads)
- add data integrity checks for downloads in the retry conf tests
