### PR TITLE
Minor: update blob client regex match pattern

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -135,7 +135,7 @@ _DOWNLOAD_AS_STRING_DEPRECATED = (
     "Use Blob.download_as_bytes() instead."
 )
 _GS_URL_REGEX_PATTERN = re.compile(
-    r"(?P<scheme>gs)://(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"
+    r"(?P<scheme>gs)://(?P<bucket_name>[a-z0-9_.-]+)(?P<trailing_slash>:/)?(?P<object_name>.+)"
 )
 
 _DEFAULT_CHUNKSIZE = 104857600  # 1024 * 1024 B * 100 = 100 MB
@@ -407,7 +407,7 @@ class Blob(_PropertyMixin):
 
         match = _GS_URL_REGEX_PATTERN.match(uri)
         if not match:
-            raise ValueError("URI scheme must be gs")
+            raise ValueError(f"URI scheme should match regex '{_GS_URL_REGEX_PATTERN}'")
         bucket = Bucket(client, name=match.group("bucket_name"))
         return cls(match.group("object_name"), bucket)
 


### PR DESCRIPTION
Currently, using the `from_string` method in `Blob` doesn't allow bucket roots because of a recent change in a regex matching pattern. This PR aims to fix that.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
