### PR TITLE
fix: un-deprecate blob.download_to_file() and bucket methods

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -1024,7 +1024,7 @@ class Blob(_PropertyMixin):
         checksum="md5",
         retry=DEFAULT_RETRY,
     ):
-        """DEPRECATED. Download the contents of this blob into a file-like object.
+        """Download the contents of this blob into a file-like object.
 
         .. note::
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -922,10 +922,7 @@ class Bucket(_PropertyMixin):
         timeout=_DEFAULT_TIMEOUT,
         retry=DEFAULT_RETRY,
     ):
-        """DEPRECATED. Creates current bucket.
-
-        .. note::
-          Direct use of this method is deprecated. Use ``Client.create_bucket()`` instead.
+        """Creates current bucket.
 
         If the bucket already exists, will raise
         :class:`google.cloud.exceptions.Conflict`.
@@ -970,12 +967,6 @@ class Bucket(_PropertyMixin):
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
-        warnings.warn(
-            "Bucket.create() is deprecated and will be removed in future."
-            "Use Client.create_bucket() instead.",
-            PendingDeprecationWarning,
-            stacklevel=1,
-        )
 
         client = self._require_client(client)
         client.create_bucket(
@@ -1300,10 +1291,7 @@ class Bucket(_PropertyMixin):
         timeout=_DEFAULT_TIMEOUT,
         retry=DEFAULT_RETRY,
     ):
-        """DEPRECATED. Return an iterator used to find blobs in the bucket.
-
-        .. note::
-          Direct use of this method is deprecated. Use ``Client.list_blobs`` instead.
+        """Return an iterator used to find blobs in the bucket.
 
         If :attr:`user_project` is set, bills the API request to that project.
 

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -2946,8 +2946,7 @@ class Test_Bucket(unittest.TestCase):
         bucket = self._make_one(name=NAME, properties=before)
         self.assertEqual(bucket.versioning_enabled, True)
 
-    @mock.patch("warnings.warn")
-    def test_create_w_defaults_deprecated(self, mock_warn):
+    def test_create_w_defaults(self):
         bucket_name = "bucket-name"
         api_response = {"name": bucket_name}
         client = mock.Mock(spec=["create_bucket"])
@@ -2967,15 +2966,7 @@ class Test_Bucket(unittest.TestCase):
             retry=DEFAULT_RETRY,
         )
 
-        mock_warn.assert_called_with(
-            "Bucket.create() is deprecated and will be removed in future."
-            "Use Client.create_bucket() instead.",
-            PendingDeprecationWarning,
-            stacklevel=1,
-        )
-
-    @mock.patch("warnings.warn")
-    def test_create_w_explicit_deprecated(self, mock_warn):
+    def test_create_w_explicit(self):
         project = "PROJECT"
         location = "eu"
         user_project = "USER_PROJECT"
@@ -3009,13 +3000,6 @@ class Test_Bucket(unittest.TestCase):
             predefined_default_object_acl=predefined_default_object_acl,
             timeout=timeout,
             retry=retry,
-        )
-
-        mock_warn.assert_called_with(
-            "Bucket.create() is deprecated and will be removed in future."
-            "Use Client.create_bucket() instead.",
-            PendingDeprecationWarning,
-            stacklevel=1,
         )
 
     def test_versioning_enabled_setter(self):


### PR DESCRIPTION
Removed deprecation and warnings:

- blob.download_to_file()
- bucket.create()
- bucket.list_blobs()


Removed warning in tests and renamed tests:

- unit test test_create_w_defaults
- unit test test_create_w_explicit



Fixes internal b/265134180