### PR TITLE
fix: Add setuptools as a dependency so pkg_resources is available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ dependencies = [
     "google-resumable-media >= 2.3.2",
     "requests >= 2.18.0, < 3.0.0dev",
     "protobuf",
+    "setuptools",
 ]
 extras = {}
 


### PR DESCRIPTION
Fixes #740 🦕