### PR TITLE
chore: unpin Sphinx version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -249,9 +249,7 @@ def docfx(session):
 
     session.install("-e", ".")
     session.install("grpcio")
-    session.install(
-        "gcp-sphinx-docfx-yaml", "alabaster", "recommonmark"
-    )
+    session.install("gcp-sphinx-docfx-yaml", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -250,7 +250,7 @@ def docfx(session):
     session.install("-e", ".")
     session.install("grpcio")
     session.install(
-        "sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
+        "gcp-sphinx-docfx-yaml", "alabaster", "recommonmark"
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)


### PR DESCRIPTION
There's no need to have a separate pinned Sphinx version, we should use the version within the plugin for docfx session. Changes have been already made for other autogenerated clients.

Towards b/288943562 🦕
