### PR TITLE
chore: add option to delete benchmarking bucket

### DIFF
--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -32,6 +32,7 @@ $ python3 benchmarking.py --num_samples 10000 --object_size 5120..16384 --output
 | --test_type | test type to run benchmarking | `w1r3`, `range` | `w1r3` |
 | --output_file | file to output results to | any file path | `output_bench<TIMESTAMP>.csv` |
 | --tmp_dir | temp directory path on file system | any file path | `tm-perf-metrics` |
+| --delete_bucket | whether or not to delete GCS bucket used for benchmarking| bool | `False` |
 
 
 ## Workload definition and CSV headers

--- a/tests/perf/_perf_utils.py
+++ b/tests/perf/_perf_utils.py
@@ -193,7 +193,7 @@ def get_bucket_instance(bucket_name):
     return bucket
 
 
-def cleanup_bucket(bucket):
+def cleanup_bucket(bucket, delete_bucket=False):
     # Delete blobs first as the bucket may contain more than 256 blobs.
     try:
         blobs = bucket.list_blobs()
@@ -201,11 +201,12 @@ def cleanup_bucket(bucket):
             blob.delete()
     except Exception as e:
         logging.exception(f"Caught an exception while deleting blobs\n {e}")
-    # Delete bucket.
-    try:
-        bucket.delete(force=True)
-    except Exception as e:
-        logging.exception(f"Caught an exception while deleting bucket\n {e}")
+    # Delete bucket if delete_bucket is set to True
+    if delete_bucket:
+        try:
+            bucket.delete(force=True)
+        except Exception as e:
+            logging.exception(f"Caught an exception while deleting bucket\n {e}")
 
 
 def get_min_max_size(object_size):

--- a/tests/perf/benchmarking.py
+++ b/tests/perf/benchmarking.py
@@ -80,7 +80,7 @@ def main(args):
         )
 
     # Cleanup and delete blobs.
-    _pu.cleanup_bucket(bucket)
+    _pu.cleanup_bucket(bucket, delete_bucket=args.delete_bucket)
 
     # BBMC will not surface errors unless the process is terminated with a non zero code.
     if counter.count.errors != 0:
@@ -172,6 +172,12 @@ if __name__ == "__main__":
         type=str,
         default=_pu.DEFAULT_BASE_DIR,
         help="Temp directory path on file system",
+    )
+    parser.add_argument(
+        "--delete_bucket",
+        type=bool,
+        default=False,
+        help="Whether or not to delete GCS bucket used for benchmarking",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Update benchmarking script with an added option to delete the GCS bucket or not.


With this option, the current SSB workloads will use the same bucket and avoid deletion/recreation in each run.
