### PR TITLE
fix: support setting STORAGE_EMULATOR_HOST without /storage/{version} suffix

### DIFF
--- a/google/cloud/storage/_http.py
+++ b/google/cloud/storage/_http.py
@@ -39,7 +39,15 @@ class Connection(_http.JSONConnection):
 
     def __init__(self, client, client_info=None, api_endpoint=None):
         super(Connection, self).__init__(client, client_info)
-        self.API_BASE_URL = api_endpoint or self.DEFAULT_API_ENDPOINT
+        self.API_BASE_URL = (
+            api_endpoint or self.DEFAULT_API_ENDPOINT + "/storage/{self.API_VERSION}"
+        )
+        # A template for the URL of a particular API call.
+        self.API_URL_TEMPLATE = (
+            "{api_base_url}/storage/{api_version}{path}"
+            if api_endpoint is None
+            else "{api_base_url}{path}"
+        )
         self.API_BASE_MTLS_URL = self.DEFAULT_API_MTLS_ENDPOINT
         self.ALLOW_AUTO_SWITCH_TO_MTLS_URL = api_endpoint is None
         self._client_info.client_library_version = __version__
@@ -53,9 +61,6 @@ class Connection(_http.JSONConnection):
 
     API_VERSION = "v1"
     """The version of the API, used in building the API call's URL."""
-
-    API_URL_TEMPLATE = "{api_base_url}/storage/{api_version}{path}"
-    """A template for the URL of a particular API call."""
 
     def api_request(self, *args, **kwargs):
         retry = kwargs.pop("retry", None)


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


Fixes #752 🦕

---

This is a draft and an attempt to fix #752.

The python client makes a request for a blob using this format (which returns an HTTP 404)
```
http://localhost:9199/storage/v1/b/redacted-bucket.appspot.com/o/user-uploads%2F4f721203-0103-408c-96aa-526d8e2ac2b1%2Fpublic%2Foriginal%2Fsignal-2021-10-19-122916.jpeg?projection=noAcl&prettyPrint=false
```
Compared to the NodeJS's implementation, which requests
```
http://localhost:9199/b/redacted-bucket.appspot.com/o/user-uploads%2F4f721203-0103-408c-96aa-526d8e2ac2b1%2Fpublic%2Foriginal%2Fsignal-2021-10-19-122916.jpeg
```

The notable difference is that there's no `/storage/v1/` prefix. This is similar to the issue called out in https://github.com/firebase/firebase-tools/issues/3508#issuecomment-963561373.

Changing the base URL [to a URL which the emulator can handle](https://github.com/firebase/firebase-tools/blob/0adffd8d1ff8e47a2e3577ec34a5570d56f43913/src/emulator/storage/apis/gcloud.ts#L41) by following the [NodeJS](https://github.com/googleapis/nodejs-storage/blob/main/src/storage.ts#L594) implementation of the `STORAGE_EMULATOR_HOST` environment variable is my attempt to fix the issue.

It seems to work for getting file blobs, but does not currently work with Uploads (using the test example from #752).