### PR TITLE
cleanup: add turbo rep samples and fix spacing on fileio samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -63,8 +63,9 @@ for more detailed instructions.
 * [CORS Configuration](#cors-configuration)
 * [Create Bucket](#create-bucket)
 * [Create Bucket Class Location](#create-bucket-class-location)
+* [Create Bucket Locat]
 * [Create Bucket Notifications](#create-bucket-notifications)
-* [Create Bucket with Turbo Replication](#create-bucket-rpo)
+* [Create Bucket Turbo Replication](#create-bucket-turbo-replication)
 * [Create HMAC Key](#create-hmac-key)
 * [Deactivate HMAC Key](#deactivate-hmac-key)
 * [Define Bucket Website Configuration](#define-bucket-website-configuration)
@@ -104,7 +105,7 @@ for more detailed instructions.
 * [Get Public Access Prevention](#get-public-access-prevention)
 * [Get Requester Pays Status](#get-requester-pays-status)
 * [Get Retention Policy](#get-retention-policy)
-* [Get RPO (Recovery Point Objective)](#get-rpo)
+* [Get RPO](#get-rpo)
 * [Get Service Account](#get-service-account)
 * [Get Uniform Bucket Level Access](#get-uniform-bucket-level-access)
 * [List Buckets](#list-buckets)
@@ -141,9 +142,9 @@ for more detailed instructions.
 * [Set Metadata](#set-metadata)
 * [Set Public Access Prevention Enforced](#set-public-access-prevention-enforced)
 * [Set Public Access Prevention Inherited](#set-public-access-prevention-inherited)
-* [Set Retention Policy](#set-retention-policy)
+* [Set RPO Async Turbo](#set-rpo-async-turbo)
 * [Set RPO Default](#set-rpo-default)
-* [Set RPO Turbo Replication](#set-rpo-turbo)
+* [Set Retention Policy](#set-retention-policy)
 * [Set Temporary Hold](#set-temporary-hold)
 * [Upload Encrypted File](#upload-encrypted-file)
 * [Upload File](#upload-file)
@@ -326,7 +327,7 @@ View the [source code](https://github.com/googleapis/python-storage/blob/main/sa
 `python storage_create_bucket_notifications.py <BUCKET_NAME> <TOPIC_NAME>`
 
 -----
-### Create Bucket with Turbo Replication
+### Create Bucket Turbo Replication
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_create_bucket_turbo_replication.py,samples/README.md)
 
 View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_create_bucket_turbo_replication.py). To run this sample:
@@ -686,7 +687,7 @@ View the [source code](https://github.com/googleapis/python-storage/blob/main/sa
 `python storage_get_retention_policy.py <BUCKET_NAME>`
 
 -----
-### Get RPO (Recovery Point Objective)
+### Get RPO
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_get_rpo.py,samples/README.md)
 
 View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_get_rpo.py). To run this sample:
@@ -1027,6 +1028,16 @@ View the [source code](https://github.com/googleapis/python-storage/blob/main/sa
 
 `python storage_set_retention_policy.py <BUCKET_NAME> <RETENTION_PERIOD>`
 
+
+-----
+### Set RPO Async Turbo
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_set_rpo_async_turbo.py,samples/README.md)
+
+View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_set_rpo_async_turbo.py). To run this sample:
+
+
+`python storage_set_rpo_async_turbo.py <BUCKET_NAME>`
+
 -----
 ### Set RPO Default
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_set_rpo_default.py,samples/README.md)
@@ -1035,15 +1046,6 @@ View the [source code](https://github.com/googleapis/python-storage/blob/main/sa
 
 
 `python storage_set_rpo_default.py <BUCKET_NAME>`
-
------
-### Set RPO Turbo Replication
-[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_set_rpo_async_turbo.py,samples/README.md)
-
-View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_set_rpo_async_turbo.py). To run this sample:
-
-
-`python storage_set_rpo_async_turbo.py <BUCKET_NAME>`
 
 -----
 ### Set Temporary Hold

--- a/samples/README.md
+++ b/samples/README.md
@@ -64,6 +64,7 @@ for more detailed instructions.
 * [Create Bucket](#create-bucket)
 * [Create Bucket Class Location](#create-bucket-class-location)
 * [Create Bucket Notifications](#create-bucket-notifications)
+* [Create Bucket with Turbo Replication](#create-bucket-rpo)
 * [Create HMAC Key](#create-hmac-key)
 * [Deactivate HMAC Key](#deactivate-hmac-key)
 * [Define Bucket Website Configuration](#define-bucket-website-configuration)
@@ -88,8 +89,8 @@ for more detailed instructions.
 * [Enable Requester Pays](#enable-requester-pays)
 * [Enable Uniform Bucket Level Access](#enable-uniform-bucket-level-access)
 * [Enable Versioning](#enable-versioning)
-* [FileIO Write-Read] (#fileio-write-read)
-* [FileIO Pandas] (#fileio-pandas)
+* [FileIO Write-Read](#fileio-write-read)
+* [FileIO Pandas](#fileio-pandas)
 * [Generate Encryption Key](#generate-encryption-key)
 * [Generate Signed Post Policy V4](#generate-signed-post-policy-v4)
 * [Generate Signed Url V2](#generate-signed-url-v2)
@@ -103,6 +104,7 @@ for more detailed instructions.
 * [Get Public Access Prevention](#get-public-access-prevention)
 * [Get Requester Pays Status](#get-requester-pays-status)
 * [Get Retention Policy](#get-retention-policy)
+* [Get RPO (Recovery Point Objective)](#get-rpo)
 * [Get Service Account](#get-service-account)
 * [Get Uniform Bucket Level Access](#get-uniform-bucket-level-access)
 * [List Buckets](#list-buckets)
@@ -140,6 +142,8 @@ for more detailed instructions.
 * [Set Public Access Prevention Enforced](#set-public-access-prevention-enforced)
 * [Set Public Access Prevention Inherited](#set-public-access-prevention-inherited)
 * [Set Retention Policy](#set-retention-policy)
+* [Set RPO Default](#set-rpo-default)
+* [Set RPO Turbo Replication](#set-rpo-turbo)
 * [Set Temporary Hold](#set-temporary-hold)
 * [Upload Encrypted File](#upload-encrypted-file)
 * [Upload File](#upload-file)
@@ -320,6 +324,15 @@ View the [source code](https://github.com/googleapis/python-storage/blob/main/sa
 
 
 `python storage_create_bucket_notifications.py <BUCKET_NAME> <TOPIC_NAME>`
+
+-----
+### Create Bucket with Turbo Replication
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_create_bucket_turbo_replication.py,samples/README.md)
+
+View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_create_bucket_turbo_replication.py). To run this sample:
+
+
+`python storage_create_bucket_turbo_replication.py <BUCKET_NAME>`
 
 -----
 ### Create HMAC Key
@@ -673,6 +686,15 @@ View the [source code](https://github.com/googleapis/python-storage/blob/main/sa
 `python storage_get_retention_policy.py <BUCKET_NAME>`
 
 -----
+### Get RPO (Recovery Point Objective)
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_get_rpo.py,samples/README.md)
+
+View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_get_rpo.py). To run this sample:
+
+
+`python storage_get_rpo.py <BUCKET_NAME>`
+
+-----
 ### Get Service Account
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_get_service_account.py,samples/README.md)
 
@@ -1004,6 +1026,24 @@ View the [source code](https://github.com/googleapis/python-storage/blob/main/sa
 
 
 `python storage_set_retention_policy.py <BUCKET_NAME> <RETENTION_PERIOD>`
+
+-----
+### Set RPO Default
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_set_rpo_default.py,samples/README.md)
+
+View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_set_rpo_default.py). To run this sample:
+
+
+`python storage_set_rpo_default.py <BUCKET_NAME>`
+
+-----
+### Set RPO Turbo Replication
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/python-storage&page=editor&open_in_editor=samples/snippets/storage_set_rpo_async_turbo.py,samples/README.md)
+
+View the [source code](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_set_rpo_async_turbo.py). To run this sample:
+
+
+`python storage_set_rpo_async_turbo.py <BUCKET_NAME>`
 
 -----
 ### Set Temporary Hold

--- a/samples/README.md
+++ b/samples/README.md
@@ -63,7 +63,6 @@ for more detailed instructions.
 * [CORS Configuration](#cors-configuration)
 * [Create Bucket](#create-bucket)
 * [Create Bucket Class Location](#create-bucket-class-location)
-* [Create Bucket Locat]
 * [Create Bucket Notifications](#create-bucket-notifications)
 * [Create Bucket Turbo Replication](#create-bucket-turbo-replication)
 * [Create HMAC Key](#create-hmac-key)

--- a/samples/snippets/storage_create_bucket_location.py
+++ b/samples/snippets/storage_create_bucket_location.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+"""Sample that creates a new bucket in a specified region
+"""
+
+# [START storage_create_bucket_location]
+
+from google.cloud import storage
+
+
+def create_bucket_location(bucket_name, bucket_location):
+    """Creates bucket in specified region."""
+    # The ID of your GCS bucket
+    # bucket_name = "my-bucket"
+    # bucket_location = 'us-west1' # region
+    # bucket_location = 'nam4' # dual-region
+    # bucket_location = 'us' #multi-region
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    bucket.create(location=bucket_location)
+
+    print(f"{bucket.name} created in {bucket.location}.")
+
+
+# [END storage_create_bucket_location]
+
+if __name__ == "__main__":
+    create_bucket_location(bucket_name=sys.argv[1], bucket_location=sys.argv[2])


### PR DESCRIPTION
There was a space that shouldn't have been there for linking the fileio samples and looks like the turbo replication samples didn't get properly linked in the readme, so this fixes both of those.