### PR TITLE
feat: add use_auth_w_custom_endpoint support

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -47,9 +47,6 @@ _DEFAULT_STORAGE_HOST = os.getenv(
 _API_VERSION = os.getenv(_API_VERSION_OVERRIDE_ENV_VAR, "v1")
 """API version of the default storage host"""
 
-_BASE_STORAGE_URI = "storage.googleapis.com"
-"""Base request endpoint URI for JSON API."""
-
 # etag match parameters in snake case and equivalent header
 _ETAG_MATCH_PARAMETERS = (
     ("if_etag_match", "If-Match"),

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -33,12 +33,18 @@ from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
 STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"
 """Environment variable defining host for Storage emulator."""
 
+_API_ENDPOINT_OVERRIDE_ENV_VAR = "API_ENDPOINT_OVERRIDE"
+"""This is an experimental configuration variable. Use api_endpoint instead."""
+
+_API_VERSION_OVERRIDE_ENV_VAR = "API_VERSION_OVERRIDE"
+"""This is an experimental configuration variable used for internal testing."""
+
 _DEFAULT_STORAGE_HOST = os.getenv(
-    "API_ENDPOINT_OVERRIDE", "https://storage.googleapis.com"
+    _API_ENDPOINT_OVERRIDE_ENV_VAR, "https://storage.googleapis.com"
 )
 """Default storage host for JSON API."""
 
-_API_VERSION = os.getenv("API_VERSION_OVERRIDE", "v1")
+_API_VERSION = os.getenv(_API_VERSION_OVERRIDE_ENV_VAR, "v1")
 """API version of the default storage host"""
 
 _BASE_STORAGE_URI = "storage.googleapis.com"

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -96,6 +96,12 @@ class Client(ClientWithProject):
     :type client_options: :class:`~google.api_core.client_options.ClientOptions` or :class:`dict`
     :param client_options: (Optional) Client options used to set user options on the client.
         API Endpoint should be set through client_options.
+
+    :type use_auth_w_custom_endpoint: bool
+    :param use_auth_w_custom_endpoint:
+        (Optional) Whether authentication is required under custom endpoints.
+        If false, uses AnonymousCredentials and bypasses authentication.
+        Defaults to True. Note this is only used when a custom endpoint is set in conjunction.
     """
 
     SCOPE = (
@@ -112,6 +118,7 @@ class Client(ClientWithProject):
         _http=None,
         client_info=None,
         client_options=None,
+        use_auth_w_custom_endpoint=True,
     ):
         self._base_connection = None
 
@@ -144,19 +151,23 @@ class Client(ClientWithProject):
                 api_endpoint = client_options.api_endpoint
                 kw_args["api_endpoint"] = api_endpoint
 
-        # Use anonymous credentials and no project when
-        # STORAGE_EMULATOR_HOST or a non-default api_endpoint is set.
-        if (
-            kw_args["api_endpoint"] is not None
-            and _BASE_STORAGE_URI not in kw_args["api_endpoint"]
-        ):
-            if credentials is None:
-                credentials = AnonymousCredentials()
-            if project is None:
-                project = _get_environ_project()
-            if project is None:
-                no_project = True
-                project = "<none>"
+        # If a custom endpoint is set, the client checks for credentials
+        # or finds the default credentials based on the current environment.
+        # Authentication may be bypassed under certain conditions:
+        # (1) STORAGE_EMULATOR_HOST is set (for backwards compatibility), OR
+        # (2) use_auth_w_custom_endpoint is set to False.
+        if kw_args["api_endpoint"] is not None:
+            if (
+                kw_args["api_endpoint"] == storage_host
+                or not use_auth_w_custom_endpoint
+            ):
+                if credentials is None:
+                    credentials = AnonymousCredentials()
+                if project is None:
+                    project = _get_environ_project()
+                if project is None:
+                    no_project = True
+                    project = "<none>"
 
         super(Client, self).__init__(
             project=project,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -28,9 +28,10 @@ from google.api_core import exceptions
 from google.auth.credentials import AnonymousCredentials
 from google.oauth2.service_account import Credentials
 
+from google.cloud.storage import _helpers
 from google.cloud.storage._helpers import STORAGE_EMULATOR_ENV_VAR
 from google.cloud.storage._helpers import _get_default_headers
-from google.cloud.storage import _helpers
+from google.cloud.storage._http import Connection
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_GENERATION_SPECIFIED
 from tests.unit.test__helpers import GCCL_INVOCATION_TEST_CONST
@@ -119,7 +120,6 @@ class TestClient(unittest.TestCase):
 
     def test_ctor_connection_type(self):
         from google.cloud._http import ClientInfo
-        from google.cloud.storage._http import Connection
 
         PROJECT = "PROJECT"
         credentials = _make_credentials()
@@ -179,8 +179,6 @@ class TestClient(unittest.TestCase):
         )
 
     def test_ctor_wo_project(self):
-        from google.cloud.storage._http import Connection
-
         PROJECT = "PROJECT"
         credentials = _make_credentials(project=PROJECT)
 
@@ -193,8 +191,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(list(client._batch_stack), [])
 
     def test_ctor_w_project_explicit_none(self):
-        from google.cloud.storage._http import Connection
-
         credentials = _make_credentials()
 
         client = self._make_one(project=None, credentials=credentials)
@@ -207,7 +203,6 @@ class TestClient(unittest.TestCase):
 
     def test_ctor_w_client_info(self):
         from google.cloud._http import ClientInfo
-        from google.cloud.storage._http import Connection
 
         credentials = _make_credentials()
         client_info = ClientInfo()
@@ -238,6 +233,38 @@ class TestClient(unittest.TestCase):
         )
         self.assertEqual(client._connection.ALLOW_AUTO_SWITCH_TO_MTLS_URL, False)
         self.assertEqual(client._connection.API_BASE_URL, "http://foo")
+
+    def test_ctor_w_custom_endpoint_use_auth(self):
+        custom_endpoint = "storage-example.p.googleapis.com"
+        client = self._make_one(client_options={"api_endpoint": custom_endpoint})
+        self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
+        self.assertIsNotNone(client.project)
+        self.assertIsInstance(client._connection, Connection)
+        self.assertIsNotNone(client._connection.credentials)
+        self.assertNotIsInstance(client._connection.credentials, AnonymousCredentials)
+
+    def test_ctor_w_custom_endpoint_bypass_auth(self):
+        custom_endpoint = "storage-example.p.googleapis.com"
+        client = self._make_one(
+            client_options={"api_endpoint": custom_endpoint},
+            use_auth_w_custom_endpoint=False,
+        )
+        self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
+        self.assertEqual(client.project, None)
+        self.assertIsInstance(client._connection, Connection)
+        self.assertIsInstance(client._connection.credentials, AnonymousCredentials)
+
+    def test_ctor_w_custom_endpoint_w_credentials(self):
+        PROJECT = "PROJECT"
+        custom_endpoint = "storage-example.p.googleapis.com"
+        credentials = _make_credentials(project=PROJECT)
+        client = self._make_one(
+            credentials=credentials, client_options={"api_endpoint": custom_endpoint}
+        )
+        self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
+        self.assertEqual(client.project, PROJECT)
+        self.assertIsInstance(client._connection, Connection)
+        self.assertIs(client._connection.credentials, credentials)
 
     def test_ctor_w_emulator_wo_project(self):
         # bypasses authentication if STORAGE_EMULATOR_ENV_VAR is set
@@ -291,47 +318,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(client._connection.API_BASE_URL, host)
         self.assertIs(client._connection.credentials, credentials)
 
-    def test_ctor_w_custom_endpoint_use_auth(self):
-        from google.cloud.storage._http import Connection
-
-        custom_endpoint = "storage-example.p.googleapis.com"
-        client = self._make_one(client_options={"api_endpoint": custom_endpoint})
-        self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
-        self.assertIsNotNone(client.project)
-        self.assertIsInstance(client._connection, Connection)
-        self.assertIsNotNone(client._connection.credentials)
-        self.assertNotIsInstance(client._connection.credentials, AnonymousCredentials)
-
-    def test_ctor_w_custom_endpoint_bypass_auth(self):
-        from google.cloud.storage._http import Connection
-
-        custom_endpoint = "storage-example.p.googleapis.com"
-        client = self._make_one(
-            client_options={"api_endpoint": custom_endpoint},
-            use_auth_w_custom_endpoint=False,
-        )
-        self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
-        self.assertEqual(client.project, None)
-        self.assertIsInstance(client._connection, Connection)
-        self.assertIsInstance(client._connection.credentials, AnonymousCredentials)
-
-    def test_ctor_w_custom_endpoint_w_credentials(self):
-        from google.cloud.storage._http import Connection
-
-        PROJECT = "PROJECT"
-        custom_endpoint = "storage-example.p.googleapis.com"
-        credentials = _make_credentials(project=PROJECT)
-        client = self._make_one(
-            credentials=credentials, client_options={"api_endpoint": custom_endpoint}
-        )
-        self.assertEqual(client._connection.API_BASE_URL, custom_endpoint)
-        self.assertEqual(client.project, PROJECT)
-        self.assertIsInstance(client._connection, Connection)
-        self.assertIs(client._connection.credentials, credentials)
-
     def test_create_anonymous_client(self):
-        from google.cloud.storage._http import Connection
-
         klass = self._get_target_class()
         client = klass.create_anonymous_client()
 
@@ -1309,6 +1296,28 @@ class TestClient(unittest.TestCase):
             _target_object=bucket,
         )
 
+    def test_create_bucket_w_custom_endpoint(self):
+        custom_endpoint = "storage-example.p.googleapis.com"
+        client = self._make_one(client_options={"api_endpoint": custom_endpoint})
+        bucket_name = "bucket-name"
+        api_response = {"name": bucket_name}
+        client._post_resource = mock.Mock()
+        client._post_resource.return_value = api_response
+
+        bucket = client.create_bucket(bucket_name)
+
+        expected_path = "/b"
+        expected_data = api_response
+        expected_query_params = {"project": client.project}
+        client._post_resource.assert_called_once_with(
+            expected_path,
+            expected_data,
+            query_params=expected_query_params,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=bucket,
+        )
+
     def test_create_bucket_w_conflict_w_user_project(self):
         from google.cloud.exceptions import Conflict
 
@@ -2082,6 +2091,37 @@ class TestClient(unittest.TestCase):
         expected_page_size = None
         expected_extra_params = {
             "project": environ_project,
+            "projection": "noAcl",
+        }
+        client._list_resource.assert_called_once_with(
+            expected_path,
+            expected_item_to_value,
+            page_token=expected_page_token,
+            max_results=expected_max_results,
+            extra_params=expected_extra_params,
+            page_size=expected_page_size,
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+        )
+
+    def test_list_buckets_w_custom_endpoint(self):
+        from google.cloud.storage.client import _item_to_bucket
+
+        custom_endpoint = "storage-example.p.googleapis.com"
+        client = self._make_one(client_options={"api_endpoint": custom_endpoint})
+        client._list_resource = mock.Mock(spec=[])
+
+        iterator = client.list_buckets()
+
+        self.assertIs(iterator, client._list_resource.return_value)
+
+        expected_path = "/b"
+        expected_item_to_value = _item_to_bucket
+        expected_page_token = None
+        expected_max_results = None
+        expected_page_size = None
+        expected_extra_params = {
+            "project": client.project,
             "projection": "noAcl",
         }
         client._list_resource.assert_called_once_with(


### PR DESCRIPTION
This adds a boolean flag `use_auth_w_custom_endpoint`  -  whether authentication is required with custom endpoints
- only used when a custom endpoint in set in conjunction
- **defaults to True** and uses authentication
- if set to False, bypasses authentication

For backwards compatibility
- by default, auth is bypassed when `STORAGE_EMULATOR_HOST` is set
- add bool `_is_emulator_set` to improve readability

Refactored to ensure preprod testing is not adversely impacted
- updated docstring to note internal testing used environment variables

Fixes #895  and internal b/258502260
