### PR TITLE
fix: rewrite object in CMEK enabled bucket

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -3576,7 +3576,15 @@ class Blob(_PropertyMixin):
         if source.generation:
             query_params["sourceGeneration"] = source.generation
 
-        if self.kms_key_name is not None:
+        # When a Customer Managed Encryption Key is used to encrypt Cloud Storage object
+        # at rest, object resource metadata will store the version of the Key Management
+        # Service cryptographic material. If a Blob instance with KMS Key metadata set is
+        # used to rewrite the object, then the existing kmsKeyName version
+        # value can't be used in the rewrite request and the client instead ignores it.
+        if (
+            self.kms_key_name is not None
+            and "cryptoKeyVersions" not in self.kms_key_name
+        ):
             query_params["destinationKmsKeyName"] = self.kms_key_name
 
         _add_generation_match_parameters(

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -224,6 +224,17 @@ def test_blob_rewrite_rotate_csek_to_cmek(
 
     assert dest.download_as_bytes() == source_data
 
+    # Test existing kmsKeyName version is ignored in the rewrite request
+    dest = kms_bucket.get_blob(blob_name)
+    source = kms_bucket.get_blob(blob_name)
+    token, rewritten, total = dest.rewrite(source)
+
+    while token is not None:
+        token, rewritten, total = dest.rewrite(source, token=token)
+
+    assert rewritten == len(source_data)
+    assert dest.download_as_bytes() == source_data
+
 
 def test_blob_upload_w_bucket_cmek_enabled(
     kms_bucket,


### PR DESCRIPTION
Allow rewrite on top of an existing blob in CMEK enabled bucket by ignoring kmsKeyName version resource ID in a rewrite request.

The Cloud Storage API expects the **`kmsKeyName` resource ID without version information**. If a Blob instance with [kmsKeyName version resource ID](https://cloud.google.com/kms/docs/resource-hierarchy#retrieve_resource_id) set is used to rewrite the object, then it can't be used in the rewrite request and the client should ignore it.

Note: A metadata `GET` on a blob includes the kmsKeyName version resource ID

Fixes #806 
