### PR TITLE
chore: update docfx minimum Python version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -245,7 +245,7 @@ def docs(session):
     )
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.10")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 


### PR DESCRIPTION
Updates minimum Python version required for DocFX to 3.10. See https://github.com/googleapis/synthtool/pull/1891.

Python3.10 is available by default for Ubuntu22.04, which this repository uses. No installation required.

