### PR TITLE
docs: open file-like objects in byte mode for uploads

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2547,10 +2547,6 @@ class Blob(_PropertyMixin):
 
         :raises: :class:`~google.cloud.exceptions.GoogleCloudError`
                  if the upload response returns an error status.
-        :raises: :exc:`UnicodeEncodeError` if the file handle is opened in text mode
-                and contains non latin-1 characters.
-                [RFC 2616 Section 3.7.1](https://datatracker.ietf.org/doc/html/rfc2616#section-3.7.1)
-                states the text default charset of iso-8859-1.
 
         .. _object versioning: https://cloud.google.com/storage/\
                                docs/object-versioning

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -2456,7 +2456,7 @@ class Blob(_PropertyMixin):
         to that project.
 
         :type file_obj: file
-        :param file_obj: A file handle open for reading.
+        :param file_obj: A file handle opened in binary mode for reading.
 
         :type rewind: bool
         :param rewind:
@@ -2547,6 +2547,10 @@ class Blob(_PropertyMixin):
 
         :raises: :class:`~google.cloud.exceptions.GoogleCloudError`
                  if the upload response returns an error status.
+        :raises: :exc:`UnicodeEncodeError` if the file handle is opened in text mode
+                and contains non latin-1 characters.
+                [RFC 2616 Section 3.7.1](https://datatracker.ietf.org/doc/html/rfc2616#section-3.7.1)
+                states the text default charset of iso-8859-1.
 
         .. _object versioning: https://cloud.google.com/storage/\
                                docs/object-versioning

--- a/samples/snippets/storage_upload_from_stream.py
+++ b/samples/snippets/storage_upload_from_stream.py
@@ -25,8 +25,8 @@ def upload_blob_from_stream(bucket_name, file_obj, destination_blob_name):
 
     # The stream or file (file-like object) from which to read
     # import io
-    # file_obj = io.StringIO()
-    # file_obj.write("This is test data.")
+    # file_obj = io.BytesIO()
+    # file_obj.write(b"This is test data.")
 
     # The desired name of the uploaded GCS object (blob)
     # destination_blob_name = "storage-object-name"


### PR DESCRIPTION
File-like objects should be opened in binary mode for `blob.upload_from_file()`
- cpython standard library accorded with [RFC 2616 Section 3.7.1](https://datatracker.ietf.org/doc/html/rfc2616#section-3.7.1) states the text default charset of iso-8859-1
- add clarifying notes in docstring
- update code sample

Fixes #818 🦕
