### PR TITLE
fix: Avoid pickling processed credentials

### DIFF
--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -130,10 +130,11 @@ class Client(ClientWithProject):
         if project is _marker:
             project = None
 
-        # Save the initial value of client_info and client_options before they
+        # Save the initial value of constructor arguments before they
         # are passed along, for use in __reduce__ defined elsewhere.
         self._initial_client_info = client_info
         self._initial_client_options = client_options
+        self._initial_credentials = credentials
 
         kw_args = {"client_info": client_info}
 

--- a/google/cloud/storage/transfer_manager.py
+++ b/google/cloud/storage/transfer_manager.py
@@ -879,7 +879,7 @@ def _reduce_client(cl):
 
     client_object_id = id(cl)
     project = cl.project
-    credentials = cl._credentials
+    credentials = cl._initial_credentials
     _http = None  # Can't carry this over
     client_info = cl._initial_client_info
     client_options = cl._initial_client_options


### PR DESCRIPTION
Resolves `TypeError: cannot pickle '_cffi_backend.FFI' object` error when using subprocesses while the `cryptography` library is installed. Merely installing the `cryptography` library causes the error even if it is not imported or used.

Regrettably it was impractical to add a regression test due to the nature of the error.

Fixes #1012 🦕
