### PR TITLE
fix: add user agent in python-storage when calling resumable media

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -581,3 +581,20 @@ def _api_core_retry_to_resumable_media_retry(retry, num_retries=None):
         return resumable_media.RetryStrategy(max_retries=num_retries)
     else:
         return resumable_media.RetryStrategy(max_retries=0)
+
+
+def _get_default_headers(user_agent):
+    """Get the headers for a request.
+
+    Args:
+        user_agent (str): The user-agent for requests.
+    Returns:
+        Dict: The headers to be used for the request.
+    """
+    return {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": user_agent,
+        "X-Goog-Api-Client": user_agent,
+        "content-type": "application/json",
+    }

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -583,7 +583,10 @@ def _api_core_retry_to_resumable_media_retry(retry, num_retries=None):
         return resumable_media.RetryStrategy(max_retries=0)
 
 
-def _get_default_headers(user_agent, content_type="application/json; charset='UTF-8"):
+def _get_default_headers(
+    user_agent,
+    content_type="application/json; charset='UTF-8",
+    x_upload_content_type=None):
     """Get the headers for a request.
 
     Args:
@@ -597,5 +600,5 @@ def _get_default_headers(user_agent, content_type="application/json; charset='UT
         "User-Agent": user_agent,
         "x-goog-api-client": user_agent,
         "content-type": content_type,
-        "x-upload-content-type": content_type, 
+        "x-upload-content-type": x_upload_content_type or content_type, 
     }

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -583,7 +583,7 @@ def _api_core_retry_to_resumable_media_retry(retry, num_retries=None):
         return resumable_media.RetryStrategy(max_retries=0)
 
 
-def _get_default_headers(user_agent):
+def _get_default_headers(user_agent, content_type="application/json; charset='UTF-8"):
     """Get the headers for a request.
 
     Args:
@@ -595,6 +595,7 @@ def _get_default_headers(user_agent):
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "User-Agent": user_agent,
-        "X-Goog-Api-Client": user_agent,
-        "content-type": "application/json",
+        "x-goog-api-client": user_agent,
+        "content-type": content_type,
+        "x-upload-content-type": content_type, 
     }

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -585,7 +585,7 @@ def _api_core_retry_to_resumable_media_retry(retry, num_retries=None):
 
 def _get_default_headers(
     user_agent,
-    content_type='application/json; charset=UTF-8',
+    content_type="application/json; charset=UTF-8",
     x_upload_content_type=None,
 ):
     """Get the headers for a request.

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -585,7 +585,7 @@ def _api_core_retry_to_resumable_media_retry(retry, num_retries=None):
 
 def _get_default_headers(
     user_agent,
-    content_type="application/json; charset='UTF-8",
+    content_type='application/json; charset=UTF-8',
     x_upload_content_type=None,
 ):
     """Get the headers for a request.

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -586,7 +586,8 @@ def _api_core_retry_to_resumable_media_retry(retry, num_retries=None):
 def _get_default_headers(
     user_agent,
     content_type="application/json; charset='UTF-8",
-    x_upload_content_type=None):
+    x_upload_content_type=None,
+):
     """Get the headers for a request.
 
     Args:
@@ -600,5 +601,5 @@ def _get_default_headers(
         "User-Agent": user_agent,
         "x-goog-api-client": user_agent,
         "content-type": content_type,
-        "x-upload-content-type": x_upload_content_type or content_type, 
+        "x-upload-content-type": x_upload_content_type or content_type,
     }

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -1865,7 +1865,7 @@ class Blob(_PropertyMixin):
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
         info = self._get_upload_arguments(client, content_type)
-        print(info)
+        #print(info)
         headers, object_metadata, content_type = info
 
         hostname = _get_host_name(client._connection)

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -1865,7 +1865,6 @@ class Blob(_PropertyMixin):
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
         info = self._get_upload_arguments(client, content_type)
-        #print(info)
         headers, object_metadata, content_type = info
 
         hostname = _get_host_name(client._connection)
@@ -2051,7 +2050,6 @@ class Blob(_PropertyMixin):
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
         info = self._get_upload_arguments(client, content_type)
-        print(info)
         headers, object_metadata, content_type = info
         if extra_headers is not None:
             headers.update(extra_headers)
@@ -2236,7 +2234,6 @@ class Blob(_PropertyMixin):
             checksum=checksum,
             retry=retry,
         )
-
         while not upload.finished:
             try:
                 response = upload.transmit_next_chunk(transport, timeout=timeout)
@@ -2244,7 +2241,6 @@ class Blob(_PropertyMixin):
                 # Attempt to delete the corrupted object.
                 self.delete()
                 raise
-
         return response
 
     def _do_upload(

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -1721,7 +1721,7 @@ class Blob(_PropertyMixin):
 
         return object_metadata
 
-    def _get_upload_arguments(self, content_type):
+    def _get_upload_arguments(self, client, content_type):
         """Get required arguments for performing an upload.
 
         The content type returned will be determined in order of precedence:
