### PR TITLE
tests: ensure config changes are propagated in sys tests

### DIFF
--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import time
 
 from google.api_core import exceptions
 
@@ -106,3 +107,10 @@ def delete_bucket(bucket):
     retry = RetryErrors(errors, max_tries=15)
     retry(empty_bucket)(bucket)
     retry(bucket.delete)(force=True)
+
+
+def await_config_changes_propagate(sec=3):
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    # See https://cloud.google.com/storage/docs/json_api/v1/buckets/patch
+    time.sleep(sec)

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -63,16 +63,16 @@ def _no_retetion_period(bucket):
 
 
 retry_bad_copy = RetryErrors(exceptions.BadRequest, error_predicate=_bad_copy)
-retry_no_event_based_hold = RetryInstanceState(_no_event_based_hold, max_tries=10)
-retry_has_kms_key_name = RetryInstanceState(_has_kms_key_name, max_tries=10)
+retry_no_event_based_hold = RetryInstanceState(_no_event_based_hold, max_tries=5)
+retry_has_kms_key_name = RetryInstanceState(_has_kms_key_name, max_tries=5)
 retry_has_retention_expiration = RetryInstanceState(
-    _has_retention_expiration, max_tries=10
+    _has_retention_expiration, max_tries=5
 )
 retry_no_retention_expiration = RetryInstanceState(
-    _no_retention_expiration, max_tries=10
+    _no_retention_expiration, max_tries=5
 )
-retry_has_retention_period = RetryInstanceState(_has_retetion_period, max_tries=10)
-retry_no_retention_period = RetryInstanceState(_no_retetion_period, max_tries=10)
+retry_has_retention_period = RetryInstanceState(_has_retetion_period, max_tries=5)
+retry_no_retention_period = RetryInstanceState(_no_retetion_period, max_tries=5)
 
 
 def unique_name(prefix):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -165,6 +165,17 @@ def signing_bucket(storage_client, signing_bucket_name):
     _helpers.delete_bucket(bucket)
 
 
+@pytest.fixture(scope="session")
+def default_ebh_bucket(storage_client, signing_bucket_name):
+    bucket = storage_client.bucket("gcp-system-default-ebh")
+    bucket.default_event_based_hold = True
+    _helpers.retry_429_503(bucket.create)()
+
+    yield bucket
+
+    _helpers.delete_bucket(bucket)
+
+
 @pytest.fixture(scope="function")
 def buckets_to_delete():
     buckets_to_delete = []

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -166,8 +166,13 @@ def signing_bucket(storage_client, signing_bucket_name):
 
 
 @pytest.fixture(scope="session")
