### PR TITLE
fix: fix typo in Bucket.clear_lifecycle_rules()

### DIFF
--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2275,13 +2275,17 @@ class Bucket(_PropertyMixin):
         rules = [dict(rule) for rule in rules]  # Convert helpers if needed
         self._patch_property("lifecycle", {"rule": rules})
 
-    def clear_lifecyle_rules(self):
+    def clear_lifecycle_rules(self):
         """Clear lifecycle rules configured for this bucket.
 
         See https://cloud.google.com/storage/docs/lifecycle and
              https://cloud.google.com/storage/docs/json_api/v1/buckets
         """
         self.lifecycle_rules = []
+
+    def clear_lifecyle_rules(self):
+        """Deprecated alias for clear_lifecycle_rules."""
+        return self.clear_lifecycle_rules()
 
     def add_lifecycle_delete_rule(self, **kw):
         """Add a "delete" rule to lifecycle rules configured for this bucket.

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -2448,6 +2448,7 @@ class Test_Bucket(unittest.TestCase):
         bucket._properties["lifecycle"] = {"rule": rules}
         self.assertEqual(list(bucket.lifecycle_rules), rules)
 
+        # This is a deprecated alias and will test both methods
         bucket.clear_lifecyle_rules()
 
         self.assertEqual(list(bucket.lifecycle_rules), [])


### PR DESCRIPTION
Fixes #1074 🦕