@@ -1740,12 +1740,12 @@ class Blob(_PropertyMixin):
                   * An object metadata dictionary
                   * The ``content_type`` as a string (according to precedence)
         """
+        content_type = self._get_content_type(content_type)
         headers = {
+            **_get_default_headers(client._connection.user_agent, content_type),
             **_get_encryption_headers(self._encryption_key),
-            **_get_default_headers(self.bucket.client._connection.user_agent)
         }
         object_metadata = self._get_writable_metadata()
-        content_type = self._get_content_type(content_type)
         return headers, object_metadata, content_type
 
     def _do_multipart_upload(
@@ -1864,7 +1864,8 @@ class Blob(_PropertyMixin):
         transport = self._get_transport(client)
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
-        info = self._get_upload_arguments(content_type)
+        info = self._get_upload_arguments(client, content_type)
+        print(info)
         headers, object_metadata, content_type = info
 
         hostname = _get_host_name(client._connection)
@@ -2049,7 +2050,8 @@ class Blob(_PropertyMixin):
         transport = self._get_transport(client)
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
-        info = self._get_upload_arguments(content_type)
+        info = self._get_upload_arguments(client, content_type)
+        print(info)
         headers, object_metadata, content_type = info
         if extra_headers is not None:
             headers.update(extra_headers)

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -64,6 +64,7 @@ from google.cloud.storage._helpers import _scalar_property
 from google.cloud.storage._helpers import _bucket_bound_hostname_url
 from google.cloud.storage._helpers import _raise_if_more_than_one_set
 from google.cloud.storage._helpers import _api_core_retry_to_resumable_media_retry
+from google.cloud.storage._helpers import _get_default_headers
 from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage._helpers import _NUM_RETRIES_MESSAGE
@@ -979,11 +980,6 @@ class Blob(_PropertyMixin):
             (google.cloud.storage.retry) for information on retry types and how
             to configure them.
         """
-
-        headers = {
-            **headers,
-            **_get_default_headers(self.bucket.client._connection.user_agent)
-        }
 
         retry_strategy = _api_core_retry_to_resumable_media_retry(retry)
 
@@ -4409,23 +4405,6 @@ def _get_encryption_headers(key, source=False):
         prefix + "Algorithm": "AES256",
         prefix + "Key": _bytes_to_unicode(key),
         prefix + "Key-Sha256": _bytes_to_unicode(key_hash),
-    }
-
-
-def _get_default_headers(user_agent):
-    """Get the headers for a request.
-
-    Args:
-        user_agent (str): The user-agent for requests.
-    Returns:
-        Dict: The headers to be used for the request.
-    """
-    return {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, deflate",
-        "User-Agent": user_agent,
-        "X-Goog-Api-Client": user_agent,
-        "content-type": "application/json",
     }
 
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -980,6 +980,11 @@ class Blob(_PropertyMixin):
             to configure them.
         """
 
+        headers = {
+            **headers,
+            **_get_default_headers(self.bucket.client._connection.user_agent)
+        }
+
         retry_strategy = _api_core_retry_to_resumable_media_retry(retry)
 
         if self.chunk_size is None:
@@ -1739,7 +1744,10 @@ class Blob(_PropertyMixin):
                   * An object metadata dictionary
                   * The ``content_type`` as a string (according to precedence)
         """
-        headers = _get_encryption_headers(self._encryption_key)
+        headers = {
+            **_get_encryption_headers(self._encryption_key),
+            **_get_default_headers(self.bucket.client._connection.user_agent)
+        }
         object_metadata = self._get_writable_metadata()
         content_type = self._get_content_type(content_type)
         return headers, object_metadata, content_type
