### PR TITLE
feat: enable delete_blobs() to preserve generation

### DIFF
--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1698,6 +1698,7 @@ class Bucket(_PropertyMixin):
         blobs,
         on_error=None,
         client=None,
+        preserve_generation=False,
         timeout=_DEFAULT_TIMEOUT,
         if_generation_match=None,
         if_generation_not_match=None,
@@ -1724,6 +1725,11 @@ class Bucket(_PropertyMixin):
         :type client: :class:`~google.cloud.storage.client.Client`
         :param client: (Optional) The client to use.  If not passed, falls back
                        to the ``client`` stored on the current bucket.
+
+        :type preserve_generation: bool
+        :param preserve_generation: (Optional) Preserves blob generation if set to True. A list of
+                                    :class:`~google.cloud.storage.blob.Blob`-s is required to preserve generation.
+                                    Default: False.
 
         :type if_generation_match: list of long
         :param if_generation_match:
@@ -1787,11 +1793,20 @@ class Bucket(_PropertyMixin):
         for blob in blobs:
             try:
                 blob_name = blob
+                generation = None
                 if not isinstance(blob_name, str):
                     blob_name = blob.name
+                    generation = blob.generation if preserve_generation else None
+                else:
+                    if preserve_generation:
+                        raise ValueError(
+                            "A list of blob instances need to be passed in to preserve blob generations."
+                        )
+
                 self.delete_blob(
                     blob_name,
                     client=client,
+                    generation=generation,
                     if_generation_match=next(if_generation_match, None),
                     if_generation_not_match=next(if_generation_not_match, None),
                     if_metageneration_match=next(if_metageneration_match, None),

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1710,6 +1710,9 @@ class Bucket(_PropertyMixin):
 
         Uses :meth:`delete_blob` to delete each individual blob.
 
+        By default, the latest versions of the blobs are deleted. Set `preserve_generation`
+        to True if blob generation should be propagated from the list of blobs.
+
         If :attr:`user_project` is set, bills the API request to that project.
 
         :type blobs: list

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1710,8 +1710,9 @@ class Bucket(_PropertyMixin):
 
         Uses :meth:`delete_blob` to delete each individual blob.
 
-        By default, the latest versions of the blobs are deleted. Set `preserve_generation`
-        to True if blob generation should be propagated from the list of blobs.
+        By default, any generation information in the list of blobs is ignored, and the
+        live versions of all blobs are deleted. Set `preserve_generation` to True
+        if blob generation should instead be propagated from the list of blobs.
 
         If :attr:`user_project` is set, bills the API request to that project.
 
@@ -1730,8 +1731,9 @@ class Bucket(_PropertyMixin):
                        to the ``client`` stored on the current bucket.
 
         :type preserve_generation: bool
-        :param preserve_generation: (Optional) Preserves blob generation if set to True. A list of
-                                    :class:`~google.cloud.storage.blob.Blob`-s is required to preserve generation.
+        :param preserve_generation: (Optional) Deletes only the generation specified on the blob object,
+                                    instead of the live version, if set to True. Only :class:~google.cloud.storage.blob.Blob
+                                    objects can have their generation set in this way.
                                     Default: False.
 
         :type if_generation_match: list of long
@@ -1800,11 +1802,6 @@ class Bucket(_PropertyMixin):
                 if not isinstance(blob_name, str):
                     blob_name = blob.name
                     generation = blob.generation if preserve_generation else None
-                else:
-                    if preserve_generation:
-                        raise ValueError(
-                            "A list of blob instances need to be passed in to preserve blob generations."
-                        )
 
                 self.delete_blob(
                     blob_name,

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1490,6 +1490,7 @@ class Test_Bucket(unittest.TestCase):
         bucket.delete_blob.assert_called_once_with(
             blob_name,
             client=client,
+            generation=None,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1649,6 +1650,7 @@ class Test_Bucket(unittest.TestCase):
         bucket.delete_blob.assert_called_once_with(
             blob_name,
             client=client,
+            generation=None,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1693,6 +1695,7 @@ class Test_Bucket(unittest.TestCase):
         call_1 = mock.call(
             blob_name,
             client=None,
+            generation=None,
             if_generation_match=generation_number,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1703,6 +1706,7 @@ class Test_Bucket(unittest.TestCase):
         call_2 = mock.call(
             blob_name2,
             client=None,
+            generation=None,
             if_generation_match=generation_number2,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1730,6 +1734,7 @@ class Test_Bucket(unittest.TestCase):
         call_1 = mock.call(
             blob_name,
             client=None,
+            generation=None,
             if_generation_match=generation_number,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1740,12 +1745,66 @@ class Test_Bucket(unittest.TestCase):
         call_2 = mock.call(
             blob_name2,
             client=None,
+            generation=None,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,
             if_metageneration_not_match=None,
             timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
+        )
+        bucket.delete_blob.assert_has_calls([call_1, call_2])
+
+    def test_delete_blobs_w_preserve_generation(self):
+        name = "name"
+        blob_name = "blob-name"
+        blob_name2 = "blob-name2"
+        generation_number = 1234567890
+        generation_number2 = 7890123456
+        client = mock.Mock(spec=[])
+        bucket = self._make_one(client=client, name=name)
+        blob = self._make_blob(bucket.name, blob_name)
+        blob.generation = generation_number
+        blob2 = self._make_blob(bucket.name, blob_name2)
+        blob2.generation = generation_number2
+        bucket.delete_blob = mock.Mock()
+        retry = mock.Mock(spec=[])
+
+        # Test raises ValueError when unable to preserve generation from list of blob names
+        with pytest.raises(
+            ValueError,
+            match="A list of blob instances need to be passed in to preserve blob generations.",
+        ):
+            bucket.delete_blobs([blob_name, blob_name2], preserve_generation=True)
+
+        # Test generation is propagated from list of blob instances
+        bucket.delete_blobs(
+            [blob, blob2],
+            preserve_generation=True,
+            retry=retry,
+        )
+
+        call_1 = mock.call(
+            blob_name,
+            client=None,
+            generation=generation_number,
+            if_generation_match=None,
+            if_generation_not_match=None,
+            if_metageneration_match=None,
+            if_metageneration_not_match=None,
+            timeout=self._get_default_timeout(),
+            retry=retry,
+        )
+        call_2 = mock.call(
+            blob_name2,
+            client=None,
+            generation=generation_number2,
+            if_generation_match=None,
+            if_generation_not_match=None,
+            if_metageneration_match=None,
+            if_metageneration_not_match=None,
+            timeout=self._get_default_timeout(),
+            retry=retry,
         )
         bucket.delete_blob.assert_has_calls([call_1, call_2])
 
@@ -1766,6 +1825,7 @@ class Test_Bucket(unittest.TestCase):
         call_1 = mock.call(
             blob_name,
             client=None,
+            generation=None,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1776,6 +1836,7 @@ class Test_Bucket(unittest.TestCase):
         call_2 = mock.call(
             blob_name2,
             client=None,
+            generation=None,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1804,6 +1865,7 @@ class Test_Bucket(unittest.TestCase):
         call_1 = mock.call(
             blob_name,
             client=None,
+            generation=None,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,
@@ -1814,6 +1876,7 @@ class Test_Bucket(unittest.TestCase):
         call_2 = mock.call(
             blob_name2,
             client=None,
+            generation=None,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1770,13 +1770,6 @@ class Test_Bucket(unittest.TestCase):
         bucket.delete_blob = mock.Mock()
         retry = mock.Mock(spec=[])
 
-        # Test raises ValueError when unable to preserve generation from list of blob names
-        with pytest.raises(
-            ValueError,
-            match="A list of blob instances need to be passed in to preserve blob generations.",
-        ):
-            bucket.delete_blobs([blob_name, blob_name2], preserve_generation=True)
-
         # Test generation is propagated from list of blob instances
         bucket.delete_blobs(
             [blob, blob2],


### PR DESCRIPTION
This adds a flag `preserve_generation` to the method `bucket.delete_blobs()`
- allows preserving and propagating blob generations when set to True (default False)
- better ensures backwards compatibility with both `delete_blobs()` and `bucket.delete(force=True)`

Fixes #814 
