### PR TITLE
feat: allow no project in client methods using storage emulator

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -32,7 +32,11 @@ from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
 STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"
 """Environment variable defining host for Storage emulator."""
 
-_DEFAULT_STORAGE_HOST = u"https://storage.googleapis.com"
+_DEFAULT_STORAGE_HOST = "https://storage.googleapis.com"
+"""Default storage host for JSON API."""
+
+_BASE_STORAGE_URI = "storage.googleapis.com"
+"""Base request endpoint URI for JSON API."""
 
 # etag match parameters in snake case and equivalent header
 _ETAG_MATCH_PARAMETERS = (

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -33,6 +33,7 @@ from google.cloud.client import ClientWithProject
 from google.cloud.exceptions import NotFound
 from google.cloud.storage._helpers import _get_environ_project
 from google.cloud.storage._helpers import _get_storage_host
+from google.cloud.storage._helpers import _BASE_STORAGE_URI
 from google.cloud.storage._helpers import _DEFAULT_STORAGE_HOST
 from google.cloud.storage._helpers import _bucket_bound_hostname_url
 from google.cloud.storage._helpers import _add_etag_match_headers
@@ -146,7 +147,7 @@ class Client(ClientWithProject):
         # STORAGE_EMULATOR_HOST or a non-default api_endpoint is set.
         if (
             kw_args["api_endpoint"] is not None
-            and kw_args["api_endpoint"].find("storage.googleapis.com") < 0
+            and _BASE_STORAGE_URI not in kw_args["api_endpoint"]
         ):
             if credentials is None:
                 credentials = AnonymousCredentials()
@@ -938,14 +939,14 @@ class Client(ClientWithProject):
             project = self.project
 
         # Use no project if STORAGE_EMULATOR_HOST is set
-        if _get_storage_host().find("storage.googleapis.com") < 0:
+        if _BASE_STORAGE_URI not in _get_storage_host():
             if project is None:
                 project = _get_environ_project()
             if project is None:
                 project = "<none>"
 
         # Only include the project parameter if a project is set.
-        # If a project is not set, falls back to API validation (BadRequest). Removes client-side validation.
+        # If a project is not set, falls back to API validation (BadRequest).
         if project is not None:
             query_params = {"project": project}
 
@@ -1389,14 +1390,14 @@ class Client(ClientWithProject):
             project = self.project
 
         # Use no project if STORAGE_EMULATOR_HOST is set
-        if _get_storage_host().find("storage.googleapis.com") < 0:
+        if _BASE_STORAGE_URI not in _get_storage_host():
             if project is None:
                 project = _get_environ_project()
             if project is None:
                 project = "<none>"
 
         # Only include the project parameter if a project is set.
-        # If a project is not set, falls back to API validation (BadRequest). Removes client-side validation.
+        # If a project is not set, falls back to API validation (BadRequest).
         if project is not None:
             extra_params = {"project": project}
 


### PR DESCRIPTION
When using a storage emulator, allow no project/fake project marker in `client.create_bucket()` and `client.list_buckets()`

Alongside, this removes client-side validation and falls back to API validations. In this case, if a project is not set, instead of raising a `ValueError` in the client, the GCS server will return a `BadRequest` with message `Required parameter: project`


Fixes #699 