@@ -4401,6 +4409,23 @@ def _get_encryption_headers(key, source=False):
         prefix + "Algorithm": "AES256",
         prefix + "Key": _bytes_to_unicode(key),
         prefix + "Key-Sha256": _bytes_to_unicode(key_hash),
+    }
+
+
+def _get_default_headers(user_agent):
+    """Get the headers for a request.
+
+    Args:
+        user_agent (str): The user-agent for requests.
+    Returns:
+        Dict: The headers to be used for the request.
+    """
+    return {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": user_agent,
+        "X-Goog-Api-Client": user_agent,
+        "content-type": "application/json",
     }
 
 

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -31,6 +31,7 @@ from google.api_core import page_iterator
 from google.cloud._helpers import _LocalStack, _NOW
 from google.cloud.client import ClientWithProject
 from google.cloud.exceptions import NotFound
+from google.cloud.storage._helpers import _get_default_headers
 from google.cloud.storage._helpers import _get_environ_project
 from google.cloud.storage._helpers import _get_storage_host
 from google.cloud.storage._helpers import _BASE_STORAGE_URI
@@ -1131,6 +1132,10 @@ class Client(ClientWithProject):
         _add_etag_match_headers(
             headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match,
         )
+        headers = {
+            **headers,
+            **_get_default_headers(self._connection.user_agent)
+        }
 
         transport = self._http
         try:

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1137,9 +1137,6 @@ class Client(ClientWithProject):
             **headers
         }
 
-        #print("HERE")
-        #print(headers)
-
         transport = self._http
         try:
             blob_or_uri._do_download(

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1133,9 +1133,12 @@ class Client(ClientWithProject):
             headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match,
         )
         headers = {
-            **headers,
-            **_get_default_headers(self._connection.user_agent)
+            **_get_default_headers(self._connection.user_agent),
+            **headers
         }
+
+        print("HERE")
+        print(headers)
 
         transport = self._http
         try:

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1137,8 +1137,8 @@ class Client(ClientWithProject):
             **headers
         }
 
-        print("HERE")
-        print(headers)
+        #print("HERE")
+        #print(headers)
 
         transport = self._http
         try:

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1132,10 +1132,7 @@ class Client(ClientWithProject):
         _add_etag_match_headers(
             headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match,
         )
-        headers = {
-            **_get_default_headers(self._connection.user_agent),
-            **headers
-        }
+        headers = {**_get_default_headers(self._connection.user_agent), **headers}
 
         transport = self._http
         try:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
     "google-auth >= 1.25.0, < 3.0dev",
     "google-api-core >= 1.29.0, < 3.0dev",
     "google-cloud-core >= 1.6.0, < 3.0dev",
-    "google-resumable-media >= 1.3.0",
+    "google-resumable-media >= 2.3.1",
     "requests >= 2.18.0, < 3.0.0dev",
     "protobuf",
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
     "google-auth >= 1.25.0, < 3.0dev",
     "google-api-core >= 1.29.0, < 3.0dev",
     "google-cloud-core >= 1.6.0, < 3.0dev",
-    "google-resumable-media >= 2.3.1",
+    "google-resumable-media >= 2.3.2",
     "requests >= 2.18.0, < 3.0.0dev",
     "protobuf",
 ]

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -2370,7 +2370,7 @@ class Test_Blob(unittest.TestCase):
             + data_read
             + b"\r\n--==0==--"
         )
-        headers = _get_default_headers(client._connection.user_agent, 'multipart/related; boundary="==0=="')
+        headers = _get_default_headers(client._connection.user_agent, b'multipart/related; boundary="==0=="', "application/xml")
         client._http.request.assert_called_once_with(
             "POST", upload_url, data=payload, headers=headers, timeout=expected_timeout
         )
@@ -2901,6 +2901,7 @@ class Test_Blob(unittest.TestCase):
         resumable_url = "http://test.invalid?upload_id=and-then-there-was-1"
         headers1 = {"location": resumable_url}
         headers2 = {"range": "bytes=0-{:d}".format(blob.chunk_size - 1)}
+        #headers3 = _get_default_headers()
         transport, responses = self._make_resumable_transport(
             headers1, headers2, {}, total_bytes, data_corruption=data_corruption
         )
