### PR TITLE
samples: add metageneration-match preconditions to samples

### DIFF
--- a/samples/snippets/storage_release_event_based_hold.py
+++ b/samples/snippets/storage_release_event_based_hold.py
@@ -30,8 +30,12 @@ def release_event_based_hold(bucket_name, blob_name):
     bucket = storage_client.bucket(bucket_name)
     blob = bucket.blob(blob_name)
 
+    # Optional: set a metageneration-match precondition to avoid potential race
+    # conditions and data corruptions. The request to patch is aborted if the
+    # object's metageneration does not match your precondition.
+    blob.reload()
     blob.event_based_hold = False
-    blob.patch()
+    blob.patch(if_metageneration_match=blob.metageneration)
 
     print(f"Event based hold was released for {blob_name}")
 

--- a/samples/snippets/storage_release_temporary_hold.py
+++ b/samples/snippets/storage_release_temporary_hold.py
@@ -30,8 +30,12 @@ def release_temporary_hold(bucket_name, blob_name):
     bucket = storage_client.bucket(bucket_name)
     blob = bucket.blob(blob_name)
 
+    # Optional: set a metageneration-match precondition to avoid potential race
+    # conditions and data corruptions. The request to patch is aborted if the
+    # object's metageneration does not match your precondition.
+    blob.reload()
     blob.temporary_hold = False
-    blob.patch()
+    blob.patch(if_metageneration_match=blob.metageneration)
 
     print("Temporary hold was release for #{blob_name}")
 

--- a/samples/snippets/storage_set_event_based_hold.py
+++ b/samples/snippets/storage_set_event_based_hold.py
@@ -29,8 +29,12 @@ def set_event_based_hold(bucket_name, blob_name):
     bucket = storage_client.bucket(bucket_name)
     blob = bucket.blob(blob_name)
 
+    # Optional: set a metageneration-match precondition to avoid potential race
+    # conditions and data corruptions. The request to patch is aborted if the
+    # object's metageneration does not match your precondition.
+    blob.reload()
     blob.event_based_hold = True
-    blob.patch()
+    blob.patch(if_metageneration_match=blob.metageneration)
 
     print(f"Event based hold was set for {blob_name}")
 

--- a/samples/snippets/storage_set_metadata.py
+++ b/samples/snippets/storage_set_metadata.py
@@ -30,7 +30,11 @@ def set_blob_metadata(bucket_name, blob_name):
     blob = bucket.get_blob(blob_name)
     metadata = {'color': 'Red', 'name': 'Test'}
     blob.metadata = metadata
-    blob.patch()
+
+    # Optional: set a metageneration-match precondition to avoid potential race
+    # conditions and data corruptions. The request to patch is aborted if the
+    # object's metageneration does not match your precondition.
+    blob.patch(if_metageneration_match=blob.metageneration)
 
     print(f"The metadata for the blob {blob.name} is {blob.metadata}")
 

--- a/samples/snippets/storage_set_temporary_hold.py
+++ b/samples/snippets/storage_set_temporary_hold.py
@@ -29,8 +29,12 @@ def set_temporary_hold(bucket_name, blob_name):
     bucket = storage_client.bucket(bucket_name)
     blob = bucket.blob(blob_name)
 
+    # Optional: set a metageneration-match precondition to avoid potential race
+    # conditions and data corruptions. The request to patch is aborted if the
+    # object's metageneration does not match your precondition.
+    blob.reload()
     blob.temporary_hold = True
-    blob.patch()
+    blob.patch(if_metageneration_match=blob.metageneration)
 
     print("Temporary hold was set for #{blob_name}")
 


### PR DESCRIPTION
This adds `if_metageneration_match` preconditions to objects.patch samples, as aligned in internal go/storage-dpe-samples-precondition-updates

Preconditions are confusing for our customers. One way we're addressing this is by adding preconditions to the frequently viewed samples where they should be used.
