### PR TITLE
Changes to make this branch testable against non-prod environments

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -24,6 +24,12 @@ cd "${PROJECT_ROOT}"
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
+# Export variable to override api endpoint
+export API_ENDPOINT_OVERRIDE
+
+# Export variable to override api endpoint version
+export API_VERSION_OVERRIDE
+
 # Debug: show build environment
 env | grep KOKORO
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -361,7 +361,10 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("https://python.readthedocs.org/en/latest/", None),
     "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None,),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
     "grpc": ("https://grpc.github.io/grpc/python/", None),
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -33,7 +33,13 @@ from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
 STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"
 """Environment variable defining host for Storage emulator."""
 
-_DEFAULT_STORAGE_HOST = u"https://storage.googleapis.com"
+_DEFAULT_STORAGE_HOST = os.getenv(
+    "API_ENDPOINT_OVERRIDE", "https://storage.googleapis.com"
+)
+"""Default storage host for JSON API."""
+
+_API_VERSION = os.getenv("API_VERSION_OVERRIDE", "v1")
+"""API version of the default storage host"""
 
 # etag match parameters in snake case and equivalent header
 _ETAG_MATCH_PARAMETERS = (

--- a/google/cloud/storage/_http.py
+++ b/google/cloud/storage/_http.py
@@ -21,6 +21,7 @@ import pkg_resources
 from google.cloud import _http
 
 from google.cloud.storage import __version__
+from google.cloud.storage import _helpers
 
 
 if os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true":  # pragma: NO COVER
@@ -43,7 +44,7 @@ class Connection(_http.JSONConnection):
     :param api_endpoint: (Optional) api endpoint to use.
     """
 
-    DEFAULT_API_ENDPOINT = "https://storage.googleapis.com"
+    DEFAULT_API_ENDPOINT = _helpers._DEFAULT_STORAGE_HOST
     DEFAULT_API_MTLS_ENDPOINT = "https://storage.mtls.googleapis.com"
 
     def __init__(self, client, client_info=None, api_endpoint=None):
@@ -60,7 +61,7 @@ class Connection(_http.JSONConnection):
         if agent_version not in self._client_info.user_agent:
             self._client_info.user_agent += " {} ".format(agent_version)
 
-    API_VERSION = "v1"
+    API_VERSION = _helpers._API_VERSION
     """The version of the API, used in building the API call's URL."""
 
     API_URL_TEMPLATE = "{api_base_url}/storage/{api_version}{path}"

--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -108,7 +108,7 @@ def get_expiration_seconds_v2(expiration):
     # If it's a datetime, convert to a timestamp.
     if isinstance(expiration, datetime.datetime):
         micros = _helpers._microseconds_from_datetime(expiration)
-        expiration = micros // 10 ** 6
+        expiration = micros // 10**6
 
     if not isinstance(expiration, six.integer_types):
         raise TypeError(

--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -460,7 +460,10 @@ class ACL(object):
         self.entities.clear()
 
         found = client._get_resource(
-            path, query_params=query_params, timeout=timeout, retry=retry,
+            path,
+            query_params=query_params,
+            timeout=timeout,
+            retry=retry,
         )
         self.loaded = True
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -91,11 +91,13 @@ from google.cloud.storage.fileio import BlobWriter
 
 
 _API_ACCESS_ENDPOINT = _DEFAULT_STORAGE_HOST
-_DEFAULT_CONTENT_TYPE = u"application/octet-stream"
-_DOWNLOAD_URL_TEMPLATE = u"{hostname}/download/storage/{api_version}{path}?alt=media"
-_BASE_UPLOAD_TEMPLATE = u"{hostname}/upload/storage/{api_version}{bucket_path}/o?uploadType="
-_MULTIPART_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + u"multipart"
-_RESUMABLE_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + u"resumable"
+_DEFAULT_CONTENT_TYPE = "application/octet-stream"
+_DOWNLOAD_URL_TEMPLATE = "{hostname}/download/storage/{api_version}{path}?alt=media"
+_BASE_UPLOAD_TEMPLATE = (
+    "{hostname}/upload/storage/{api_version}{bucket_path}/o?uploadType="
+)
+_MULTIPART_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + "multipart"
+_RESUMABLE_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + "resumable"
 # NOTE: "acl" is also writeable but we defer ACL management to
 #       the classes in the google.cloud.storage.acl module.
 _CONTENT_TYPE_FIELD = "contentType"
@@ -850,7 +852,9 @@ class Blob(_PropertyMixin):
         name_value_pairs = []
         if self.media_link is None:
             hostname = _get_host_name(client._connection)
-            base_url = _DOWNLOAD_URL_TEMPLATE.format(hostname=hostname, path=self.path, api_version=_API_VERSION )
+            base_url = _DOWNLOAD_URL_TEMPLATE.format(
+                hostname=hostname, path=self.path, api_version=_API_VERSION
+            )
             if self.generation is not None:
                 name_value_pairs.append(("generation", "{:d}".format(self.generation)))
         else:
@@ -1873,7 +1877,7 @@ class Blob(_PropertyMixin):
 
         hostname = _get_host_name(client._connection)
         base_url = _MULTIPART_URL_TEMPLATE.format(
-            hostname=hostname, bucket_path=self.bucket.path,  api_version=_API_VERSION
+            hostname=hostname, bucket_path=self.bucket.path, api_version=_API_VERSION
         )
         name_value_pairs = []
 
@@ -2060,7 +2064,7 @@ class Blob(_PropertyMixin):
 
         hostname = _get_host_name(client._connection)
         base_url = _RESUMABLE_URL_TEMPLATE.format(
-            hostname=hostname, bucket_path=self.bucket.path,  api_version=_API_VERSION
+            hostname=hostname, bucket_path=self.bucket.path, api_version=_API_VERSION
         )
         name_value_pairs = []
 
@@ -4465,7 +4469,7 @@ def _raise_from_invalid_response(error):
     else:
         error_message = str(error)
 
-    message = u"{method} {url}: {error}".format(
+    message = "{method} {url}: {error}".format(
         method=response.request.method, url=response.request.url, error=error_message
     )
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -1873,7 +1873,7 @@ class Blob(_PropertyMixin):
 
         hostname = _get_host_name(client._connection)
         base_url = _MULTIPART_URL_TEMPLATE.format(
-            hostname=hostname, bucket_path=self.bucket.path
+            hostname=hostname, bucket_path=self.bucket.path,  api_version=_API_VERSION
         )
         name_value_pairs = []
 
@@ -2060,7 +2060,7 @@ class Blob(_PropertyMixin):
 
         hostname = _get_host_name(client._connection)
         base_url = _RESUMABLE_URL_TEMPLATE.format(
-            hostname=hostname, bucket_path=self.bucket.path
+            hostname=hostname, bucket_path=self.bucket.path,  api_version=_API_VERSION
         )
         name_value_pairs = []
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -70,6 +70,8 @@ from google.cloud.storage._helpers import _api_core_retry_to_resumable_media_ret
 from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage._helpers import _NUM_RETRIES_MESSAGE
+from google.cloud.storage._helpers import _DEFAULT_STORAGE_HOST
+from google.cloud.storage._helpers import _API_VERSION
 from google.cloud.storage.acl import ACL
 from google.cloud.storage.acl import ObjectACL
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
@@ -88,10 +90,10 @@ from google.cloud.storage.fileio import BlobReader
 from google.cloud.storage.fileio import BlobWriter
 
 
-_API_ACCESS_ENDPOINT = "https://storage.googleapis.com"
+_API_ACCESS_ENDPOINT = _DEFAULT_STORAGE_HOST
 _DEFAULT_CONTENT_TYPE = u"application/octet-stream"
-_DOWNLOAD_URL_TEMPLATE = u"{hostname}/download/storage/v1{path}?alt=media"
-_BASE_UPLOAD_TEMPLATE = u"{hostname}/upload/storage/v1{bucket_path}/o?uploadType="
+_DOWNLOAD_URL_TEMPLATE = u"{hostname}/download/storage/{api_version}{path}?alt=media"
+_BASE_UPLOAD_TEMPLATE = u"{hostname}/upload/storage/{api_version}{bucket_path}/o?uploadType="
 _MULTIPART_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + u"multipart"
 _RESUMABLE_URL_TEMPLATE = _BASE_UPLOAD_TEMPLATE + u"resumable"
 # NOTE: "acl" is also writeable but we defer ACL management to
@@ -848,7 +850,7 @@ class Blob(_PropertyMixin):
         name_value_pairs = []
         if self.media_link is None:
             hostname = _get_host_name(client._connection)
-            base_url = _DOWNLOAD_URL_TEMPLATE.format(hostname=hostname, path=self.path)
+            base_url = _DOWNLOAD_URL_TEMPLATE.format(hostname=hostname, path=self.path, api_version=_API_VERSION )
             if self.generation is not None:
                 name_value_pairs.append(("generation", "{:d}".format(self.generation)))
         else:

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1362,7 +1362,10 @@ class Bucket(_PropertyMixin):
         client = self._require_client(client)
         path = self.path + "/notificationConfigs"
         iterator = client._list_resource(
-            path, _item_to_notification, timeout=timeout, retry=retry,
+            path,
+            _item_to_notification,
+            timeout=timeout,
+            retry=retry,
         )
         iterator.bucket = self
         return iterator
@@ -2931,7 +2934,8 @@ class Bucket(_PropertyMixin):
             for blob in blobs:
                 blob.acl.all().grant_read()
                 blob.acl.save(
-                    client=client, timeout=timeout,
+                    client=client,
+                    timeout=timeout,
                 )
 
     def make_private(

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1105,7 +1105,9 @@ class Client(ClientWithProject):
         headers = _get_encryption_headers(blob_or_uri._encryption_key)
         headers["accept-encoding"] = "gzip"
         _add_etag_match_headers(
-            headers, if_etag_match=if_etag_match, if_etag_not_match=if_etag_not_match,
+            headers,
+            if_etag_match=if_etag_match,
+            if_etag_not_match=if_etag_not_match,
         )
 
         transport = self._http
@@ -1440,7 +1442,11 @@ class Client(ClientWithProject):
             qs_params["userProject"] = user_project
 
         api_response = self._post_resource(
-            path, None, query_params=qs_params, timeout=timeout, retry=retry,
+            path,
+            None,
+            query_params=qs_params,
+            timeout=timeout,
+            retry=retry,
         )
         metadata = HMACKeyMetadata(self)
         metadata._properties = api_response["metadata"]

--- a/google/cloud/storage/hmac_key.py
+++ b/google/cloud/storage/hmac_key.py
@@ -211,7 +211,10 @@ class HMACKeyMetadata(object):
                 qs_params["userProject"] = self.user_project
 
             self._client._get_resource(
-                self.path, query_params=qs_params, timeout=timeout, retry=retry,
+                self.path,
+                query_params=qs_params,
+                timeout=timeout,
+                retry=retry,
             )
         except NotFound:
             return False
@@ -239,7 +242,10 @@ class HMACKeyMetadata(object):
             qs_params["userProject"] = self.user_project
 
         self._properties = self._client._get_resource(
-            self.path, query_params=qs_params, timeout=timeout, retry=retry,
+            self.path,
+            query_params=qs_params,
+            timeout=timeout,
+            retry=retry,
         )
 
     def update(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY_IF_ETAG_IN_JSON):
@@ -263,7 +269,11 @@ class HMACKeyMetadata(object):
 
         payload = {"state": self.state}
         self._properties = self._client._put_resource(
-            self.path, payload, query_params=qs_params, timeout=timeout, retry=retry,
+            self.path,
+            payload,
+            query_params=qs_params,
+            timeout=timeout,
+            retry=retry,
         )
 
     def delete(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
@@ -289,5 +299,8 @@ class HMACKeyMetadata(object):
             qs_params["userProject"] = self.user_project
 
         self._client._delete_resource(
-            self.path, query_params=qs_params, timeout=timeout, retry=retry,
+            self.path,
+            query_params=qs_params,
+            timeout=timeout,
+            retry=retry,
         )

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -156,26 +156,22 @@ class BucketNotification(object):
 
     @property
     def topic_project(self):
-        """Project ID of topic to which notifications are published.
-        """
+        """Project ID of topic to which notifications are published."""
         return self._topic_project
 
     @property
     def custom_attributes(self):
-        """Custom attributes passed with notification events.
-        """
+        """Custom attributes passed with notification events."""
         return self._properties.get("custom_attributes")
 
     @property
     def event_types(self):
-        """Event types for which notification events are published.
-        """
+        """Event types for which notification events are published."""
         return self._properties.get("event_types")
 
     @property
     def blob_name_prefix(self):
-        """Prefix of blob names for which notification events are published.
-        """
+        """Prefix of blob names for which notification events are published."""
         return self._properties.get("object_name_prefix")
 
     @property
@@ -278,7 +274,11 @@ class BucketNotification(object):
             )
 
         self._properties = client._post_resource(
-            path, properties, query_params=query_params, timeout=timeout, retry=retry,
+            path,
+            properties,
+            query_params=query_params,
+            timeout=timeout,
+            retry=retry,
         )
 
     def exists(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
@@ -318,7 +318,10 @@ class BucketNotification(object):
 
         try:
             client._get_resource(
-                self.path, query_params=query_params, timeout=timeout, retry=retry,
+                self.path,
+                query_params=query_params,
+                timeout=timeout,
+                retry=retry,
             )
         except NotFound:
             return False
@@ -360,7 +363,10 @@ class BucketNotification(object):
             query_params["userProject"] = self.bucket.user_project
 
         response = client._get_resource(
-            self.path, query_params=query_params, timeout=timeout, retry=retry,
+            self.path,
+            query_params=query_params,
+            timeout=timeout,
+            retry=retry,
         )
         self._set_properties(response)
 
@@ -400,7 +406,10 @@ class BucketNotification(object):
             query_params["userProject"] = self.bucket.user_project
 
         client._delete_resource(
-            self.path, query_params=query_params, timeout=timeout, retry=retry,
+            self.path,
+            query_params=query_params,
+            timeout=timeout,
+            retry=retry,
         )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==19.10b0"
+BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"

--- a/noxfile.py
+++ b/noxfile.py
@@ -108,6 +108,7 @@ def system(session):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
+    rerun_count = 0
 
     # Check the value of `RUN_SYSTEM_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_SYSTEM_TESTS", "true") == "false":
@@ -118,6 +119,12 @@ def system(session):
     # mTLS tests requires pyopenssl.
     if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "") == "true":
         session.install("pyopenssl")
+    # Check if endpoint is being overriden for rerun_count
+    if (
+        os.getenv("API_ENDPOINT_OVERRIDE", "https://storage.googleapis.com")
+        != "https://storage.googleapis.com"
+    ):
+        rerun_count = 3
 
     system_test_exists = os.path.exists(system_test_path)
     system_test_folder_exists = os.path.exists(system_test_folder_path)
@@ -133,7 +140,7 @@ def system(session):
     # 2021-05-06: defer installing 'google-cloud-*' to after this package,
     #             in order to work around Python 2.7 googolapis-common-protos
     #             issue.
-    session.install("mock", "pytest", "-c", constraints_path)
+    session.install("mock", "pytest", "pytest-rerunfailures", "-c", constraints_path)
     session.install("-e", ".", "-c", constraints_path)
     session.install(
         "google-cloud-testutils",
@@ -146,9 +153,21 @@ def system(session):
 
     # Run py.test against the system tests.
     if system_test_exists:
-        session.run("py.test", "--quiet", system_test_path, *session.posargs)
+        session.run(
+            "py.test",
+            "--quiet",
+            "--reruns={}".format(rerun_count),
+            system_test_path,
+            *session.posargs,
+        )
     if system_test_folder_exists:
-        session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
+        session.run(
+            "py.test",
+            "--quiet",
+            "--reruns={}".format(rerun_count),
+            system_test_folder_path,
+            *session.posargs,
+        )
 
 
 @nox.session(python=CONFORMANCE_TEST_PYTHON_VERSIONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -167,7 +167,7 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
-            "-s"
+            "-s",
             #"--quiet",
             "--reruns={}".format(rerun_count),
             system_test_folder_path,

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,7 +46,9 @@ def lint(session):
     """
     session.install("flake8", BLACK_VERSION)
     session.run(
-        "black", "--check", *BLACK_PATHS,
+        "black",
+        "--check",
+        *BLACK_PATHS,
     )
     session.run("flake8", "google", "tests")
 
@@ -59,7 +61,8 @@ def blacken(session):
     """
     session.install(BLACK_VERSION)
     session.run(
-        "black", *BLACK_PATHS,
+        "black",
+        *BLACK_PATHS,
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==22.3.0"
+BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"

--- a/noxfile.py
+++ b/noxfile.py
@@ -158,7 +158,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
-            "--quiet",
+            "-s",
+            #"--quiet",
             "--reruns={}".format(rerun_count),
             system_test_path,
             *session.posargs,
@@ -166,7 +167,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
-            "--quiet",
+            "-s"
+            #"--quiet",
             "--reruns={}".format(rerun_count),
             system_test_folder_path,
             *session.posargs,

--- a/noxfile.py
+++ b/noxfile.py
@@ -159,7 +159,7 @@ def system(session):
         session.run(
             "py.test",
             "-s",
-            #"--quiet",
+            # "--quiet",
             "--reruns={}".format(rerun_count),
             system_test_path,
             *session.posargs,
@@ -168,7 +168,7 @@ def system(session):
         session.run(
             "py.test",
             "-s",
-            #"--quiet",
+            # "--quiet",
             "--reruns={}".format(rerun_count),
             system_test_folder_path,
             *session.posargs,

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -63,6 +63,9 @@ def _has_kms_key_name(blob):
 retry_bad_copy = RetryErrors(exceptions.BadRequest, error_predicate=_bad_copy)
 retry_no_event_based_hold = RetryInstanceState(_no_event_based_hold)
 retry_has_kms_key_name = RetryInstanceState(_has_kms_key_name)
+retry_no_retention_expiration = RetryInstanceState(
+    _no_retention_expiration, max_tries=5
+)
 retry_has_retention_period = RetryInstanceState(_has_retetion_period, max_tries=5)
 
 

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -21,6 +21,7 @@ from google.api_core import exceptions
 from test_utils.retry import RetryErrors
 from test_utils.retry import RetryInstanceState
 from test_utils.system import unique_resource_id
+from google.cloud.storage._helpers import _DEFAULT_STORAGE_HOST
 
 retry_429 = RetryErrors(exceptions.TooManyRequests)
 retry_429_harder = RetryErrors(exceptions.TooManyRequests, max_tries=10)
@@ -42,6 +43,7 @@ else:
 user_project = os.environ.get("GOOGLE_CLOUD_TESTS_USER_PROJECT")
 testing_mtls = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true"
 signing_blob_content = b"This time for sure, Rocky!"
+is_api_endpoint_override = _DEFAULT_STORAGE_HOST != "https://storage.googleapis.com"
 
 
 def _bad_copy(bad_request):

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -122,7 +122,7 @@ def delete_bucket(bucket):
     retry(empty_bucket)(bucket)
     retry(bucket.delete)(force=True)
 
- 
+
 def await_config_changes_propagate(sec=3):
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -60,6 +60,14 @@ def _has_kms_key_name(blob):
     return blob.kms_key_name is not None
 
 
+def _has_retetion_period(bucket):
+    return bucket.retention_period is not None
+
+
+def _no_retention_expiration(blob):
+    return blob.retention_expiration_time is None
+
+
 retry_bad_copy = RetryErrors(exceptions.BadRequest, error_predicate=_bad_copy)
 retry_no_event_based_hold = RetryInstanceState(_no_event_based_hold)
 retry_has_kms_key_name = RetryInstanceState(_has_kms_key_name)

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -96,3 +96,10 @@ def delete_bucket(bucket):
     retry = RetryErrors(errors, max_tries=15)
     retry(empty_bucket)(bucket)
     retry(bucket.delete)(force=True)
+
+ 
+def await_config_changes_propagate(sec=3):
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    # See https://cloud.google.com/storage/docs/json_api/v1/buckets/patch
+    time.sleep(sec)

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 import os
 
 import six
@@ -60,6 +61,10 @@ def _has_kms_key_name(blob):
     return blob.kms_key_name is not None
 
 
+def _has_retention_expiration(blob):
+    return blob.retention_expiration_time is not None
+
+
 def _has_retetion_period(bucket):
     return bucket.retention_period is not None
 
@@ -71,6 +76,9 @@ def _no_retention_expiration(blob):
 retry_bad_copy = RetryErrors(exceptions.BadRequest, error_predicate=_bad_copy)
 retry_no_event_based_hold = RetryInstanceState(_no_event_based_hold)
 retry_has_kms_key_name = RetryInstanceState(_has_kms_key_name)
+retry_has_retention_expiration = RetryInstanceState(
+    _has_retention_expiration, max_tries=5
+)
 retry_no_retention_expiration = RetryInstanceState(
     _no_retention_expiration, max_tries=5
 )

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -63,6 +63,7 @@ def _has_kms_key_name(blob):
 retry_bad_copy = RetryErrors(exceptions.BadRequest, error_predicate=_bad_copy)
 retry_no_event_based_hold = RetryInstanceState(_no_event_based_hold)
 retry_has_kms_key_name = RetryInstanceState(_has_kms_key_name)
+retry_has_retention_period = RetryInstanceState(_has_retetion_period, max_tries=5)
 
 
 def unique_name(prefix):

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -69,6 +69,10 @@ def _has_retetion_period(bucket):
     return bucket.retention_period is not None
 
 
+def _no_retetion_period(bucket):
+    return bucket.retention_period is None
+
+
 def _no_retention_expiration(blob):
     return blob.retention_expiration_time is None
 
@@ -83,6 +87,7 @@ retry_no_retention_expiration = RetryInstanceState(
     _no_retention_expiration, max_tries=5
 )
 retry_has_retention_period = RetryInstanceState(_has_retetion_period, max_tries=5)
+retry_no_retention_period = RetryInstanceState(_no_retetion_period, max_tries=5)
 
 
 def unique_name(prefix):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -108,7 +108,9 @@ def listable_bucket(storage_client, listable_bucket_name, file_data):
 
     for filename in _listable_filenames[1:]:
         _helpers.retry_bad_copy(bucket.copy_blob)(
-            source_blob, bucket, filename,
+            source_blob,
+            bucket,
+            filename,
         )
 
     yield bucket

--- a/tests/system/test__signing.py
+++ b/tests/system/test__signing.py
@@ -17,7 +17,7 @@ import datetime
 import hashlib
 import os
 import time
-
+import pytest
 import requests
 
 from google.api_core import path_template
@@ -41,7 +41,7 @@ def _create_signed_list_blobs_url_helper(
     expiration = _morph_expiration(version, expiration)
 
     signed_url = bucket.generate_signed_url(
-        expiration=expiration, method=method, client=client, version=version
+        expiration=expiration, method=method, client=client, version=version,  api_access_endpoint=_helpers._DEFAULT_STORAGE_HOST
     )
 
     response = requests.get(signed_url)

--- a/tests/system/test__signing.py
+++ b/tests/system/test__signing.py
@@ -41,7 +41,11 @@ def _create_signed_list_blobs_url_helper(
     expiration = _morph_expiration(version, expiration)
 
     signed_url = bucket.generate_signed_url(
-        expiration=expiration, method=method, client=client, version=version,  api_access_endpoint=_helpers._DEFAULT_STORAGE_HOST
+        expiration=expiration,
+        method=method,
+        client=client,
+        version=version,
+        api_access_endpoint=_helpers._DEFAULT_STORAGE_HOST,
     )
 
     response = requests.get(signed_url)
@@ -50,7 +54,9 @@ def _create_signed_list_blobs_url_helper(
 
 def test_create_signed_list_blobs_url_v2(storage_client, signing_bucket, no_mtls):
     _create_signed_list_blobs_url_helper(
-        storage_client, signing_bucket, version="v2",
+        storage_client,
+        signing_bucket,
+        version="v2",
     )
 
 
@@ -61,13 +67,18 @@ def test_create_signed_list_blobs_url_v2_w_expiration(
     delta = datetime.timedelta(seconds=10)
 
     _create_signed_list_blobs_url_helper(
-        storage_client, signing_bucket, expiration=now + delta, version="v2",
+        storage_client,
+        signing_bucket,
+        expiration=now + delta,
+        version="v2",
     )
 
 
 def test_create_signed_list_blobs_url_v4(storage_client, signing_bucket, no_mtls):
     _create_signed_list_blobs_url_helper(
-        storage_client, signing_bucket, version="v4",
+        storage_client,
+        signing_bucket,
+        version="v4",
     )
 
 
@@ -77,7 +88,10 @@ def test_create_signed_list_blobs_url_v4_w_expiration(
     now = datetime.datetime.utcnow()
     delta = datetime.timedelta(seconds=10)
     _create_signed_list_blobs_url_helper(
-        storage_client, signing_bucket, expiration=now + delta, version="v4",
+        storage_client,
+        signing_bucket,
+        expiration=now + delta,
+        version="v4",
     )
 
 
@@ -135,7 +149,9 @@ def test_create_signed_read_url_v2(storage_client, signing_bucket, no_mtls):
 
 def test_create_signed_read_url_v4(storage_client, signing_bucket, no_mtls):
     _create_signed_read_url_helper(
-        storage_client, signing_bucket, version="v4",
+        storage_client,
+        signing_bucket,
+        version="v4",
     )
 
 
@@ -180,7 +196,7 @@ def test_create_signed_read_url_v2_w_non_ascii_name(
     _create_signed_read_url_helper(
         storage_client,
         signing_bucket,
-        blob_name=u"Caf\xe9.txt",
+        blob_name="Caf\xe9.txt",
         payload=b"Test signed URL for blob w/ non-ASCII name",
     )
 
@@ -191,7 +207,7 @@ def test_create_signed_read_url_v4_w_non_ascii_name(
     _create_signed_read_url_helper(
         storage_client,
         signing_bucket,
-        blob_name=u"Caf\xe9.txt",
+        blob_name="Caf\xe9.txt",
         payload=b"Test signed URL for blob w/ non-ASCII name",
         version="v4",
     )
@@ -276,7 +292,10 @@ def _create_signed_delete_url_helper(client, bucket, version="v2", expiration=No
     blob.upload_from_string(b"DELETE ME!")
 
     signed_delete_url = blob.generate_signed_url(
-        expiration=expiration, method="DELETE", client=client, version=version,
+        expiration=expiration,
+        method="DELETE",
+        client=client,
+        version=version,
     )
 
     response = requests.request("DELETE", signed_delete_url)
@@ -303,7 +322,10 @@ def _create_signed_resumable_upload_url_helper(
 
     # Initiate the upload using a signed URL.
     signed_resumable_upload_url = blob.generate_signed_url(
-        expiration=expiration, method="RESUMABLE", client=client, version=version,
+        expiration=expiration,
+        method="RESUMABLE",
+        client=client,
+        version=version,
     )
 
     post_headers = {"x-goog-resumable": "start"}
@@ -327,7 +349,10 @@ def _create_signed_resumable_upload_url_helper(
 
     # Finally, delete the blob using a signed URL.
     signed_delete_url = blob.generate_signed_url(
-        expiration=expiration, method="DELETE", client=client, version=version,
+        expiration=expiration,
+        method="DELETE",
+        client=client,
+        version=version,
     )
 
     delete_response = requests.delete(signed_delete_url)
@@ -336,20 +361,24 @@ def _create_signed_resumable_upload_url_helper(
 
 def test_create_signed_resumable_upload_url_v2(storage_client, signing_bucket, no_mtls):
     _create_signed_resumable_upload_url_helper(
-        storage_client, signing_bucket, version="v2",
+        storage_client,
+        signing_bucket,
+        version="v2",
     )
 
 
 def test_create_signed_resumable_upload_url_v4(storage_client, signing_bucket, no_mtls):
     _create_signed_resumable_upload_url_helper(
-        storage_client, signing_bucket, version="v4",
+        storage_client,
+        signing_bucket,
+        version="v4",
     )
 
 
 @pytest.mark.skipif(
     _helpers.is_api_endpoint_override,
     reason="Test does not yet support endpoint override",
-)    
+)
 def test_generate_signed_post_policy_v4(
     storage_client, buckets_to_delete, blobs_to_delete, service_account, no_mtls
 ):

--- a/tests/system/test__signing.py
+++ b/tests/system/test__signing.py
@@ -346,6 +346,10 @@ def test_create_signed_resumable_upload_url_v4(storage_client, signing_bucket, n
     )
 
 
+@pytest.mark.skipif(
+    _helpers.is_api_endpoint_override,
+    reason="Test does not yet support endpoint override",
+)    
 def test_generate_signed_post_policy_v4(
     storage_client, buckets_to_delete, blobs_to_delete, service_account, no_mtls
 ):

--- a/tests/system/test__signing.py
+++ b/tests/system/test__signing.py
@@ -196,7 +196,7 @@ def test_create_signed_read_url_v2_w_non_ascii_name(
     _create_signed_read_url_helper(
         storage_client,
         signing_bucket,
-        blob_name="Caf\xe9.txt",
+        blob_name=u"Caf\xe9.txt",
         payload=b"Test signed URL for blob w/ non-ASCII name",
     )
 
@@ -207,7 +207,7 @@ def test_create_signed_read_url_v4_w_non_ascii_name(
     _create_signed_read_url_helper(
         storage_client,
         signing_bucket,
-        blob_name="Caf\xe9.txt",
+        blob_name=u"Caf\xe9.txt",
         payload=b"Test signed URL for blob w/ non-ASCII name",
         version="v4",
     )

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -87,7 +87,11 @@ def test_large_file_write_from_stream_w_failed_checksum(
 
     assert not blob.exists()
 
-
+    
+@pytest.mark.skipif(
+    _helpers.is_api_endpoint_override,
+    reason="Test does not yet support endpoint override",
+)
 def test_large_file_write_from_stream_w_encryption_key(
     storage_client, shared_bucket, blobs_to_delete, file_data, service_account,
 ):

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -18,6 +18,7 @@ import io
 import os
 import tempfile
 import warnings
+import uuid
 
 import pytest
 import six
@@ -833,14 +834,14 @@ def test_blob_compose_w_generation_match_long(shared_bucket, blobs_to_delete):
 
 def test_blob_compose_w_source_generation_match(shared_bucket, blobs_to_delete):
     payload_before = b"AAA\n"
-    original = shared_bucket.blob("original")
+    original = shared_bucket.blob(uuid.uuid4().hex)
     original.content_type = "text/plain"
     original.upload_from_string(payload_before)
     blobs_to_delete.append(original)
     wrong_source_generations = [6, 7]
 
     payload_to_append = b"BBB\n"
-    to_append = shared_bucket.blob("to_append")
+    to_append = shared_bucket.blob(uuid.uuid4().hex)
     to_append.upload_from_string(payload_to_append)
     blobs_to_delete.append(to_append)
 

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -41,7 +41,10 @@ def _check_blob_hash(blob, info):
 
 
 def test_large_file_write_from_stream(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("LargeFile")
 
@@ -54,7 +57,10 @@ def test_large_file_write_from_stream(
 
 
 def test_large_file_write_from_stream_w_checksum(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("LargeFile")
 
@@ -67,7 +73,10 @@ def test_large_file_write_from_stream_w_checksum(
 
 
 def test_large_file_write_from_stream_w_failed_checksum(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("LargeFile")
 
@@ -88,13 +97,17 @@ def test_large_file_write_from_stream_w_failed_checksum(
 
     assert not blob.exists()
 
-    
+
 @pytest.mark.skipif(
     _helpers.is_api_endpoint_override,
     reason="Test does not yet support endpoint override",
 )
 def test_large_file_write_from_stream_w_encryption_key(
-    storage_client, shared_bucket, blobs_to_delete, file_data, service_account,
+    storage_client,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("LargeFile", encryption_key=encryption_key)
 
@@ -116,7 +129,10 @@ def test_large_file_write_from_stream_w_encryption_key(
 
 
 def test_small_file_write_from_filename(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("SmallFile")
 
@@ -128,7 +144,10 @@ def test_small_file_write_from_filename(
 
 
 def test_small_file_write_from_filename_with_checksum(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("SmallFile")
 
@@ -140,7 +159,10 @@ def test_small_file_write_from_filename_with_checksum(
 
 
 def test_small_file_write_from_filename_with_failed_checksum(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("SmallFile")
 
@@ -241,7 +263,10 @@ def test_blob_crud_w_user_project(
 
 
 def test_blob_crud_w_etag_match(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     wrong_etag = "kittens"
 
@@ -287,7 +312,10 @@ def test_blob_crud_w_etag_match(
 
 
 def test_blob_crud_w_generation_match(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     wrong_generation_number = 6
     wrong_metageneration_number = 9
@@ -379,7 +407,10 @@ def test_blob_acl_w_user_project(
 
 
 def test_blob_acl_w_metageneration_match(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     wrong_metageneration_number = 9
     wrong_generation_number = 6
@@ -414,7 +445,10 @@ def test_blob_acl_w_metageneration_match(
 
 
 def test_blob_acl_upload_predefined(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     control = shared_bucket.blob("logo")
     control_info = file_data["logo"]
@@ -444,7 +478,10 @@ def test_blob_acl_upload_predefined(
 
 
 def test_blob_patch_metadata(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     filename = file_data["logo"]["path"]
     blob_name = os.path.basename(filename)
@@ -473,7 +510,9 @@ def test_blob_patch_metadata(
 
 
 def test_blob_direct_write_and_read_into_file(
-    shared_bucket, blobs_to_delete, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     payload = b"Hello World"
     blob = shared_bucket.blob("MyBuffer")
@@ -495,7 +534,9 @@ def test_blob_direct_write_and_read_into_file(
 
 
 def test_blob_download_w_generation_match(
-    shared_bucket, blobs_to_delete, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     wrong_generation_number = 6
 
@@ -528,7 +569,9 @@ def test_blob_download_w_generation_match(
 
 
 def test_blob_download_w_failed_crc32c_checksum(
-    shared_bucket, blobs_to_delete, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     blob = shared_bucket.blob("FailedChecksumBlob")
     payload = b"Hello World"
@@ -561,7 +604,9 @@ def test_blob_download_w_failed_crc32c_checksum(
 
 
 def test_blob_download_as_text(
-    shared_bucket, blobs_to_delete, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     blob = shared_bucket.blob("MyBuffer")
     payload = "Hello World"
@@ -577,7 +622,9 @@ def test_blob_download_as_text(
 
 
 def test_blob_upload_w_gzip_encoded_download_raw(
-    shared_bucket, blobs_to_delete, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     payload = b"DEADBEEF" * 1000
     raw_stream = io.BytesIO()
@@ -598,7 +645,10 @@ def test_blob_upload_w_gzip_encoded_download_raw(
 
 
 def test_blob_upload_from_file_resumable_with_generation(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("LargeFile")
     wrong_generation = 3
@@ -622,18 +672,23 @@ def test_blob_upload_from_file_resumable_with_generation(
     with pytest.raises(exceptions.PreconditionFailed):
         with open(info["path"], "rb") as file_obj:
             blob.upload_from_file(
-                file_obj, if_generation_match=wrong_generation,
+                file_obj,
+                if_generation_match=wrong_generation,
             )
 
     with pytest.raises(exceptions.PreconditionFailed):
         with open(info["path"], "rb") as file_obj:
             blob.upload_from_file(
-                file_obj, if_metageneration_match=wrong_meta_generation,
+                file_obj,
+                if_metageneration_match=wrong_meta_generation,
             )
 
 
 def test_blob_upload_from_string_w_owner(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("MyBuffer")
     payload = b"Hello World"
@@ -648,7 +703,10 @@ def test_blob_upload_from_string_w_owner(
 
 
 def test_blob_upload_from_string_w_custom_time(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("CustomTimeBlob")
     payload = b"Hello World"
@@ -664,7 +722,10 @@ def test_blob_upload_from_string_w_custom_time(
 
 
 def test_blob_upload_from_string_w_custom_time_no_micros(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     # Test that timestamps without microseconds are treated correctly by
     # custom_time encoding/decoding.
@@ -682,7 +743,10 @@ def test_blob_upload_from_string_w_custom_time_no_micros(
 
 
 def test_blob_upload_download_crc32_md5_hash(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("MyBuffer")
     payload = b"Hello World"
@@ -699,8 +763,8 @@ def test_blob_upload_download_crc32_md5_hash(
 @pytest.mark.parametrize(
     "blob_name,payload",
     [
-        (u"Caf\u00e9", b"Normalization Form C"),
-        (u"Cafe\u0301", b"Normalization Form D"),
+        ("Caf\u00e9", b"Normalization Form C"),
+        ("Cafe\u0301", b"Normalization Form D"),
     ],
 )
 def test_blob_w_unicode_names(blob_name, payload, shared_bucket, blobs_to_delete):
@@ -847,7 +911,8 @@ def test_blob_compose_w_source_generation_match(shared_bucket, blobs_to_delete):
 
     with pytest.raises(exceptions.PreconditionFailed):
         original.compose(
-            [original, to_append], if_source_generation_match=wrong_source_generations,
+            [original, to_append],
+            if_source_generation_match=wrong_source_generations,
         )
 
     original.compose(

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -668,7 +668,11 @@ def test_bucket_w_default_event_based_hold(
     assert bucket.retention_period is None
     assert bucket.retention_policy_effective_time is None
     assert not bucket.retention_policy_locked
-
+    
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    _helpers.await_config_changes_propagate()
+    
     blob.upload_from_string(payload)
 
     # https://github.com/googleapis/python-storage/issues/435

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -595,7 +595,7 @@ def test_bucket_w_retention_period(
     blobs_to_delete.append(blob)
 
     other = bucket.get_blob(blob_name)
-     _helpers.retry_has_retention_expiration(other.reload)()
+    _helpers.retry_has_retention_expiration(other.reload)()
 
     assert not other.event_based_hold
     assert not other.temporary_hold

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -94,6 +94,10 @@ def test_bucket_lifecycle_rules(storage_client, buckets_to_delete):
     assert list(bucket.lifecycle_rules) == []
 
 
+@pytest.mark.skipif(
+    _helpers.is_api_endpoint_override,
+    reason="Test does not yet support endpoint override",
+)
 def test_bucket_update_labels(storage_client, buckets_to_delete):
     bucket_name = _helpers.unique_name("update-labels")
     bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -728,6 +728,10 @@ def test_bucket_lock_retention_policy(
         bucket.patch()
 
 
+@pytest.mark.skipif(
+    _helpers.is_api_endpoint_override,
+    reason="Test does not yet support endpoint override",
+)         
 def test_new_bucket_w_ubla(
     storage_client, buckets_to_delete, blobs_to_delete,
 ):

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import time
 
 import pytest
 import six

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -123,7 +123,9 @@ def test_bucket_update_labels(storage_client, buckets_to_delete):
 
 
 def test_bucket_get_set_iam_policy(
-    storage_client, buckets_to_delete, service_account,
+    storage_client,
+    buckets_to_delete,
+    service_account,
 ):
     from google.cloud.storage.iam import STORAGE_OBJECT_VIEWER_ROLE
     from google.api_core.exceptions import BadRequest
@@ -183,7 +185,10 @@ def test_bucket_crud_w_requester_pays(storage_client, buckets_to_delete, user_pr
     assert created.name == bucket_name
     assert created.requester_pays
 
-    with_user_project = storage_client.bucket(bucket_name, user_project=user_project,)
+    with_user_project = storage_client.bucket(
+        bucket_name,
+        user_project=user_project,
+    )
 
     try:
         # Exercise 'buckets.get' w/ userProject.
@@ -216,7 +221,8 @@ def test_bucket_acls_iam_w_user_project(
 ):
     bucket_name = _helpers.unique_name("acl-w-user-project")
     created = _helpers.retry_429_503(storage_client.create_bucket)(
-        bucket_name, requester_pays=True,
+        bucket_name,
+        requester_pays=True,
     )
     buckets_to_delete.append(created)
 
@@ -288,7 +294,10 @@ def test_bucket_acls_w_metageneration_match(storage_client, buckets_to_delete):
 
 
 def test_bucket_copy_blob(
-    storage_client, buckets_to_delete, blobs_to_delete, user_project,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
+    user_project,
 ):
     payload = b"DEADBEEF"
     bucket_name = _helpers.unique_name("copy-blob")
@@ -310,7 +319,10 @@ def test_bucket_copy_blob(
 
 
 def test_bucket_copy_blob_w_user_project(
-    storage_client, buckets_to_delete, blobs_to_delete, user_project,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
+    user_project,
 ):
     payload = b"DEADBEEF"
     bucket_name = _helpers.unique_name("copy-w-requester-pays")
@@ -336,7 +348,9 @@ def test_bucket_copy_blob_w_user_project(
 
 
 def test_bucket_copy_blob_w_generation_match(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     payload = b"DEADBEEF"
     bucket_name = _helpers.unique_name("generation-match")
@@ -351,7 +365,10 @@ def test_bucket_copy_blob_w_generation_match(
     dest_bucket = storage_client.bucket(bucket_name)
 
     new_blob = dest_bucket.copy_blob(
-        blob, dest_bucket, "simple-copy", if_source_generation_match=blob.generation,
+        blob,
+        dest_bucket,
+        "simple-copy",
+        if_source_generation_match=blob.generation,
     )
     blobs_to_delete.append(new_blob)
 
@@ -359,7 +376,9 @@ def test_bucket_copy_blob_w_generation_match(
 
 
 def test_bucket_copy_blob_w_metageneration_match(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     payload = b"DEADBEEF"
     bucket_name = _helpers.unique_name("generation-match")
@@ -387,7 +406,10 @@ def test_bucket_copy_blob_w_metageneration_match(
 
 
 def test_bucket_get_blob_with_user_project(
-    storage_client, buckets_to_delete, blobs_to_delete, user_project,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
+    user_project,
 ):
     blob_name = "blob-name"
     payload = b"DEADBEEF"
@@ -419,7 +441,10 @@ def test_bucket_list_blobs(listable_bucket, listable_filenames):
 
 @_helpers.retry_failures
 def test_bucket_list_blobs_w_user_project(
-    storage_client, listable_bucket, listable_filenames, user_project,
+    storage_client,
+    listable_bucket,
+    listable_filenames,
+    user_project,
 ):
     with_user_project = storage_client.bucket(
         listable_bucket.name, user_project=user_project
@@ -551,7 +576,8 @@ def test_bucket_list_blobs_hierarchy_third_level(hierarchy_bucket, hierarchy_fil
 
 @_helpers.retry_failures
 def test_bucket_list_blobs_hierarchy_w_include_trailing_delimiter(
-    hierarchy_bucket, hierarchy_filenames,
+    hierarchy_bucket,
+    hierarchy_filenames,
 ):
     expected_names = ["file01.txt", "parent/"]
     expected_prefixes = set(["parent/"])
@@ -568,7 +594,9 @@ def test_bucket_list_blobs_hierarchy_w_include_trailing_delimiter(
 
 
 def test_bucket_w_retention_period(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     period_secs = 10
     bucket_name = _helpers.unique_name("w-retention-period")
@@ -578,7 +606,7 @@ def test_bucket_w_retention_period(
     bucket.retention_period = period_secs
     bucket.default_event_based_hold = False
     bucket.patch()
-    
+
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
     _helpers.retry_has_retention_period(bucket.reload)()
@@ -607,8 +635,8 @@ def test_bucket_w_retention_period(
 
     bucket.retention_period = None
     bucket.patch()
-    
-   # Changes to the bucket will be readable immediately after writing,
+
+    # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
     _helpers.retry_no_retention_period(bucket.reload)()
 
@@ -628,7 +656,9 @@ def test_bucket_w_retention_period(
 
 
 def test_bucket_w_default_event_based_hold(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     bucket_name = _helpers.unique_name("w-def-ebh")
     bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)
@@ -669,11 +699,11 @@ def test_bucket_w_default_event_based_hold(
     assert bucket.retention_period is None
     assert bucket.retention_policy_effective_time is None
     assert not bucket.retention_policy_locked
-    
+
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
     _helpers.await_config_changes_propagate()
-    
+
     blob.upload_from_string(payload)
 
     # https://github.com/googleapis/python-storage/issues/435
@@ -689,7 +719,9 @@ def test_bucket_w_default_event_based_hold(
 
 
 def test_blob_w_temporary_hold(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     bucket_name = _helpers.unique_name("w-tmp-hold")
     bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)
@@ -721,7 +753,8 @@ def test_blob_w_temporary_hold(
 
 
 def test_bucket_lock_retention_policy(
-    storage_client, buckets_to_delete,
+    storage_client,
+    buckets_to_delete,
 ):
     period_secs = 10
     bucket_name = _helpers.unique_name("loc-ret-policy")
@@ -749,9 +782,11 @@ def test_bucket_lock_retention_policy(
 @pytest.mark.skipif(
     _helpers.is_api_endpoint_override,
     reason="Test does not yet support endpoint override",
-)         
+)
 def test_new_bucket_w_ubla(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     bucket_name = _helpers.unique_name("new-w-ubla")
     bucket = storage_client.bucket(bucket_name)
@@ -788,7 +823,9 @@ def test_new_bucket_w_ubla(
 
 
 def test_ubla_set_unset_preserves_acls(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     bucket_name = _helpers.unique_name("ubla-acls")
     bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)
@@ -829,7 +866,9 @@ def test_ubla_set_unset_preserves_acls(
 
 
 def test_new_bucket_created_w_inherited_pap(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     from google.cloud.storage import constants
 
@@ -880,7 +919,9 @@ def test_new_bucket_created_w_inherited_pap(
 
 @pytest.mark.skip(reason="Unspecified PAP is changing to inherited")
 def test_new_bucket_created_w_enforced_pap(
-    storage_client, buckets_to_delete, blobs_to_delete,
+    storage_client,
+    buckets_to_delete,
+    blobs_to_delete,
 ):
     from google.cloud.storage import constants
 

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -26,6 +26,10 @@ from . import _helpers
 public_bucket = "gcp-public-data-landsat"
 
 
+@pytest.mark.skipif(
+    _helpers.is_api_endpoint_override,
+    reason="Test does not yet support endpoint override",
+) 
 @vpcsc_config.skip_if_inside_vpcsc
 def test_anonymous_client_access_to_public_bucket():
     from google.cloud.storage.client import Client
@@ -39,6 +43,10 @@ def test_anonymous_client_access_to_public_bucket():
         _helpers.retry_429_503(blob.download_to_file)(stream)
 
 
+@pytest.mark.skipif(
+    _helpers.is_api_endpoint_override,
+    reason="Test does not yet support endpoint override",
+)         
 def test_get_service_account_email(storage_client, service_account):
     domain = "gs-project-accounts.iam.gserviceaccount.com"
     email = storage_client.get_service_account_email()

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -29,7 +29,7 @@ public_bucket = "gcp-public-data-landsat"
 @pytest.mark.skipif(
     _helpers.is_api_endpoint_override,
     reason="Test does not yet support endpoint override",
-) 
+)
 @vpcsc_config.skip_if_inside_vpcsc
 def test_anonymous_client_access_to_public_bucket():
     from google.cloud.storage.client import Client
@@ -37,7 +37,8 @@ def test_anonymous_client_access_to_public_bucket():
     anonymous_client = Client.create_anonymous_client()
     bucket = anonymous_client.bucket(public_bucket)
     (blob,) = _helpers.retry_429_503(anonymous_client.list_blobs)(
-        bucket, max_results=1,
+        bucket,
+        max_results=1,
     )
     with tempfile.TemporaryFile() as stream:
         _helpers.retry_429_503(blob.download_to_file)(stream)
@@ -46,7 +47,7 @@ def test_anonymous_client_access_to_public_bucket():
 @pytest.mark.skipif(
     _helpers.is_api_endpoint_override,
     reason="Test does not yet support endpoint override",
-)         
+)
 def test_get_service_account_email(storage_client, service_account):
     domain = "gs-project-accounts.iam.gserviceaccount.com"
     email = storage_client.get_service_account_email()
@@ -93,7 +94,10 @@ def test_list_buckets(storage_client, buckets_to_delete):
 
 
 def test_download_blob_to_file_w_uri(
-    storage_client, shared_bucket, blobs_to_delete, service_account,
+    storage_client,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     blob = shared_bucket.blob("MyBuffer")
     payload = b"Hello World"
@@ -114,7 +118,10 @@ def test_download_blob_to_file_w_uri(
 
 
 def test_download_blob_to_file_w_etag(
-    storage_client, shared_bucket, blobs_to_delete, service_account,
+    storage_client,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     filename = "kittens"
     blob = shared_bucket.blob(filename)
@@ -148,6 +155,8 @@ def test_download_blob_to_file_w_etag(
 
     buffer = io.BytesIO()
     storage_client.download_blob_to_file(
-        "gs://" + shared_bucket.name + "/" + filename, buffer, if_etag_match=blob.etag,
+        "gs://" + shared_bucket.name + "/" + filename,
+        buffer,
+        if_etag_match=blob.etag,
     )
     assert buffer.getvalue() == payload

--- a/tests/system/test_fileio.py
+++ b/tests/system/test_fileio.py
@@ -18,7 +18,10 @@ from .test_blob import _check_blob_hash
 
 
 def test_blobwriter_and_blobreader(
-    shared_bucket, blobs_to_delete, file_data, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    file_data,
+    service_account,
 ):
     blob = shared_bucket.blob("LargeFile")
 
@@ -49,12 +52,14 @@ def test_blobwriter_and_blobreader(
 
 
 def test_blobwriter_and_blobreader_text_mode(
-    shared_bucket, blobs_to_delete, service_account,
+    shared_bucket,
+    blobs_to_delete,
+    service_account,
 ):
     blob = shared_bucket.blob("MultibyteTextFile")
 
     # Construct a multibyte text_data sample file.
-    base_multibyte_text_string = u"abcde あいうえお line: "
+    base_multibyte_text_string = "abcde あいうえお line: "
     text_data = "\n".join([base_multibyte_text_string + str(x) for x in range(100)])
 
     # Test text BlobWriter works.

--- a/tests/system/test_fileio.py
+++ b/tests/system/test_fileio.py
@@ -59,7 +59,7 @@ def test_blobwriter_and_blobreader_text_mode(
     blob = shared_bucket.blob("MultibyteTextFile")
 
     # Construct a multibyte text_data sample file.
-    base_multibyte_text_string = "abcde あいうえお line: "
+    base_multibyte_text_string = u"abcde あいうえお line: "
     text_data = "\n".join([base_multibyte_text_string + str(x) for x in range(100)])
 
     # Test text BlobWriter works.

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -28,7 +28,10 @@ _key_name_format = "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}"
 
 def _kms_key_name(client, bucket, key_name):
     return _key_name_format.format(
-        client.project, bucket.location.lower(), keyring_name, key_name,
+        client.project,
+        bucket.location.lower(),
+        keyring_name,
+        key_name,
     )
 
 
@@ -165,10 +168,13 @@ def test_bucket_w_default_kms_key_name(
     kms_bucket.default_kms_key_name = None
     kms_bucket.patch()
     assert kms_bucket.default_kms_key_name is None
-    
+
 
 def test_blob_rewrite_rotate_csek_to_cmek(
-    kms_bucket, blobs_to_delete, kms_key_name, file_data,
+    kms_bucket,
+    blobs_to_delete,
+    kms_key_name,
+    file_data,
 ):
     blob_name = "rotating-keys"
     source_key = os.urandom(32)
@@ -201,7 +207,10 @@ def test_blob_rewrite_rotate_csek_to_cmek(
 
 
 def test_blob_upload_w_bucket_cmek_enabled(
-    kms_bucket, blobs_to_delete, kms_key_name, file_data,
+    kms_bucket,
+    blobs_to_delete,
+    kms_key_name,
+    file_data,
 ):
     blob_name = "test-blob"
     payload = b"DEADBEEF"
@@ -210,7 +219,7 @@ def test_blob_upload_w_bucket_cmek_enabled(
     kms_bucket.default_kms_key_name = kms_key_name
     kms_bucket.patch()
     assert kms_bucket.default_kms_key_name == kms_key_name
-    
+
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
     _helpers.await_config_changes_propagate()

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -127,13 +127,13 @@ def test_blob_w_explicit_kms_key_name(
 
 @_helpers.retry_failures
 def test_bucket_w_default_kms_key_name(
-    kms_bucket, blobs_to_delete, kms_key_name, alt_kms_key_name, file_data,
+    kms_bucket,
+    blobs_to_delete,
+    kms_key_name,
+    alt_kms_key_name,
+    file_data,
 ):
     blob_name = "default-kms-key-name"
-    override_blob_name = "override-default-kms-key-name"
-    alt_blob_name = "alt-default-kms-key-name"
-    cleartext_blob_name = "cleartext"
-
     info = file_data["simple"]
 
     with open(info["path"], "rb") as file_obj:
@@ -142,11 +142,11 @@ def test_bucket_w_default_kms_key_name(
     kms_bucket.default_kms_key_name = kms_key_name
     kms_bucket.patch()
     assert kms_bucket.default_kms_key_name == kms_key_name
-    
+
     # Changes to the bucket will be readable immediately after writing,
     # but configuration changes may take time to propagate.
-    _helpers.await_config_changes_propagate()    
-    
+    _helpers.await_config_changes_propagate()
+
     defaulted_blob = kms_bucket.blob(blob_name)
     defaulted_blob.upload_from_filename(info["path"])
     blobs_to_delete.append(defaulted_blob)
@@ -156,35 +156,16 @@ def test_bucket_w_default_kms_key_name(
     # We don't know the current version of the key.
     assert defaulted_blob.kms_key_name.startswith(kms_key_name)
 
-    override_blob = kms_bucket.blob(override_blob_name, kms_key_name=alt_kms_key_name)
-    override_blob.upload_from_filename(info["path"])
-    blobs_to_delete.append(override_blob)
-
-    assert override_blob.download_as_bytes() == payload
-    # We don't know the current version of the key.
-    assert override_blob.kms_key_name.startswith(alt_kms_key_name)
-
+    # Test changing the default KMS key.
     kms_bucket.default_kms_key_name = alt_kms_key_name
     kms_bucket.patch()
+    assert kms_bucket.default_kms_key_name == alt_kms_key_name
 
-    alt_blob = kms_bucket.blob(alt_blob_name)
-    alt_blob.upload_from_filename(info["path"])
-    blobs_to_delete.append(alt_blob)
-
-    assert alt_blob.download_as_bytes() == payload
-    # We don't know the current version of the key.
-    assert alt_blob.kms_key_name.startswith(alt_kms_key_name)
-
+    # Test removing the default KMS key.
     kms_bucket.default_kms_key_name = None
     kms_bucket.patch()
-
-    cleartext_blob = kms_bucket.blob(cleartext_blob_name)
-    cleartext_blob.upload_from_filename(info["path"])
-    blobs_to_delete.append(cleartext_blob)
-
-    assert cleartext_blob.download_as_bytes() == payload
-    assert cleartext_blob.kms_key_name is None
-
+    assert kms_bucket.default_kms_key_name is None
+    
 
 def test_blob_rewrite_rotate_csek_to_cmek(
     kms_bucket, blobs_to_delete, kms_key_name, file_data,

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -229,6 +229,10 @@ def test_blob_upload_w_bucket_cmek_enabled(
     kms_bucket.default_kms_key_name = kms_key_name
     kms_bucket.patch()
     assert kms_bucket.default_kms_key_name == kms_key_name
+    
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    _helpers.await_config_changes_propagate()
 
     blob = kms_bucket.blob(blob_name)
     blob.upload_from_string(payload)

--- a/tests/system/test_kms_integration.py
+++ b/tests/system/test_kms_integration.py
@@ -142,7 +142,11 @@ def test_bucket_w_default_kms_key_name(
     kms_bucket.default_kms_key_name = kms_key_name
     kms_bucket.patch()
     assert kms_bucket.default_kms_key_name == kms_key_name
-
+    
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    _helpers.await_config_changes_propagate()    
+    
     defaulted_blob = kms_bucket.blob(blob_name)
     defaulted_blob.upload_from_filename(info["path"])
     blobs_to_delete.append(defaulted_blob)

--- a/tests/system/test_notification.py
+++ b/tests/system/test_notification.py
@@ -70,7 +70,10 @@ def notification_topic(storage_client, publisher_client, topic_path, no_mtls):
 
 
 def test_notification_create_minimal(
-    storage_client, buckets_to_delete, topic_name, notification_topic,
+    storage_client,
+    buckets_to_delete,
+    topic_name,
+    notification_topic,
 ):
     bucket_name = _helpers.unique_name("notification-minimal")
     bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)
@@ -126,7 +129,11 @@ def test_notification_create_explicit(
 
 
 def test_notification_create_w_user_project(
-    storage_client, buckets_to_delete, topic_name, notification_topic, user_project,
+    storage_client,
+    buckets_to_delete,
+    topic_name,
+    notification_topic,
+    user_project,
 ):
     bucket_name = _helpers.unique_name("notification-w-up")
     bucket = _helpers.retry_429_503(storage_client.create_bucket)(bucket_name)


### PR DESCRIPTION
Made changes that override api endpoint information while triggering builds from kokoro .
All tests against prod are still successful.
Some system tests are currently incompatible with nonprod environments and hence are marked to be skipped if endpoint is being overriden.