@@ -2975,6 +2976,7 @@ class Test_Blob(unittest.TestCase):
             if_metageneration_not_match=if_metageneration_not_match,
             timeout=expected_timeout,
         )
+        print(transport.request.mock_calls)
         self.assertEqual(transport.request.mock_calls, [call0, call1, call2])
 
     def test__do_resumable_upload_with_custom_timeout(self):

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -26,6 +26,7 @@ from urllib.parse import urlencode
 import mock
 import pytest
 
+from google.cloud.storage._helpers import _get_default_headers
 from google.cloud.storage.retry import (
     DEFAULT_RETRY,
     DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
@@ -3556,6 +3557,8 @@ class Test_Blob(unittest.TestCase):
         upload_url += "?" + urlencode(qs_params)
         payload = b'{"name": "blob-name"}'
         expected_headers = {
+            #**_get_default_headers(client._connection.user_agent), 
+            "accept-encoding": "gzip",
             "content-type": "application/json; charset=UTF-8",
             "x-upload-content-length": str(size),
             "x-upload-content-type": content_type,
@@ -5739,6 +5742,7 @@ class _Connection(object):
 
     API_BASE_URL = "http://example.com"
     USER_AGENT = "testing 1.2.3"
+    user_agent = "testing 1.2.3"
     credentials = object()
 
 

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -2672,7 +2672,7 @@ class Test_Blob(unittest.TestCase):
             blob._get_writable_metadata.assert_called_once_with()
         payload = json.dumps(object_metadata).encode("utf-8")
         expected_headers = _get_default_headers(
-            client._connection.user_agent, content_type
+            client._connection.user_agent, x_upload_content_type=content_type
         )
         if size is not None:
             expected_headers["x-upload-content-length"] = str(size)
@@ -2812,7 +2812,7 @@ class Test_Blob(unittest.TestCase):
         if predefined_acl is not None:
             upload_url += "&predefinedAcl={}".format(predefined_acl)
         expected_headers = _get_default_headers(
-            client._connection.user_agent, content_type
+            client._connection.user_agent, x_upload_content_type=content_type
         )
         if size is not None:
             expected_headers["x-upload-content-length"] = str(size)
@@ -2843,7 +2843,7 @@ class Test_Blob(unittest.TestCase):
             content_range = "bytes 0-{:d}/{:d}".format(blob.chunk_size - 1, size)
 
         expected_headers = {
-            **_get_default_headers(client._connection.user_agent, content_type),
+            **_get_default_headers(client._connection.user_agent, x_upload_content_type=content_type),
             "content-type": content_type,
             "content-range": content_range,
         }
@@ -2876,7 +2876,7 @@ class Test_Blob(unittest.TestCase):
             blob.chunk_size, total_bytes - 1, total_bytes
         )
         expected_headers = {
-            **_get_default_headers(client._connection.user_agent, content_type),
+            **_get_default_headers(client._connection.user_agent, x_upload_content_type=content_type),
             "content-type": content_type,
             "content-range": content_range,
         }
@@ -3588,7 +3588,7 @@ class Test_Blob(unittest.TestCase):
         upload_url += "?" + urlencode(qs_params)
         payload = b'{"name": "blob-name"}'
         expected_headers = {
-            **_get_default_headers(client._connection.user_agent, content_type),
+            **_get_default_headers(client._connection.user_agent, x_upload_content_type=content_type),
             "x-upload-content-length": str(size),
             "x-upload-content-type": content_type,
         }

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -18,7 +18,6 @@ import hashlib
 import io
 import json
 import os
-from pydoc import cli
 import tempfile
 import unittest
 import http.client
@@ -2222,7 +2221,6 @@ class Test_Blob(unittest.TestCase):
         content_type = u"image/jpeg"
         info = blob._get_upload_arguments(client, content_type)
 
-        self.maxDiff = None
         headers, object_metadata, new_content_type = info
         header_key_value = "W3BYd0AscEBAQWZCZnJSM3gtMmIyU0NIUiwuP1l3Uk8="
         header_key_hash_value = "G0++dxF4q5rG4o9kE8gvEKn15RH6wLm0wXV1MgAlXOg="
@@ -2232,7 +2230,6 @@ class Test_Blob(unittest.TestCase):
             "X-Goog-Encryption-Key": header_key_value,
             "X-Goog-Encryption-Key-Sha256": header_key_hash_value,
         }
