### PR TITLE
chore(revert): revert add support for use_auth_w_custom_endpoint

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -33,14 +33,16 @@ from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
 STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"
 """Environment variable defining host for Storage emulator."""
 
-_BASE_STORAGE_URI = "https://storage.googleapis.com"
-"""Base request endpoint URI for JSON API."""
-
-_DEFAULT_STORAGE_HOST = os.getenv("API_ENDPOINT_OVERRIDE", _BASE_STORAGE_URI)
+_DEFAULT_STORAGE_HOST = os.getenv(
+    "API_ENDPOINT_OVERRIDE", "https://storage.googleapis.com"
+)
 """Default storage host for JSON API."""
 
 _API_VERSION = os.getenv("API_VERSION_OVERRIDE", "v1")
 """API version of the default storage host"""
+
+_BASE_STORAGE_URI = "storage.googleapis.com"
+"""Base request endpoint URI for JSON API."""
 
 # etag match parameters in snake case and equivalent header
 _ETAG_MATCH_PARAMETERS = (

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -96,12 +96,6 @@ class Client(ClientWithProject):
     :type client_options: :class:`~google.api_core.client_options.ClientOptions` or :class:`dict`
     :param client_options: (Optional) Client options used to set user options on the client.
         API Endpoint should be set through client_options.
-
-    :type use_auth_w_custom_endpoint: bool
-    :param use_auth_w_custom_endpoint:
-        (Optional) Whether authentication is required under custom endpoints.
-        If false, uses AnonymousCredentials and bypasses authentication.
-        Defaults to True. Note this is only used when a custom endpoint is set in conjunction.
     """
 
     SCOPE = (
@@ -118,7 +112,6 @@ class Client(ClientWithProject):
         _http=None,
         client_info=None,
         client_options=None,
-        use_auth_w_custom_endpoint=True,
     ):
         self._base_connection = None
 
@@ -139,7 +132,7 @@ class Client(ClientWithProject):
         # then mTLS logic will be applied to decide which endpoint will be used.
         storage_host = _get_storage_host()
         kw_args["api_endpoint"] = (
-            storage_host if storage_host != _BASE_STORAGE_URI else None
+            storage_host if storage_host != _DEFAULT_STORAGE_HOST else None
         )
 
         if client_options:
@@ -151,23 +144,19 @@ class Client(ClientWithProject):
                 api_endpoint = client_options.api_endpoint
                 kw_args["api_endpoint"] = api_endpoint
 
-        # If a custom endpoint is set, the client checks for credentials
-        # or finds the default credentials based on the current environment.
-        # Authentication may be bypassed under certain conditions:
-        # (1) STORAGE_EMULATOR_HOST is set (for backwards compatibility), OR
-        # (2) use_auth_w_custom_endpoint is set to False.
-        if kw_args["api_endpoint"] is not None:
-            if (
-                kw_args["api_endpoint"] == storage_host
-                or not use_auth_w_custom_endpoint
-            ):
-                if credentials is None:
-                    credentials = AnonymousCredentials()
-                if project is None:
-                    project = _get_environ_project()
-                if project is None:
-                    no_project = True
-                    project = "<none>"
+        # Use anonymous credentials and no project when
+        # STORAGE_EMULATOR_HOST or a non-default api_endpoint is set.
+        if (
+            kw_args["api_endpoint"] is not None
+            and _BASE_STORAGE_URI not in kw_args["api_endpoint"]
+        ):
+            if credentials is None:
+                credentials = AnonymousCredentials()
+            if project is None:
+                project = _get_environ_project()
+            if project is None:
+                no_project = True
+                project = "<none>"
 
         super(Client, self).__init__(
             project=project,
@@ -908,7 +897,7 @@ class Client(ClientWithProject):
             project = self.project
 
         # Use no project if STORAGE_EMULATOR_HOST is set
-        if _get_storage_host() != _DEFAULT_STORAGE_HOST:
+        if _BASE_STORAGE_URI not in _get_storage_host():
             if project is None:
                 project = _get_environ_project()
             if project is None:
@@ -1338,7 +1327,7 @@ class Client(ClientWithProject):
             project = self.project
 
         # Use no project if STORAGE_EMULATOR_HOST is set
-        if _get_storage_host() != _DEFAULT_STORAGE_HOST:
+        if _BASE_STORAGE_URI not in _get_storage_host():
             if project is None:
                 project = _get_environ_project()
             if project is None:


### PR DESCRIPTION
Reverts googleapis/python-storage#901

Reworking on auth config for custom endpoints and overrides - further investigation required in presubmit, continuous and preprod testing

closes #920- #938
closes #920, closes #921, closes #922, closes #923, closes #924, closes #925