### PR TITLE
tests: move range read test

### DIFF
--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -85,19 +85,6 @@ def blob_download_as_bytes(client, _preconditions, **resources):
     assert stored_contents == data.encode("utf-8")
 
 
-def blob_download_as_bytes_w_range(client, _preconditions, **resources):
-    # Range read response headers are returned differently in JSON vs XML. JSON response omits the x-goog-hash header;
-    # XML response returns checksum that covers the complete object content for range reads.
-    # Skip test as the testbench is now aligned with XML and returns complete object checksum.
-    bucket = resources.get("bucket")
-    file, data = resources.get("file_data")
-    blob = client.bucket(bucket.name).blob(file.name)
-    start_byte = 0
-    end_byte = 1000000
-    stored_contents = blob.download_as_bytes(start=start_byte, end=end_byte - 1)
-    assert stored_contents == data.encode("utf-8")[start_byte:end_byte]
-
-
 def blob_download_as_text(client, _preconditions, **resources):
     bucket = resources.get("bucket")
     file, data = resources.get("file_data")

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -86,6 +86,9 @@ def blob_download_as_bytes(client, _preconditions, **resources):
 
 
 def blob_download_as_bytes_w_range(client, _preconditions, **resources):
+    # Range read response headers are returned differently in JSON vs XML. JSON response omits the x-goog-hash header;
+    # XML response returns checksum that covers the complete object content for range reads.
+    # Skip test as the testbench is now aligned with XML and returns complete object checksum.
     bucket = resources.get("bucket")
     file, data = resources.get("file_data")
     blob = client.bucket(bucket.name).blob(file.name)
@@ -767,7 +770,6 @@ method_mapping = {
         blob_download_to_filename,
         blob_download_to_filename_chunked,
         blob_download_as_bytes,
-        blob_download_as_bytes_w_range,
         blob_download_as_text,
         blobreader_read,
     ],

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -614,6 +614,11 @@ def test_blob_download_as_text(
     assert stored_contents == payload
     assert blob.etag == etag
 
+    # Test download with byte range
+    end_byte = 5
+    stored_contents = blob.download_as_text(start=0, end=end_byte - 1)
+    assert stored_contents == payload[0:end_byte]
+
 
 def test_blob_upload_w_gzip_encoded_download_raw(
     shared_bucket,


### PR DESCRIPTION
Move range read test to system testing. Skip conf test as the testbench is now aligned with XML and returns complete object checksum.

Range reads headers are returned differently in JSON vs XML. The JSON response omits the x-goog-hash header whereas the XML response returns checksum that covers the complete object content for range reads.