-        print(expected_headers)
         self.assertEqual(headers, expected_headers)
         expected_metadata = {
             "contentDisposition": blob.content_disposition,
@@ -2769,7 +2766,6 @@ class Test_Blob(unittest.TestCase):
         fake_response2 = self._mock_requests_response(
             resumable_media.PERMANENT_REDIRECT, headers2
         )
-        print("hello", headers2)
         json_body = '{{"size": "{:d}"}}'.format(total_bytes)
         if data_corruption:
             fake_response3 = resumable_media.DataCorruption(None)
@@ -2780,7 +2776,6 @@ class Test_Blob(unittest.TestCase):
 
         responses = [fake_response1, fake_response2, fake_response3]
         fake_transport.request.side_effect = responses
-        print('here1')
         return fake_transport, responses
 
     @staticmethod
@@ -2805,8 +2800,6 @@ class Test_Blob(unittest.TestCase):
         if predefined_acl is not None:
             upload_url += "&predefinedAcl={}".format(predefined_acl)
         expected_headers = _get_default_headers(client._connection.user_agent, content_type)
-
-
         if size is not None:
             expected_headers["x-upload-content-length"] = str(size)
         payload = json.dumps({"name": blob.name}).encode("utf-8")
@@ -2840,9 +2833,6 @@ class Test_Blob(unittest.TestCase):
             "content-type": content_type,
             "content-range": content_range,
         }
-
-        print("expected", expected_headers)
-
         payload = data[: blob.chunk_size]
         return mock.call(
             "PUT",
@@ -2898,11 +2888,11 @@ class Test_Blob(unittest.TestCase):
         data_corruption=False,
         retry=None,
     ):
-        chunk_size = 256*1024
+        CHUNK_SIZE = 256*1024
         USER_AGENT = 'testing 1.2.3'
         content_type = u"text/html"
         # Data to be uploaded.
-        data = b"<html>" + (b"A" * chunk_size) + b"</html>"
+        data = b"<html>" + (b"A" * CHUNK_SIZE) + b"</html>"
         total_bytes = len(data)
         if use_size:
             size = total_bytes
@@ -2912,7 +2902,7 @@ class Test_Blob(unittest.TestCase):
         # Create mocks to be checked for doing transport.
         resumable_url = "http://test.invalid?upload_id=and-then-there-was-1"
         headers1 = {**_get_default_headers(USER_AGENT, content_type), "location": resumable_url}
-        headers2 = {**_get_default_headers(USER_AGENT, content_type), "range": "bytes=0-{:d}".format(chunk_size - 1)}
+        headers2 = {**_get_default_headers(USER_AGENT, content_type), "range": "bytes=0-{:d}".format(CHUNK_SIZE - 1)}
         headers3 = _get_default_headers(USER_AGENT, content_type)
         transport, responses = self._make_resumable_transport(
             headers1, headers2, headers3, total_bytes, data_corruption=data_corruption
@@ -2936,7 +2926,6 @@ class Test_Blob(unittest.TestCase):
             expected_timeout = timeout
             timeout_kwarg = {"timeout": timeout}
 
-        #import pdb; pdb.set_trace()
         response = blob._do_resumable_upload(
             client,
             stream,
@@ -2951,8 +2940,6 @@ class Test_Blob(unittest.TestCase):
             retry=retry,
             **timeout_kwarg
         )
-        print('break post resumable')
-        #import pdb; pdb.set_trace()
 
         # Check the returned values.
         self.assertIs(response, responses[2])
@@ -2999,14 +2986,7 @@ class Test_Blob(unittest.TestCase):
             if_metageneration_not_match=if_metageneration_not_match,
             timeout=expected_timeout,
         )