-def default_ebh_bucket(storage_client, signing_bucket_name):
-    bucket = storage_client.bucket("gcp-system-default-ebh")
+def default_ebh_bucket_name():
+    return _helpers.unique_name("gcp-systest-default-ebh")
+
+
+@pytest.fixture(scope="session")
+def default_ebh_bucket(storage_client, default_ebh_bucket_name):
+    bucket = storage_client.bucket(default_ebh_bucket_name)
     bucket.default_event_based_hold = True
     _helpers.retry_429_503(bucket.create)()
 

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -874,6 +874,10 @@ def test_ubla_set_unset_preserves_acls(
     bucket.iam_configuration.uniform_bucket_level_access_enabled = False
     bucket.patch()
 
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    time.sleep(3)
+
     # Query ACLs after clearing UBLA
     bucket.acl.reload()
     bucket_acl_after = list(bucket.acl)

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import time
 
 import pytest
 
@@ -682,20 +683,18 @@ def test_bucket_w_retention_period(
 
 def test_bucket_w_default_event_based_hold(
     storage_client,
-    buckets_to_delete,
     blobs_to_delete,
+    default_ebh_bucket,
 ):
-    bucket_name = _helpers.unique_name("w-def-ebh")
-    bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)
-    buckets_to_delete.append(bucket)
-
-    bucket.default_event_based_hold = True
-    bucket.patch()
-
+    bucket = storage_client.get_bucket(default_ebh_bucket)
     assert bucket.default_event_based_hold
     assert bucket.retention_period is None
     assert bucket.retention_policy_effective_time is None
     assert not bucket.retention_policy_locked
+
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    time.sleep(3)
 
     blob_name = "test-blob"
     payload = b"DEADBEEF"
@@ -724,6 +723,10 @@ def test_bucket_w_default_event_based_hold(
     assert bucket.retention_period is None
     assert bucket.retention_policy_effective_time is None
     assert not bucket.retention_policy_locked
+
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    time.sleep(3)
 
     blob.upload_from_string(payload)
 

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import datetime
-import time
 
 import pytest
 
@@ -692,10 +691,6 @@ def test_bucket_w_default_event_based_hold(
     assert bucket.retention_policy_effective_time is None
     assert not bucket.retention_policy_locked
 
-    # Changes to the bucket will be readable immediately after writing,
-    # but configuration changes may take time to propagate.
-    time.sleep(3)
-
     blob_name = "test-blob"
     payload = b"DEADBEEF"
     blob = bucket.blob(blob_name)
@@ -726,7 +721,7 @@ def test_bucket_w_default_event_based_hold(
 
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
-    time.sleep(3)
+    _helpers.await_config_changes_propagate()
 
     blob.upload_from_string(payload)
 
@@ -873,10 +868,7 @@ def test_ubla_set_unset_preserves_acls(
     # Clear UBLA
     bucket.iam_configuration.uniform_bucket_level_access_enabled = False
     bucket.patch()
-
-    # Changes to the bucket will be readable immediately after writing,
-    # but configuration changes may take time to propagate.
-    time.sleep(3)
+    _helpers.await_config_changes_propagate()
 
     # Query ACLs after clearing UBLA
     bucket.acl.reload()

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import time
 
 import pytest
 
@@ -149,7 +148,7 @@ def test_bucket_w_default_kms_key_name(
 
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
-    time.sleep(3)
+    _helpers.await_config_changes_propagate()
 
     defaulted_blob = kms_bucket.blob(blob_name)
     defaulted_blob.upload_from_filename(info["path"])
@@ -235,7 +234,7 @@ def test_blob_upload_w_bucket_cmek_enabled(
 
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
-    time.sleep(3)
+    _helpers.await_config_changes_propagate()
 
     blob = kms_bucket.blob(blob_name)
     blob.upload_from_string(payload)

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -138,10 +138,6 @@ def test_bucket_w_default_kms_key_name(
     file_data,
 ):
     blob_name = "default-kms-key-name"
-    override_blob_name = "override-default-kms-key-name"
-    alt_blob_name = "alt-default-kms-key-name"
-    cleartext_blob_name = "cleartext"
-
     info = file_data["simple"]
 
     with open(info["path"], "rb") as file_obj:
@@ -164,34 +160,15 @@ def test_bucket_w_default_kms_key_name(
     # We don't know the current version of the key.
     assert defaulted_blob.kms_key_name.startswith(kms_key_name)
 
-    override_blob = kms_bucket.blob(override_blob_name, kms_key_name=alt_kms_key_name)
-    override_blob.upload_from_filename(info["path"])
-    blobs_to_delete.append(override_blob)
-
-    assert override_blob.download_as_bytes() == payload
-    # We don't know the current version of the key.
-    assert override_blob.kms_key_name.startswith(alt_kms_key_name)
-
+    # Test changing the default KMS key.
     kms_bucket.default_kms_key_name = alt_kms_key_name
     kms_bucket.patch()
+    assert kms_bucket.default_kms_key_name == alt_kms_key_name
 
-    alt_blob = kms_bucket.blob(alt_blob_name)
-    alt_blob.upload_from_filename(info["path"])
-    blobs_to_delete.append(alt_blob)
-
-    assert alt_blob.download_as_bytes() == payload
-    # We don't know the current version of the key.
-    assert alt_blob.kms_key_name.startswith(alt_kms_key_name)
-
+    # Test removing the default KMS key.
     kms_bucket.default_kms_key_name = None
     kms_bucket.patch()
-
-    cleartext_blob = kms_bucket.blob(cleartext_blob_name)
-    cleartext_blob.upload_from_filename(info["path"])
-    blobs_to_delete.append(cleartext_blob)
-
-    assert cleartext_blob.download_as_bytes() == payload
-    assert cleartext_blob.kms_key_name is None
+    assert kms_bucket.default_kms_key_name is None
 
 
 def test_blob_rewrite_rotate_csek_to_cmek(
@@ -245,9 +222,10 @@ def test_blob_upload_w_bucket_cmek_enabled(
     kms_bucket,
     blobs_to_delete,
     kms_key_name,
-    file_data,
+    alt_kms_key_name,
 ):
     blob_name = "test-blob"
+    override_blob_name = "override-default-kms-key-name"
     payload = b"DEADBEEF"
     alt_payload = b"NEWDEADBEEF"
 
@@ -264,14 +242,20 @@ def test_blob_upload_w_bucket_cmek_enabled(
     blobs_to_delete.append(blob)
 
     _helpers.retry_429_harder(_helpers.retry_has_kms_key_name(blob.reload))()
-    # We don't know the current version of the key.
     assert blob.kms_key_name.startswith(kms_key_name)
 
     blob.upload_from_string(alt_payload, if_generation_match=blob.generation)
-
     assert blob.download_as_bytes() == alt_payload
+
+    # Test the specific key is used to encrypt the object if you have both
+    # a default KMS key set on your bucket and a specific key included in your request.
+    override_blob = kms_bucket.blob(override_blob_name, kms_key_name=alt_kms_key_name)
+    override_blob.upload_from_string(payload)
+    blobs_to_delete.append(override_blob)
+
+    assert override_blob.download_as_bytes() == payload
+    assert override_blob.kms_key_name.startswith(alt_kms_key_name)
 
     kms_bucket.default_kms_key_name = None
     _helpers.retry_429_harder(kms_bucket.patch)()
-
     assert kms_bucket.default_kms_key_name is None

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import time
 
 import pytest
 
@@ -150,6 +151,10 @@ def test_bucket_w_default_kms_key_name(
     kms_bucket.patch()
     assert kms_bucket.default_kms_key_name == kms_key_name
 
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    time.sleep(3)
+
     defaulted_blob = kms_bucket.blob(blob_name)
     defaulted_blob.upload_from_filename(info["path"])
     blobs_to_delete.append(defaulted_blob)
@@ -249,6 +254,10 @@ def test_blob_upload_w_bucket_cmek_enabled(
     kms_bucket.default_kms_key_name = kms_key_name
     kms_bucket.patch()
     assert kms_bucket.default_kms_key_name == kms_key_name
+
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    time.sleep(3)
 
     blob = kms_bucket.blob(blob_name)
     blob.upload_from_string(payload)


### PR DESCRIPTION
It seems like [bucket config changes may not be propagated in time](https://cloud.google.com/storage/docs/json_api/v1/buckets/patch), resulting in flaky system tests. 

- refactor system tests to use preconfigured fixtures
- rearrange tests with appropriate wait and test order
- adjust max retries
