### PR TITLE
feat: add transfer_manager.upload_chunks_concurrently using the XML MPU API

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -1697,7 +1697,7 @@ class Blob(_PropertyMixin):
 
         return object_metadata
 
-    def _get_upload_arguments(self, client, content_type):
+    def _get_upload_arguments(self, client, content_type, filename=None):
         """Get required arguments for performing an upload.
 
         The content type returned will be determined in order of precedence:
@@ -1716,7 +1716,7 @@ class Blob(_PropertyMixin):
                   * An object metadata dictionary
                   * The ``content_type`` as a string (according to precedence)
         """
-        content_type = self._get_content_type(content_type)
+        content_type = self._get_content_type(content_type, filename=filename)
         headers = {
             **_get_default_headers(client._connection.user_agent, content_type),
             **_get_encryption_headers(self._encryption_key),

--- a/google/cloud/storage/transfer_manager.py
+++ b/google/cloud/storage/transfer_manager.py
@@ -913,7 +913,8 @@ def upload_chunks_concurrently(
     :param chunk_size:
         The size in bytes of each chunk to send. The optimal chunk size for
         maximum throughput may vary depending on the exact network environment
-        and size of the blob.
+        and size of the blob. The remote API has restrictions on the minimum
+        and maximum size allowable, see: https://cloud.google.com/storage/quotas#requests
 
     :type deadline: int
     :param deadline:

--- a/google/cloud/storage/transfer_manager.py
+++ b/google/cloud/storage/transfer_manager.py
@@ -975,9 +975,13 @@ def upload_chunks_concurrently(
     transport = blob._get_transport(client)
 
     hostname = _get_host_name(client._connection)
-    url = "{hostname}/{bucket}/{blob}".format(hostname=hostname, bucket=bucket.name, blob=blob.name)
+    url = "{hostname}/{bucket}/{blob}".format(
+        hostname=hostname, bucket=bucket.name, blob=blob.name
+    )
 
-    base_headers, object_metadata, content_type = blob._get_upload_arguments(client, content_type, filename=filename)
+    base_headers, object_metadata, content_type = blob._get_upload_arguments(
+        client, content_type, filename=filename
+    )
     headers = {**base_headers, **_headers_from_metadata(object_metadata)}
 
     if blob.user_project is not None:
@@ -988,12 +992,8 @@ def upload_chunks_concurrently(
     # Service cryptographic material. If a Blob instance with KMS Key metadata set is
     # used to upload a new version of the object then the existing kmsKeyName version
     # value can't be used in the upload request and the client instead ignores it.
-    if (
-        blob.kms_key_name is not None
-        and "cryptoKeyVersions" not in blob.kms_key_name
-    ):
+    if blob.kms_key_name is not None and "cryptoKeyVersions" not in blob.kms_key_name:
         headers["x-goog-encryption-kms-key-name"] = blob.kms_key_name
-
 
     container = XMLMPUContainer(url, filename, headers=headers)
     container.initiate(transport=transport, content_type=content_type)
@@ -1025,7 +1025,7 @@ def upload_chunks_concurrently(
                     end=end,
                     part_number=part_number,
                     checksum=checksum,
-                    headers=headers
+                    headers=headers,
                 )
             )
 
@@ -1046,7 +1046,15 @@ def upload_chunks_concurrently(
 
 
 def _upload_part(
-    maybe_pickled_client, url, upload_id, filename, start, end, part_number, checksum, headers
+    maybe_pickled_client,
+    url,
+    upload_id,
+    filename,
+    start,
+    end,
+    part_number,
+    checksum,
+    headers,
 ):
     """Helper function that runs inside a thread or subprocess to upload a part.
 
@@ -1066,7 +1074,7 @@ def _upload_part(
         end=end,
         part_number=part_number,
         checksum=checksum,
-        headers=headers
+        headers=headers,
     )
     part.upload(client._http)
     return (part_number, part.etag)

--- a/google/cloud/storage/transfer_manager.py
+++ b/google/cloud/storage/transfer_manager.py
@@ -975,9 +975,13 @@ def upload_chunks_concurrently(
     transport = blob._get_transport(client)
 
     hostname = _get_host_name(client._connection)
-    url = "{hostname}/{bucket}/{blob}".format(hostname=hostname, bucket=bucket.name, blob=blob.name)
+    url = "{hostname}/{bucket}/{blob}".format(
+        hostname=hostname, bucket=bucket.name, blob=blob.name
+    )
 
-    base_headers, object_metadata, content_type = blob._get_upload_arguments(client, content_type, filename=filename)
+    base_headers, object_metadata, content_type = blob._get_upload_arguments(
+        client, content_type, filename=filename
+    )
     headers = {**base_headers, **_headers_from_metadata(object_metadata)}
 
     container = XMLMPUContainer(url, filename, headers=headers)
@@ -1010,7 +1014,7 @@ def upload_chunks_concurrently(
                     end=end,
                     part_number=part_number,
                     checksum=checksum,
-                    headers=headers
+                    headers=headers,
                 )
             )
 
@@ -1031,7 +1035,15 @@ def upload_chunks_concurrently(
 
 
 def _upload_part(
-    maybe_pickled_client, url, upload_id, filename, start, end, part_number, checksum, headers
+    maybe_pickled_client,
+    url,
+    upload_id,
+    filename,
+    start,
+    end,
+    part_number,
+    checksum,
+    headers,
 ):
     """Helper function that runs inside a thread or subprocess to upload a part.
 
@@ -1051,7 +1063,7 @@ def _upload_part(
         end=end,
         part_number=part_number,
         checksum=checksum,
-        headers=headers
+        headers=headers,
     )
     part.upload(client._http)
     return (part_number, part.etag)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dependencies = [
     "google-auth >= 1.25.0, < 3.0dev",
     "google-api-core >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-cloud-core >= 2.3.0, < 3.0dev",
-    "google-resumable-media >= 2.3.2",
+    "google-resumable-media >= 2.6.0",
     "requests >= 2.18.0, < 3.0.0dev",
 ]
 extras = {"protobuf": ["protobuf<5.0.0dev"]}

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -52,6 +52,7 @@ keyring_name = "gcs-test"
 default_key_name = "gcs-test"
 alt_key_name = "gcs-test-alternate"
 
+
 def _kms_key_name(client, bucket, key_name):
     return _key_name_format.format(
         client.project,
@@ -59,6 +60,7 @@ def _kms_key_name(client, bucket, key_name):
         keyring_name,
         key_name,
     )
+
 
 @pytest.fixture(scope="session")
 def storage_client():
@@ -231,6 +233,7 @@ def file_data():
             file_data["hash"] = _base64_md5hash(file_obj)
 
     return _file_data
+
 
 @pytest.fixture(scope="session")
 def kms_bucket_name():

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -46,6 +46,19 @@ _hierarchy_filenames = [
 
 ebh_bucket_iteration = 0
 
+_key_name_format = "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}"
+
+keyring_name = "gcs-test"
+default_key_name = "gcs-test"
+alt_key_name = "gcs-test-alternate"
+
+def _kms_key_name(client, bucket, key_name):
+    return _key_name_format.format(
+        client.project,
+        bucket.location.lower(),
+        keyring_name,
+        key_name,
+    )
 
 @pytest.fixture(scope="session")
 def storage_client():
@@ -218,3 +231,26 @@ def file_data():
             file_data["hash"] = _base64_md5hash(file_obj)
 
     return _file_data
+
+@pytest.fixture(scope="session")
+def kms_bucket_name():
+    return _helpers.unique_name("gcp-systest-kms")
+
+
+@pytest.fixture(scope="session")
+def kms_bucket(storage_client, kms_bucket_name, no_mtls):
+    bucket = _helpers.retry_429_503(storage_client.create_bucket)(kms_bucket_name)
+
+    yield bucket
+
+    _helpers.delete_bucket(bucket)
+
+
+@pytest.fixture(scope="session")
+def kms_key_name(storage_client, kms_bucket):
+    return _kms_key_name(storage_client, kms_bucket, default_key_name)
+
+
+@pytest.fixture(scope="session")
+def alt_kms_key_name(storage_client, kms_bucket):
+    return _kms_key_name(storage_client, kms_bucket, alt_key_name)

--- a/tests/system/test_transfer_manager.py
+++ b/tests/system/test_transfer_manager.py
@@ -221,13 +221,17 @@ def test_upload_chunks_concurrently(shared_bucket, file_data, blobs_to_delete):
             temp_contents = tmp.read()
             assert source_contents == temp_contents
 
-def test_upload_chunks_concurrently_with_metadata(shared_bucket, file_data, blobs_to_delete):
+
+def test_upload_chunks_concurrently_with_metadata(
+    shared_bucket, file_data, blobs_to_delete
+):
     import datetime
     from google.cloud._helpers import UTC
-#    from google.cloud._helpers import _RFC3339_MICROS
+
+    #    from google.cloud._helpers import _RFC3339_MICROS
 
     now = datetime.datetime.utcnow().replace(tzinfo=UTC)
-#    NOW = now.strftime(_RFC3339_MICROS)
+    #    NOW = now.strftime(_RFC3339_MICROS)
 
     custom_metadata = {"key_a": "value_a", "key_b": "value_b"}
 

--- a/tests/system/test_transfer_manager.py
+++ b/tests/system/test_transfer_manager.py
@@ -16,12 +16,24 @@
 import tempfile
 import os
 
+import pytest
+
 from google.cloud.storage import transfer_manager
 from google.cloud.storage._helpers import _base64_md5hash
 
 from google.api_core import exceptions
 
 DEADLINE = 30
+
+encryption_key = "b23ff11bba187db8c37077e6af3b25b8"
+
+
+def _check_blob_hash(blob, info):
+    md5_hash = blob.md5_hash
+    if not isinstance(md5_hash, bytes):
+        md5_hash = md5_hash.encode("utf-8")
+
+    assert md5_hash == info["hash"]
 
 
 def test_upload_many(shared_bucket, file_data, blobs_to_delete):
@@ -224,11 +236,8 @@ def test_upload_chunks_concurrently(shared_bucket, file_data, blobs_to_delete):
 def test_upload_chunks_concurrently_with_metadata(shared_bucket, file_data, blobs_to_delete):
     import datetime
     from google.cloud._helpers import UTC
-#    from google.cloud._helpers import _RFC3339_MICROS
 
     now = datetime.datetime.utcnow().replace(tzinfo=UTC)
-#    NOW = now.strftime(_RFC3339_MICROS)
-
     custom_metadata = {"key_a": "value_a", "key_b": "value_b"}
 
     METADATA = {
@@ -245,8 +254,6 @@ def test_upload_chunks_concurrently_with_metadata(shared_bucket, file_data, blob
     blob_name = "mpu_file_with_metadata"
     upload_blob = shared_bucket.blob(blob_name)
 
-    blobs_to_delete.append(upload_blob)
-
     for key, value in METADATA.items():
         setattr(upload_blob, key, value)
 
@@ -256,6 +263,7 @@ def test_upload_chunks_concurrently_with_metadata(shared_bucket, file_data, blob
     transfer_manager.upload_chunks_concurrently(
         filename, upload_blob, chunk_size=chunk_size, deadline=DEADLINE
     )
+    blobs_to_delete.append(upload_blob)
 
     with tempfile.NamedTemporaryFile() as tmp:
         download_blob = shared_bucket.get_blob(blob_name)
@@ -264,6 +272,106 @@ def test_upload_chunks_concurrently_with_metadata(shared_bucket, file_data, blob
             assert getattr(download_blob, key) == value
 
         download_blob.download_to_file(tmp)
+        tmp.seek(0)
+
+        with open(source_file["path"], "rb") as sf:
+            source_contents = sf.read()
+            temp_contents = tmp.read()
+            assert source_contents == temp_contents
+
+
+def test_upload_chunks_concurrently_with_content_encoding(shared_bucket, file_data, blobs_to_delete):
+    import gzip
+
+    METADATA = {
+        "content_encoding": "gzip",
+    }
+
+    source_file = file_data["big"]
+    filename = source_file["path"]
+    blob_name = "mpu_file_encoded"
+    upload_blob = shared_bucket.blob(blob_name)
+
+    for key, value in METADATA.items():
+        setattr(upload_blob, key, value)
+
+    chunk_size = 5 * 1024 * 1024  # Minimum supported by XML MPU API
+
+    with tempfile.NamedTemporaryFile() as tmp_gzip:
+        with open(filename, 'rb') as f:
+            compressed_bytes = gzip.compress(f.read())
+
+        tmp_gzip.write(compressed_bytes)
+        tmp_gzip.seek(0)
+        transfer_manager.upload_chunks_concurrently(
+            tmp_gzip.name, upload_blob, chunk_size=chunk_size, deadline=DEADLINE
+        )
+        blobs_to_delete.append(upload_blob)
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        download_blob = shared_bucket.get_blob(blob_name)
+
+        for key, value in METADATA.items():
+            assert getattr(download_blob, key) == value
+
+        download_blob.download_to_file(tmp)
+        tmp.seek(0)
+
+        with open(source_file["path"], "rb") as sf:
+            source_contents = sf.read()
+            temp_contents = tmp.read()
+            assert source_contents == temp_contents
+
+def test_upload_chunks_concurrently_with_encryption_key(shared_bucket, file_data, blobs_to_delete):
+    source_file = file_data["big"]
+    filename = source_file["path"]
+    blob_name = "mpu_file_encrypted"
+    upload_blob = shared_bucket.blob(blob_name, encryption_key=encryption_key)
+
+    chunk_size = 5 * 1024 * 1024  # Minimum supported by XML MPU API
+    assert os.path.getsize(filename) > chunk_size  # Won't make a good test otherwise
+
+    transfer_manager.upload_chunks_concurrently(
+        filename, upload_blob, chunk_size=chunk_size, deadline=DEADLINE
+    )
+    blobs_to_delete.append(upload_blob)
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        download_blob = shared_bucket.get_blob(blob_name, encryption_key=encryption_key)
+
+        download_blob.download_to_file(tmp)
+        tmp.seek(0)
+
+        with open(source_file["path"], "rb") as sf:
+            source_contents = sf.read()
+            temp_contents = tmp.read()
+            assert source_contents == temp_contents
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        keyless_blob = shared_bucket.get_blob(blob_name)
+
+        with pytest.raises(exceptions.BadRequest):
+            keyless_blob.download_to_file(tmp)
+
+
+def test_upload_chunks_concurrently_with_kms(kms_bucket, file_data, blobs_to_delete, kms_key_name):
+    source_file = file_data["big"]
+    filename = source_file["path"]
+    blob_name = "mpu_file_kms"
+    blob = kms_bucket.blob(blob_name, kms_key_name=kms_key_name)
+
+    chunk_size = 5 * 1024 * 1024  # Minimum supported by XML MPU API
+    assert os.path.getsize(filename) > chunk_size  # Won't make a good test otherwise
+
+    transfer_manager.upload_chunks_concurrently(
+        filename, blob, chunk_size=chunk_size, deadline=DEADLINE
+    )
+    blobs_to_delete.append(blob)
+    blob.reload()
+    assert blob.kms_key_name.startswith(kms_key_name)
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        blob.download_to_file(tmp)
         tmp.seek(0)
 
         with open(source_file["path"], "rb") as sf:

--- a/tests/system/test_transfer_manager.py
+++ b/tests/system/test_transfer_manager.py
@@ -233,7 +233,10 @@ def test_upload_chunks_concurrently(shared_bucket, file_data, blobs_to_delete):
             temp_contents = tmp.read()
             assert source_contents == temp_contents
 
-def test_upload_chunks_concurrently_with_metadata(shared_bucket, file_data, blobs_to_delete):
+
+def test_upload_chunks_concurrently_with_metadata(
+    shared_bucket, file_data, blobs_to_delete
+):
     import datetime
     from google.cloud._helpers import UTC
 
@@ -280,7 +283,9 @@ def test_upload_chunks_concurrently_with_metadata(shared_bucket, file_data, blob
             assert source_contents == temp_contents
 
 
-def test_upload_chunks_concurrently_with_content_encoding(shared_bucket, file_data, blobs_to_delete):
+def test_upload_chunks_concurrently_with_content_encoding(
+    shared_bucket, file_data, blobs_to_delete
+):
     import gzip
 
     METADATA = {
@@ -298,7 +303,7 @@ def test_upload_chunks_concurrently_with_content_encoding(shared_bucket, file_da
     chunk_size = 5 * 1024 * 1024  # Minimum supported by XML MPU API
 
     with tempfile.NamedTemporaryFile() as tmp_gzip:
-        with open(filename, 'rb') as f:
+        with open(filename, "rb") as f:
             compressed_bytes = gzip.compress(f.read())
 
         tmp_gzip.write(compressed_bytes)
@@ -322,7 +327,10 @@ def test_upload_chunks_concurrently_with_content_encoding(shared_bucket, file_da
             temp_contents = tmp.read()
             assert source_contents == temp_contents
 
-def test_upload_chunks_concurrently_with_encryption_key(shared_bucket, file_data, blobs_to_delete):
+
+def test_upload_chunks_concurrently_with_encryption_key(
+    shared_bucket, file_data, blobs_to_delete
+):
     source_file = file_data["big"]
     filename = source_file["path"]
     blob_name = "mpu_file_encrypted"
@@ -354,7 +362,9 @@ def test_upload_chunks_concurrently_with_encryption_key(shared_bucket, file_data
             keyless_blob.download_to_file(tmp)
 
 
-def test_upload_chunks_concurrently_with_kms(kms_bucket, file_data, blobs_to_delete, kms_key_name):
+def test_upload_chunks_concurrently_with_kms(
+    kms_bucket, file_data, blobs_to_delete, kms_key_name
+):
     source_file = file_data["big"]
     filename = source_file["path"]
     blob_name = "mpu_file_kms"

--- a/tests/unit/test_transfer_manager.py
+++ b/tests/unit/test_transfer_manager.py
@@ -591,7 +591,9 @@ def test_download_chunks_concurrently_passes_concurrency_options():
 
     with mock.patch("concurrent.futures.ThreadPoolExecutor") as pool_patch, mock.patch(
         "concurrent.futures.wait"
-    ) as wait_patch, mock.patch("google.cloud.storage.transfer_manager.open", mock.mock_open()):
+    ) as wait_patch, mock.patch(
+        "google.cloud.storage.transfer_manager.open", mock.mock_open()
+    ):
         transfer_manager.download_chunks_concurrently(
             blob_mock,
             FILENAME,

--- a/tests/unit/test_transfer_manager.py
+++ b/tests/unit/test_transfer_manager.py
@@ -533,7 +533,7 @@ def test_download_chunks_concurrently():
 
     blob_mock.download_to_filename.return_value = FAKE_RESULT
 
-    with mock.patch("__main__.open", mock.mock_open()):
+    with mock.patch("google.cloud.storage.transfer_manager.open", mock.mock_open()):
         result = transfer_manager.download_chunks_concurrently(
             blob_mock,
             FILENAME,
@@ -558,7 +558,7 @@ def test_download_chunks_concurrently_raises_on_start_and_end():
     MULTIPLE = 4
     blob_mock.size = CHUNK_SIZE * MULTIPLE
 
-    with mock.patch("__main__.open", mock.mock_open()):
+    with mock.patch("google.cloud.storage.transfer_manager.open", mock.mock_open()):
         with pytest.raises(ValueError):
             transfer_manager.download_chunks_concurrently(
                 blob_mock,
@@ -591,7 +591,7 @@ def test_download_chunks_concurrently_passes_concurrency_options():
 
     with mock.patch("concurrent.futures.ThreadPoolExecutor") as pool_patch, mock.patch(
         "concurrent.futures.wait"
-    ) as wait_patch, mock.patch("__main__.open", mock.mock_open()):
+    ) as wait_patch, mock.patch("google.cloud.storage.transfer_manager.open", mock.mock_open()):
         transfer_manager.download_chunks_concurrently(
             blob_mock,
             FILENAME,
@@ -844,7 +844,7 @@ def test_download_chunks_concurrently_with_processes():
     with mock.patch(
         "google.cloud.storage.transfer_manager._download_and_write_chunk_in_place",
         new=_validate_blob_token_in_subprocess_for_chunk,
-    ), mock.patch("__main__.open", mock.mock_open()):
+    ), mock.patch("google.cloud.storage.transfer_manager.open", mock.mock_open()):
         result = transfer_manager.download_chunks_concurrently(
             blob,
             FILENAME,
@@ -880,7 +880,7 @@ def test__pickle_client():
 def test__download_and_write_chunk_in_place():
     pickled_mock = pickle.dumps(_PickleableMockBlob())
     FILENAME = "file_a.txt"
-    with mock.patch("__main__.open", mock.mock_open()):
+    with mock.patch("google.cloud.storage.transfer_manager.open", mock.mock_open()):
         result = transfer_manager._download_and_write_chunk_in_place(
             pickled_mock, FILENAME, 0, 8, {}
         )


### PR DESCRIPTION
This adds support for XML MPU multiprocess uploads to Transfer Manager.