-        #print(type(call1))
-        #print(transport.request.mock_calls[1])
-        #print(call1)
-        #import pdb
-        #pdb.set_trace()
-        #transport.request.mock_calls[1]
-        self.assertEqual(transport.request.mock_calls[1], call1)
-        #self.assertEqual(transport.request.mock_calls, [call0, call1, call2])
+        self.assertEqual(transport.request.mock_calls, [call0, call1, call2])
 
     def test__do_resumable_upload_with_custom_timeout(self):
         self._do_resumable_helper(timeout=9.58)

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -2843,7 +2843,9 @@ class Test_Blob(unittest.TestCase):
             content_range = "bytes 0-{:d}/{:d}".format(blob.chunk_size - 1, size)
 
         expected_headers = {
-            **_get_default_headers(client._connection.user_agent, x_upload_content_type=content_type),
+            **_get_default_headers(
+                client._connection.user_agent, x_upload_content_type=content_type
+            ),
             "content-type": content_type,
             "content-range": content_range,
         }
@@ -2876,7 +2878,9 @@ class Test_Blob(unittest.TestCase):
             blob.chunk_size, total_bytes - 1, total_bytes
         )
         expected_headers = {
-            **_get_default_headers(client._connection.user_agent, x_upload_content_type=content_type),
+            **_get_default_headers(
+                client._connection.user_agent, x_upload_content_type=content_type
+            ),
             "content-type": content_type,
             "content-range": content_range,
         }
@@ -3588,7 +3592,9 @@ class Test_Blob(unittest.TestCase):
         upload_url += "?" + urlencode(qs_params)
         payload = b'{"name": "blob-name"}'
         expected_headers = {
-            **_get_default_headers(client._connection.user_agent, x_upload_content_type=content_type),
+            **_get_default_headers(
+                client._connection.user_agent, x_upload_content_type=content_type
+            ),
             "x-upload-content-length": str(size),
             "x-upload-content-type": content_type,
         }

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -2372,7 +2372,11 @@ class Test_Blob(unittest.TestCase):
             + data_read
             + b"\r\n--==0==--"
         )
-        headers = _get_default_headers(client._connection.user_agent, b'multipart/related; boundary="==0=="', "application/xml")
+        headers = _get_default_headers(
+            client._connection.user_agent,
+            b'multipart/related; boundary="==0=="',
+            "application/xml",
+        )
         client._http.request.assert_called_once_with(
             "POST", upload_url, data=payload, headers=headers, timeout=expected_timeout
         )
@@ -2618,9 +2622,15 @@ class Test_Blob(unittest.TestCase):
 
         self.assertEqual(upload.upload_url, upload_url)
         if extra_headers is None:
-            self.assertEqual(upload._headers, _get_default_headers(client._connection.user_agent, content_type))
+            self.assertEqual(
+                upload._headers,
+                _get_default_headers(client._connection.user_agent, content_type),
+            )
         else:
-            expected_headers = {**_get_default_headers(client._connection.user_agent, content_type), **extra_headers}
+            expected_headers = {
+                **_get_default_headers(client._connection.user_agent, content_type),
+                **extra_headers,
+            }
             self.assertEqual(upload._headers, expected_headers)
             self.assertIsNot(upload._headers, expected_headers)
         self.assertFalse(upload.finished)
@@ -2661,7 +2671,9 @@ class Test_Blob(unittest.TestCase):
             # Check the mocks.
             blob._get_writable_metadata.assert_called_once_with()
         payload = json.dumps(object_metadata).encode("utf-8")
-        expected_headers = _get_default_headers(client._connection.user_agent, content_type)
+        expected_headers = _get_default_headers(
+            client._connection.user_agent, content_type
+        )
         if size is not None:
             expected_headers["x-upload-content-length"] = str(size)
         if extra_headers is not None:
@@ -2799,7 +2811,9 @@ class Test_Blob(unittest.TestCase):
         )
         if predefined_acl is not None:
             upload_url += "&predefinedAcl={}".format(predefined_acl)
-        expected_headers = _get_default_headers(client._connection.user_agent, content_type)
+        expected_headers = _get_default_headers(
+            client._connection.user_agent, content_type
+        )
         if size is not None:
             expected_headers["x-upload-content-length"] = str(size)
         payload = json.dumps({"name": blob.name}).encode("utf-8")
@@ -2864,7 +2878,7 @@ class Test_Blob(unittest.TestCase):
         expected_headers = {
             **_get_default_headers(client._connection.user_agent, content_type),
             "content-type": content_type,
-            "content-range": content_range
+            "content-range": content_range,
         }
         payload = data[blob.chunk_size :]
         return mock.call(
@@ -2888,8 +2902,8 @@ class Test_Blob(unittest.TestCase):
         data_corruption=False,
         retry=None,
     ):
