### PR TITLE
fix(deps): drop pkg_resources

### DIFF
--- a/google/cloud/storage/_http.py
+++ b/google/cloud/storage/_http.py
@@ -15,18 +15,9 @@
 """Create / interact with Google Cloud Storage connections."""
 
 import functools
-import os
-import pkg_resources
 
 from google.cloud import _http
-
 from google.cloud.storage import __version__
-
-
-if os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true":  # pragma: NO COVER
-    release = pkg_resources.get_distribution("google-cloud-core").parsed_version
-    if release < pkg_resources.parse_version("1.6.0"):
-        raise ImportError("google-cloud-core >= 1.6.0 is required to use mTLS feature")
 
 
 class Connection(_http.JSONConnection):


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-storage/issues/740 🦕

`google-cloud-core>=1.6.0` is already listed as a dependency in `setup.py`. We should remove code that uses `pkg_resources` to check `google-cloud-core>=1.6.0`.
https://github.com/googleapis/python-storage/blob/ad3911610a5178942c1ebdd5d8280ca70b890231/setup.py#L33