### PR TITLE
docs: add Transfer Manager documentation in c.g.c

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ API Reference
   storage/hmac_key
   storage/notification
   storage/retry
+  storage/transfer_manager
 
 
 More Examples

--- a/docs/storage/transfer_manager.rst
+++ b/docs/storage/transfer_manager.rst
@@ -1,0 +1,6 @@
+Transfer Manager
+~~~~~~~~~~~~~~~~
+
+.. automodule:: google.cloud.storage.transfer_manager
+  :members:
+  :show-inheritance:


### PR DESCRIPTION
Publish Transfer Manager preview feature documentation to cloud docs

Fixes #1083 🦕
