### PR TITLE
fix: retry client side requests timeout

### DIFF
--- a/google/cloud/storage/retry.py
+++ b/google/cloud/storage/retry.py
@@ -29,6 +29,7 @@ _RETRYABLE_TYPES = (
     ConnectionError,
     requests.ConnectionError,
     requests_exceptions.ChunkedEncodingError,
+    requests_exceptions.Timeout,
 )
 
 


### PR DESCRIPTION
Add client-side `requests.exceptions.Timeout` to `_RETRYABLE_TYPES`
Test automatically covered [here](https://github.com/googleapis/python-storage/blob/main/tests/unit/test_retry.py#L37-L42)

Fixes #726  🦕