-        CHUNK_SIZE = 256*1024
-        USER_AGENT = 'testing 1.2.3'
+        CHUNK_SIZE = 256 * 1024
+        USER_AGENT = "testing 1.2.3"
         content_type = u"text/html"
         # Data to be uploaded.
         data = b"<html>" + (b"A" * CHUNK_SIZE) + b"</html>"
@@ -2901,8 +2915,14 @@ class Test_Blob(unittest.TestCase):
 
         # Create mocks to be checked for doing transport.
         resumable_url = "http://test.invalid?upload_id=and-then-there-was-1"
-        headers1 = {**_get_default_headers(USER_AGENT, content_type), "location": resumable_url}
-        headers2 = {**_get_default_headers(USER_AGENT, content_type), "range": "bytes=0-{:d}".format(CHUNK_SIZE - 1)}
+        headers1 = {
+            **_get_default_headers(USER_AGENT, content_type),
+            "location": resumable_url,
+        }
+        headers2 = {
+            **_get_default_headers(USER_AGENT, content_type),
+            "range": "bytes=0-{:d}".format(CHUNK_SIZE - 1),
+        }
         headers3 = _get_default_headers(USER_AGENT, content_type)
         transport, responses = self._make_resumable_transport(
             headers1, headers2, headers3, total_bytes, data_corruption=data_corruption

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1568,7 +1568,10 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(file_obj.tell(), 0)
 
-        headers = {**_get_default_headers(client._connection.user_agent), "accept-encoding": "gzip"}
+        headers = {
+            **_get_default_headers(client._connection.user_agent),
+            "accept-encoding": "gzip",
+        }
         blob._do_download.assert_called_once_with(
             client._http,
             file_obj,
@@ -1599,7 +1602,10 @@ class TestClient(unittest.TestCase):
         ):
             client.download_blob_to_file("gs://bucket_name/path/to/object", file_obj)
 
-        headers = {**_get_default_headers(client._connection.user_agent), "accept-encoding": "gzip"}
+        headers = {
+            **_get_default_headers(client._connection.user_agent),
+            "accept-encoding": "gzip",
+        }
         blob._do_download.assert_called_once_with(
             client._http,
             file_obj,
@@ -1715,10 +1721,7 @@ class TestClient(unittest.TestCase):
                 if_etag_not_match = [if_etag_not_match]
             headers["If-None-Match"] = ", ".join(if_etag_not_match)
 
-        headers = {
-            **_get_default_headers(client._connection.user_agent),
-            **headers
-        }
+        headers = {**_get_default_headers(client._connection.user_agent), **headers}
         blob._do_download.assert_called_once_with(
             client._http,
             file_obj,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -28,6 +28,7 @@ from google.auth.credentials import AnonymousCredentials
 from google.oauth2.service_account import Credentials
 
 from google.cloud.storage._helpers import STORAGE_EMULATOR_ENV_VAR
+from google.cloud.storage._helpers import _get_default_headers
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_GENERATION_SPECIFIED
 
@@ -1567,7 +1568,7 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(file_obj.tell(), 0)
 
-        headers = {"accept-encoding": "gzip"}
+        headers = {**_get_default_headers(client._connection.user_agent), "accept-encoding": "gzip"}
         blob._do_download.assert_called_once_with(
             client._http,
             file_obj,
@@ -1598,7 +1599,7 @@ class TestClient(unittest.TestCase):
         ):
             client.download_blob_to_file("gs://bucket_name/path/to/object", file_obj)
 
-        headers = {"accept-encoding": "gzip"}
+        headers = {**_get_default_headers(client._connection.user_agent), "accept-encoding": "gzip"}
         blob._do_download.assert_called_once_with(
             client._http,
             file_obj,
@@ -1714,6 +1715,10 @@ class TestClient(unittest.TestCase):
                 if_etag_not_match = [if_etag_not_match]
             headers["If-None-Match"] = ", ".join(if_etag_not_match)
 
+        headers = {
+            **_get_default_headers(client._connection.user_agent),
+            **headers
+        }
         blob._do_download.assert_called_once_with(
             client._http,
             file_obj,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: add user agent in python-storage when calling resumable media
END_COMMIT_OVERRIDE