### PR TITLE
Fix: BlobWriter.close() will do nothing if already closed

### DIFF
--- a/google/cloud/storage/fileio.py
+++ b/google/cloud/storage/fileio.py
@@ -423,9 +423,8 @@ class BlobWriter(io.BufferedIOBase):
             )
 
     def close(self):
-        self._checkClosed()  # Raises ValueError if closed.
-
-        self._upload_chunks_from_buffer(1)
+        if not self._buffer.closed:
+            self._upload_chunks_from_buffer(1)
         self._buffer.close()
 
     def _checkClosed(self):

--- a/tests/unit/test_fileio.py
+++ b/tests/unit/test_fileio.py
@@ -402,6 +402,24 @@ class TestBlobWriterBinary(unittest.TestCase, _BlobWriterBase):
             stacklevel=2,
         )
 
+    def test_close_errors(self):
+        blob = mock.Mock(chunk_size=None)
+
+        upload = mock.Mock()
+        transport = mock.Mock()
+
+        blob._initiate_resumable_upload.return_value = (upload, transport)
+
+        writer = self._make_blob_writer(blob)
+
+        writer.close()
+        # Close a second time to verify it successfully does nothing.
+        writer.close()
+        # Try to write to closed file.
+        with self.assertRaises(ValueError):
+            writer.write(TEST_BINARY_DATA)
+
+
     def test_flush_fails(self):
         blob = mock.Mock(chunk_size=None)
         writer = self._make_blob_writer(blob)

--- a/tests/unit/test_fileio.py
+++ b/tests/unit/test_fileio.py
@@ -419,7 +419,6 @@ class TestBlobWriterBinary(unittest.TestCase, _BlobWriterBase):
         with self.assertRaises(ValueError):
             writer.write(TEST_BINARY_DATA)
 
-
     def test_flush_fails(self):
         blob = mock.Mock(chunk_size=None)
         writer = self._make_blob_writer(blob)


### PR DESCRIPTION
Fixes #884 🦕
