### PR TITLE
fix: bucket.delete(force=True) now works with version-enabled buckets

### DIFF
--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -1539,6 +1539,7 @@ class Bucket(_PropertyMixin):
                     client=client,
                     timeout=timeout,
                     retry=retry,
+                    versions=True,
                 )
             )
             if len(blobs) > self._MAX_OBJECTS_FOR_ITERATION:
@@ -1557,6 +1558,7 @@ class Bucket(_PropertyMixin):
                 client=client,
                 timeout=timeout,
                 retry=retry,
+                preserve_generation=True,
             )
 
         # We intentionally pass `_target_object=None` since a DELETE

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -1063,3 +1063,45 @@ def test_new_bucket_with_autoclass(
 
     assert bucket.autoclass_enabled is False
     assert bucket.autoclass_toggle_time != previous_toggle_time
+
+
+def test_bucket_delete_force(storage_client):
+    bucket_name = _helpers.unique_name("version-disabled")
+    bucket_obj = storage_client.bucket(bucket_name)
+    bucket = storage_client.create_bucket(bucket_obj)
+
+    BLOB_NAME = "my_object"
+    blob = bucket.blob(BLOB_NAME)
+    blob.upload_from_string("abcd")
+    blob.upload_from_string("efgh")
+
+    blobs = bucket.list_blobs(versions=True)
+    counter = 0
+    for blob in blobs:
+        counter += 1
+        assert blob.name == BLOB_NAME
+    assert counter == 1
+
+    bucket.delete(force=True)  # Will fail with 409 if blobs aren't deleted
+
+
+def test_bucket_delete_force_works_with_versions(storage_client):
+    bucket_name = _helpers.unique_name("version-enabled")
+    bucket_obj = storage_client.bucket(bucket_name)
+    bucket_obj.versioning_enabled = True
+    bucket = storage_client.create_bucket(bucket_obj)
+    assert bucket.versioning_enabled
+
+    BLOB_NAME = "my_versioned_object"
+    blob = bucket.blob(BLOB_NAME)
+    blob.upload_from_string("abcd")
+    blob.upload_from_string("efgh")
+
+    blobs = bucket.list_blobs(versions=True)
+    counter = 0
+    for blob in blobs:
+        counter += 1
+        assert blob.name == BLOB_NAME
+    assert counter == 2
+
+    bucket.delete(force=True)  # Will fail with 409 if versions aren't deleted

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -1141,4 +1141,3 @@ def test_config_autoclass_w_existing_bucket(
     assert (
         bucket.autoclass_terminal_storage_class_update_time != previous_tsc_update_time
     )
-

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -1419,6 +1419,7 @@ class Test_Bucket(unittest.TestCase):
             client=client,
             timeout=timeout,
             retry=retry,
+            versions=True,
         )
 
         bucket.delete_blobs.assert_called_once_with(
@@ -1427,6 +1428,7 @@ class Test_Bucket(unittest.TestCase):
             client=client,
             timeout=timeout,
             retry=retry,
+            preserve_generation=True,
         )
 
         expected_query_params = {"userProject": user_project}
@@ -1456,6 +1458,7 @@ class Test_Bucket(unittest.TestCase):
             client=client,
             timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY,
+            versions=True,
         )
 
         bucket.delete_blobs.assert_called_once_with(
@@ -1464,6 +1467,7 @@ class Test_Bucket(unittest.TestCase):
             client=client,
             timeout=self._get_default_timeout(),
             retry=DEFAULT_RETRY,
+            preserve_generation=True,
         )
 
         expected_query_params = {}
@@ -1483,8 +1487,10 @@ class Test_Bucket(unittest.TestCase):
         client = mock.Mock(spec=["_delete_resource"])
         client._delete_resource.return_value = None
         bucket = self._make_one(client=client, name=name)
-        blob = mock.Mock(spec=["name"])
+        blob = mock.Mock(spec=["name", "generation"])
         blob.name = blob_name
+        GEN = 1234
+        blob.generation = GEN
         blobs = [blob]
         bucket.list_blobs = mock.Mock(return_value=iter(blobs))
         bucket.delete_blob = mock.Mock(side_effect=NotFound("testing"))
@@ -1496,7 +1502,7 @@ class Test_Bucket(unittest.TestCase):
         bucket.delete_blob.assert_called_once_with(
             blob_name,
             client=client,
-            generation=None,
+            generation=GEN,
             if_generation_match=None,
             if_generation_not_match=None,
             if_metageneration_match=None,


### PR DESCRIPTION
Fixes #1071 🦕

As a side-effect, the behavior of this method during a race condition has changed slightly. Previously, if a new object was created while the bucket.delete(force=True) method is running, it would fail, but if a new generation of an existing object was uploaded, it would still succeed. Now it will fail in both cases. Regardless of the exact behavior, please do not use this method on a bucket that is still being updated by another process.