### PR TITLE
fix: implement closed property on fileio.py classes

### DIFF
--- a/google/cloud/storage/fileio.py
+++ b/google/cloud/storage/fileio.py
@@ -211,9 +211,9 @@ class BlobReader(io.BufferedIOBase):
     def close(self):
         self._buffer.close()
 
-    def _checkClosed(self):
-        if self._buffer.closed:
-            raise ValueError("I/O operation on closed file.")
+    @property
+    def closed(self):
+        return self._buffer.closed
 
     def readable(self):
         return True
@@ -431,9 +431,9 @@ class BlobWriter(io.BufferedIOBase):
             self._upload_chunks_from_buffer(1)
         self._buffer.close()
 
-    def _checkClosed(self):
-        if self._buffer.closed:
-            raise ValueError("I/O operation on closed file.")
+    @property
+    def closed(self):
+        return self._buffer.closed
 
     def readable(self):
         return False

--- a/tests/unit/test_fileio.py
+++ b/tests/unit/test_fileio.py
@@ -416,6 +416,8 @@ class TestBlobWriterBinary(unittest.TestCase, _BlobWriterBase):
         writer.close()
         # Close a second time to verify it successfully does nothing.
         writer.close()
+
+        self.assertTrue(writer.closed)
         # Try to write to closed file.
         with self.assertRaises(ValueError):
             writer.write(TEST_BINARY_DATA)
@@ -768,7 +770,7 @@ class Test_SlidingBuffer(unittest.TestCase):
     def test_close(self):
         buff = self._make_sliding_buffer()
         buff.close()
-        self.assertTrue(buff.closed())
+        self.assertTrue(buff.closed)
         with self.assertRaises(ValueError):
             buff.read()
 
@@ -915,7 +917,7 @@ class TestBlobReaderText(unittest.TestCase, _BlobReaderBase):
         reader = self._make_blob_reader(blob)
 
         reader.close()
-        self.assertRaises(self.closed)
+        self.assertTrue(reader.closed)
 
         with self.assertRaises(ValueError):
             reader.read()

--- a/tests/unit/test_fileio.py
+++ b/tests/unit/test_fileio.py
@@ -287,6 +287,7 @@ class TestBlobReaderBinary(unittest.TestCase, _BlobReaderBase):
         reader = self._make_blob_reader(blob)
 
         reader.close()
+        self.assertTrue(reader.closed)
 
         with self.assertRaises(ValueError):
             reader.read()
@@ -767,6 +768,7 @@ class Test_SlidingBuffer(unittest.TestCase):
     def test_close(self):
         buff = self._make_sliding_buffer()
         buff.close()
+        self.assertTrue(buff.closed())
         with self.assertRaises(ValueError):
             buff.read()
 
@@ -913,6 +915,7 @@ class TestBlobReaderText(unittest.TestCase, _BlobReaderBase):
         reader = self._make_blob_reader(blob)
 
         reader.close()
+        self.assertRaises(self.closed)
 
         with self.assertRaises(ValueError):
             reader.read()


### PR DESCRIPTION
Replace `_checkClosed()` function with `closed` property on fileio.py classes. `_checkClosed()` will still work, as the inherited implementation uses `self.closed`.

Fixes #903 🦕
