### PR TITLE
fix: remove utcnow usage

### DIFF
--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -18,6 +18,7 @@ These are *not* part of the API.
 """
 
 import base64
+import datetime
 from hashlib import md5
 import os
 from urllib.parse import urlsplit
@@ -70,6 +71,12 @@ _NUM_RETRIES_MESSAGE = (
     "release. Use the `retry` argument with a Retry or ConditionalRetryPolicy "
     "object, or None, instead."
 )
+
+# _NOW() returns the current local date and time.
+# It is preferred to use timezone-aware datetimes _NOW(_UTC),
+# which returns the current UTC date and time.
+_NOW = datetime.datetime.now
+_UTC = datetime.timezone.utc
 
 
 def _get_storage_host():

--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -28,11 +28,13 @@ import google.auth.credentials
 from google.auth import exceptions
 from google.auth.transport import requests
 from google.cloud import _helpers
+from google.cloud.storage._helpers import _NOW
+from google.cloud.storage._helpers import _UTC
 
 
-NOW = datetime.datetime.utcnow  # `google.cloud.storage._signing.NOW` is deprecated
-_NOW = datetime.datetime.now
-_UTC = datetime.timezone.utc
+# `google.cloud.storage._signing.NOW` is deprecated.
+# Use `_NOW(_UTC)` instead.
+NOW = datetime.datetime.utcnow
 
 SERVICE_ACCOUNT_URL = (
     "https://googleapis.dev/python/google-api-core/latest/"

--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -30,7 +30,9 @@ from google.auth.transport import requests
 from google.cloud import _helpers
 
 
-NOW = datetime.datetime.utcnow  # To be replaced by tests.
+NOW = datetime.datetime.utcnow  # `google.cloud.storage._signing.NOW` is deprecated
+_NOW = datetime.datetime.now
+_UTC = datetime.timezone.utc
 
 SERVICE_ACCOUNT_URL = (
     "https://googleapis.dev/python/google-api-core/latest/"
@@ -103,7 +105,7 @@ def get_expiration_seconds_v2(expiration):
     """
     # If it's a timedelta, add it to `now` in UTC.
     if isinstance(expiration, datetime.timedelta):
-        now = NOW().replace(tzinfo=_helpers.UTC)
+        now = _NOW(_UTC)
         expiration = now + expiration
 
     # If it's a datetime, convert to a timestamp.
@@ -141,7 +143,7 @@ def get_expiration_seconds_v4(expiration):
             "timedelta. Got %s" % type(expiration)
         )
 
-    now = NOW().replace(tzinfo=_helpers.UTC)
+    now = _NOW(_UTC)
 
     if isinstance(expiration, int):
         seconds = expiration
@@ -149,7 +151,6 @@ def get_expiration_seconds_v4(expiration):
     if isinstance(expiration, datetime.datetime):
         if expiration.tzinfo is None:
             expiration = expiration.replace(tzinfo=_helpers.UTC)
-
         expiration = expiration - now
 
     if isinstance(expiration, datetime.timedelta):
@@ -638,7 +639,7 @@ def get_v4_now_dtstamps():
     :rtype: str, str
     :returns: Current timestamp, datestamp.
     """
-    now = NOW()
+    now = _NOW(_UTC)
     timestamp = now.strftime("%Y%m%dT%H%M%SZ")
     datestamp = now.date().strftime("%Y%m%d")
     return timestamp, datestamp

--- a/google/cloud/storage/_signing.py
+++ b/google/cloud/storage/_signing.py
@@ -641,7 +641,7 @@ def get_v4_now_dtstamps():
     :rtype: str, str
     :returns: Current timestamp, datestamp.
     """
-    now = _NOW(_UTC)
+    now = _NOW(_UTC).replace(tzinfo=None)
     timestamp = now.strftime("%Y%m%dT%H%M%SZ")
     datestamp = now.date().strftime("%Y%m%d")
     return timestamp, datestamp

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -29,7 +29,9 @@ from google.api_core.iam import Policy
 from google.cloud.storage import _signing
 from google.cloud.storage._helpers import _add_etag_match_headers
 from google.cloud.storage._helpers import _add_generation_match_parameters
+from google.cloud.storage._helpers import _NOW
 from google.cloud.storage._helpers import _PropertyMixin
+from google.cloud.storage._helpers import _UTC
 from google.cloud.storage._helpers import _scalar_property
 from google.cloud.storage._helpers import _validate_name
 from google.cloud.storage._signing import generate_signed_url_v2
@@ -82,7 +84,6 @@ _LOCATION_SETTER_MESSAGE = (
     "to `Bucket.create`."
 )
 _API_ACCESS_ENDPOINT = "https://storage.googleapis.com"
-_NOW = datetime.datetime.now
 
 
 def _blobs_page_start(iterator, page, response):
@@ -3186,7 +3187,7 @@ class Bucket(_PropertyMixin):
         _signing.ensure_signed_credentials(credentials)
 
         if expiration is None:
-            expiration = _NOW(datetime.timezone.utc) + datetime.timedelta(hours=1)
+            expiration = _NOW(_UTC) + datetime.timedelta(hours=1)
 
         conditions = conditions + [{"bucket": self.name}]
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -3187,7 +3187,7 @@ class Bucket(_PropertyMixin):
         _signing.ensure_signed_credentials(credentials)
 
         if expiration is None:
-            expiration = _NOW(_UTC) + datetime.timedelta(hours=1)
+            expiration = _NOW(_UTC).replace(tzinfo=None) + datetime.timedelta(hours=1)
 
         conditions = conditions + [{"bucket": self.name}]
 

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -23,7 +23,6 @@ import warnings
 
 from google.api_core import datetime_helpers
 from google.cloud._helpers import _datetime_to_rfc3339
-from google.cloud._helpers import _NOW
 from google.cloud._helpers import _rfc3339_nanos_to_datetime
 from google.cloud.exceptions import NotFound
 from google.api_core.iam import Policy
@@ -83,6 +82,7 @@ _LOCATION_SETTER_MESSAGE = (
     "to `Bucket.create`."
 )
 _API_ACCESS_ENDPOINT = "https://storage.googleapis.com"
+_NOW = datetime.datetime.now
 
 
 def _blobs_page_start(iterator, page, response):
@@ -3186,7 +3186,7 @@ class Bucket(_PropertyMixin):
         _signing.ensure_signed_credentials(credentials)
 
         if expiration is None:
-            expiration = _NOW() + datetime.timedelta(hours=1)
+            expiration = _NOW(datetime.timezone.utc) + datetime.timedelta(hours=1)
 
         conditions = conditions + [{"bucket": self.name}]
 

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -26,14 +26,16 @@ import google.api_core.client_options
 from google.auth.credentials import AnonymousCredentials
 
 from google.api_core import page_iterator
-from google.cloud._helpers import _LocalStack, _NOW
+from google.cloud._helpers import _LocalStack
 from google.cloud.client import ClientWithProject
 from google.cloud.exceptions import NotFound
 
+from google.cloud.storage._helpers import _bucket_bound_hostname_url
 from google.cloud.storage._helpers import _get_environ_project
 from google.cloud.storage._helpers import _get_storage_host
 from google.cloud.storage._helpers import _DEFAULT_STORAGE_HOST
-from google.cloud.storage._helpers import _bucket_bound_hostname_url
+from google.cloud.storage._helpers import _NOW
+from google.cloud.storage._helpers import _UTC
 
 from google.cloud.storage._http import Connection
 from google.cloud.storage._signing import (
@@ -1625,14 +1627,13 @@ class Client(ClientWithProject):
         conditions += required_conditions
 
         # calculate policy expiration time
-        now = _NOW()
+        now = _NOW(_UTC)
         if expiration is None:
             expiration = now + datetime.timedelta(hours=1)
 
         policy_expires = now + datetime.timedelta(
             seconds=get_expiration_seconds_v4(expiration)
         )
-
         # encode policy for signing
         policy = json.dumps(
             collections.OrderedDict(

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1634,6 +1634,7 @@ class Client(ClientWithProject):
         policy_expires = now + datetime.timedelta(
             seconds=get_expiration_seconds_v4(expiration)
         )
+
         # encode policy for signing
         policy = json.dumps(
             collections.OrderedDict(

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1627,7 +1627,7 @@ class Client(ClientWithProject):
         conditions += required_conditions
 
         # calculate policy expiration time
-        now = _NOW(_UTC)
+        now = _NOW(_UTC).replace(tzinfo=None)
         if expiration is None:
             expiration = now + datetime.timedelta(hours=1)
 

--- a/tests/system/test__signing.py
+++ b/tests/system/test__signing.py
@@ -404,6 +404,9 @@ def test_generate_signed_post_policy_v4(
     with open(blob_name, "r") as f:
         files = {"file": (blob_name, f)}
         response = requests.post(policy["url"], data=policy["fields"], files=files)
+        import pdb
+
+        pdb.set_trace()
 
     os.remove(blob_name)
     assert response.status_code == 204

--- a/tests/system/test__signing.py
+++ b/tests/system/test__signing.py
@@ -22,6 +22,8 @@ import requests
 
 from google.api_core import path_template
 from google.cloud import iam_credentials_v1
+from google.cloud.storage._helpers import _NOW
+from google.cloud.storage._helpers import _UTC
 from . import _helpers
 
 
@@ -63,7 +65,7 @@ def test_create_signed_list_blobs_url_v2(storage_client, signing_bucket, no_mtls
 def test_create_signed_list_blobs_url_v2_w_expiration(
     storage_client, signing_bucket, no_mtls
 ):
-    now = datetime.datetime.utcnow()
+    now = _NOW(_UTC).replace(tzinfo=None)
     delta = datetime.timedelta(seconds=10)
 
     _create_signed_list_blobs_url_helper(
@@ -85,7 +87,7 @@ def test_create_signed_list_blobs_url_v4(storage_client, signing_bucket, no_mtls
 def test_create_signed_list_blobs_url_v4_w_expiration(
     storage_client, signing_bucket, no_mtls
 ):
-    now = datetime.datetime.utcnow()
+    now = _NOW(_UTC).replace(tzinfo=None)
     delta = datetime.timedelta(seconds=10)
     _create_signed_list_blobs_url_helper(
         storage_client,
@@ -158,7 +160,7 @@ def test_create_signed_read_url_v4(storage_client, signing_bucket, no_mtls):
 def test_create_signed_read_url_v2_w_expiration(
     storage_client, signing_bucket, no_mtls
 ):
-    now = datetime.datetime.utcnow()
+    now = _NOW(_UTC).replace(tzinfo=None)
     delta = datetime.timedelta(seconds=10)
 
     _create_signed_read_url_helper(
@@ -169,7 +171,7 @@ def test_create_signed_read_url_v2_w_expiration(
 def test_create_signed_read_url_v4_w_expiration(
     storage_client, signing_bucket, no_mtls
 ):
-    now = datetime.datetime.utcnow()
+    now = _NOW(_UTC).replace(tzinfo=None)
     delta = datetime.timedelta(seconds=10)
     _create_signed_read_url_helper(
         storage_client, signing_bucket, expiration=now + delta, version="v4"
@@ -391,6 +393,7 @@ def test_generate_signed_post_policy_v4(
     with open(blob_name, "wb") as f:
         f.write(payload)
 
+    now = _NOW(_UTC).replace(tzinfo=None)
     policy = storage_client.generate_signed_post_policy_v4(
         bucket_name,
         blob_name,
@@ -398,7 +401,7 @@ def test_generate_signed_post_policy_v4(
             {"bucket": bucket_name},
             ["starts-with", "$Content-Type", "text/pla"],
         ],
-        expiration=datetime.datetime.utcnow() + datetime.timedelta(hours=1),
+        expiration=now + datetime.timedelta(hours=1),
         fields={"content-type": "text/plain"},
     )
     with open(blob_name, "r") as f:
@@ -424,6 +427,7 @@ def test_generate_signed_post_policy_v4_invalid_field(
     with open(blob_name, "wb") as f:
         f.write(payload)
 
+    now = _NOW(_UTC).replace(tzinfo=None)
     policy = storage_client.generate_signed_post_policy_v4(
         bucket_name,
         blob_name,
@@ -431,7 +435,7 @@ def test_generate_signed_post_policy_v4_invalid_field(
             {"bucket": bucket_name},
             ["starts-with", "$Content-Type", "text/pla"],
         ],
-        expiration=datetime.datetime.utcnow() + datetime.timedelta(hours=1),
+        expiration=now + datetime.timedelta(hours=1),
         fields={"x-goog-random": "invalid_field", "content-type": "text/plain"},
     )
     with open(blob_name, "r") as f:

--- a/tests/system/test__signing.py
+++ b/tests/system/test__signing.py
@@ -404,9 +404,6 @@ def test_generate_signed_post_policy_v4(
     with open(blob_name, "r") as f:
         files = {"file": (blob_name, f)}
         response = requests.post(policy["url"], data=policy["fields"], files=files)
-        import pdb
-
-        pdb.set_trace()
 
     os.remove(blob_name)
     assert response.status_code == 204

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -1120,6 +1120,9 @@ def test_blob_update_storage_class_large_file(
 
 
 def test_object_retention_lock(storage_client, buckets_to_delete, blobs_to_delete):
+    from google.cloud.storage._helpers import _NOW
+    from google.cloud.storage._helpers import _UTC
+
     # Test bucket created with object retention enabled
     new_bucket_name = _helpers.unique_name("object-retention")
     created_bucket = _helpers.retry_429_503(storage_client.create_bucket)(
@@ -1131,7 +1134,7 @@ def test_object_retention_lock(storage_client, buckets_to_delete, blobs_to_delet
     # Test create object with object retention enabled
     payload = b"Hello World"
     mode = "Unlocked"
-    current_time = datetime.datetime.utcnow()
+    current_time = _NOW(_UTC).replace(tzinfo=None)
     expiration_time = current_time + datetime.timedelta(seconds=10)
     blob = created_bucket.blob("object-retention-lock")
     blob.retention.mode = mode

--- a/tests/system/test_hmac_key_metadata.py
+++ b/tests/system/test_hmac_key_metadata.py
@@ -16,8 +16,6 @@ import datetime
 
 import pytest
 
-from google.cloud import _helpers as _cloud_helpers
-
 from . import _helpers
 
 
@@ -32,9 +30,12 @@ def ensure_hmac_key_deleted(hmac_key):
 
 @pytest.fixture
 def scrubbed_hmac_keys(storage_client):
+    from google.cloud.storage._helpers import _NOW
+    from google.cloud.storage._helpers import _UTC
+
     before_hmac_keys = set(storage_client.list_hmac_keys())
 
-    now = datetime.datetime.utcnow().replace(tzinfo=_cloud_helpers.UTC)
+    now = _NOW(_UTC)
     yesterday = now - datetime.timedelta(days=1)
 
     # Delete any HMAC keys older than a day.

--- a/tests/system/test_transfer_manager.py
+++ b/tests/system/test_transfer_manager.py
@@ -267,10 +267,10 @@ def test_upload_chunks_concurrently(shared_bucket, file_data, blobs_to_delete):
 def test_upload_chunks_concurrently_with_metadata(
     shared_bucket, file_data, blobs_to_delete
 ):
-    import datetime
-    from google.cloud._helpers import UTC
+    from google.cloud.storage._helpers import _NOW
+    from google.cloud.storage._helpers import _UTC
 
-    now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+    now = _NOW(_UTC)
     custom_metadata = {"key_a": "value_a", "key_b": "value_b"}
 
     METADATA = {

--- a/tests/unit/test__signing.py
+++ b/tests/unit/test__signing.py
@@ -26,7 +26,7 @@ import urllib.parse
 import mock
 import pytest
 
-from google.cloud.storage._signing import _UTC
+from google.cloud.storage._helpers import _UTC
 from . import _read_local_json
 
 

--- a/tests/unit/test__signing.py
+++ b/tests/unit/test__signing.py
@@ -26,6 +26,7 @@ import urllib.parse
 import mock
 import pytest
 
+from google.cloud.storage._signing import _UTC
 from . import _read_local_json
 
 
@@ -74,9 +75,7 @@ class Test_get_expiration_seconds_v2(unittest.TestCase):
         self.assertEqual(self._call_fut(expiration_no_tz), utc_seconds)
 
     def test_w_expiration_utc_datetime(self):
-        from google.cloud._helpers import UTC
-
-        expiration_utc = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, UTC)
+        expiration_utc = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, _UTC)
         utc_seconds = _utc_seconds(expiration_utc)
         self.assertEqual(self._call_fut(expiration_utc), utc_seconds)
 
@@ -88,32 +87,32 @@ class Test_get_expiration_seconds_v2(unittest.TestCase):
         self.assertEqual(self._call_fut(expiration_other), cet_seconds)
 
     def test_w_expiration_timedelta_seconds(self):
-        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0)
+        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, _UTC)
         utc_seconds = _utc_seconds(fake_utcnow)
         expiration_as_delta = datetime.timedelta(seconds=10)
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
         with patch as utcnow:
             result = self._call_fut(expiration_as_delta)
 
         self.assertEqual(result, utc_seconds + 10)
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once_with(datetime.timezone.utc)
 
     def test_w_expiration_timedelta_days(self):
-        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0)
+        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, _UTC)
         utc_seconds = _utc_seconds(fake_utcnow)
         expiration_as_delta = datetime.timedelta(days=1)
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
         with patch as utcnow:
             result = self._call_fut(expiration_as_delta)
 
         self.assertEqual(result, utc_seconds + 86400)
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once_with(datetime.timezone.utc)
 
 
 class Test_get_expiration_seconds_v4(unittest.TestCase):
@@ -138,88 +137,83 @@ class Test_get_expiration_seconds_v4(unittest.TestCase):
         expiration_seconds = _utc_seconds(expiration_utc)
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
 
         with patch as utcnow:
             with self.assertRaises(ValueError):
                 self._call_fut(expiration_seconds)
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once_with(datetime.timezone.utc)
 
     def test_w_expiration_int(self):
         fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0)
         expiration_seconds = 10
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
 
         with patch as utcnow:
             result = self._call_fut(expiration_seconds)
 
         self.assertEqual(result, expiration_seconds)
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once_with(datetime.timezone.utc)
 
     def test_w_expiration_naive_datetime(self):
-        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0)
+        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, _UTC)
         delta = datetime.timedelta(seconds=10)
         expiration_no_tz = fake_utcnow + delta
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
         with patch as utcnow:
             result = self._call_fut(expiration_no_tz)
 
         self.assertEqual(result, delta.seconds)
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once()
 
     def test_w_expiration_utc_datetime(self):
-        from google.cloud._helpers import UTC
-
-        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, UTC)
+        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, _UTC)
         delta = datetime.timedelta(seconds=10)
         expiration_utc = fake_utcnow + delta
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
         with patch as utcnow:
             result = self._call_fut(expiration_utc)
 
         self.assertEqual(result, delta.seconds)
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once_with(datetime.timezone.utc)
 
     def test_w_expiration_other_zone_datetime(self):
-        from google.cloud._helpers import UTC
-
         zone = _make_cet_timezone()
-        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, UTC)
+        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, _UTC)
         fake_cetnow = fake_utcnow.astimezone(zone)
         delta = datetime.timedelta(seconds=10)
         expiration_other = fake_cetnow + delta
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
         with patch as utcnow:
             result = self._call_fut(expiration_other)
-
         self.assertEqual(result, delta.seconds)
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once_with(datetime.timezone.utc)
 
     def test_w_expiration_timedelta(self):
-        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0)
+        fake_utcnow = datetime.datetime(2004, 8, 19, 0, 0, 0, 0, _UTC)
         expiration_as_delta = datetime.timedelta(seconds=10)
 
         patch = mock.patch(
-            "google.cloud.storage._signing.NOW", return_value=fake_utcnow
+            "google.cloud.storage._signing._NOW", return_value=fake_utcnow
         )
         with patch as utcnow:
             result = self._call_fut(expiration_as_delta)
 
         self.assertEqual(result, expiration_as_delta.total_seconds())
-        utcnow.assert_called_once_with()
+        utcnow.assert_called_once_with(datetime.timezone.utc)
 
 
 class Test_get_signed_query_params_v2(unittest.TestCase):
@@ -534,7 +528,7 @@ class Test_generate_signed_url_v4(unittest.TestCase):
         credentials = _make_credentials(signer_email=signer_email)
         credentials.sign_bytes.return_value = b"DEADBEEF"
 
-        with mock.patch("google.cloud.storage._signing.NOW", lambda: now):
+        with mock.patch("google.cloud.storage._signing._NOW", lambda tz: now):
             url = self._call_fut(
                 credentials,
                 resource,
@@ -797,7 +791,7 @@ class TestV4Stamps(unittest.TestCase):
         from google.cloud.storage._signing import get_v4_now_dtstamps
 
         with mock.patch(
-            "google.cloud.storage._signing.NOW",
+            "google.cloud.storage._signing._NOW",
             return_value=datetime.datetime(2020, 3, 12, 13, 14, 15),
         ) as now_mock:
             timestamp, datestamp = get_v4_now_dtstamps()

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -29,6 +29,8 @@ import pytest
 
 from google.cloud.storage import _helpers
 from google.cloud.storage._helpers import _get_default_headers
+from google.cloud.storage._helpers import _NOW
+from google.cloud.storage._helpers import _UTC
 from google.cloud.storage.retry import (
     DEFAULT_RETRY,
     DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
@@ -132,11 +134,9 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.generation, GENERATION)
 
     def _set_properties_helper(self, kms_key_name=None):
-        import datetime
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _RFC3339_MICROS
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
         NOW = now.strftime(_RFC3339_MICROS)
         BLOB_NAME = "blob-name"
         GENERATION = 12345
@@ -459,7 +459,6 @@ class Test_Blob(unittest.TestCase):
         scheme="http",
     ):
         from urllib import parse
-        from google.cloud._helpers import UTC
         from google.cloud.storage._helpers import _bucket_bound_hostname_url
         from google.cloud.storage.blob import _API_ACCESS_ENDPOINT
         from google.cloud.storage.blob import _get_encryption_headers
@@ -469,7 +468,7 @@ class Test_Blob(unittest.TestCase):
         delta = datetime.timedelta(hours=1)
 
         if expiration is None:
-            expiration = datetime.datetime.utcnow().replace(tzinfo=UTC) + delta
+            expiration = _NOW(_UTC) + delta
 
         if credentials is None:
             expected_creds = _make_credentials()
@@ -565,9 +564,7 @@ class Test_Blob(unittest.TestCase):
         self._generate_signed_url_v2_helper()
 
     def test_generate_signed_url_v2_w_expiration(self):
-        from google.cloud._helpers import UTC
-
-        expiration = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        expiration = _NOW(_UTC)
         self._generate_signed_url_v2_helper(expiration=expiration)
 
     def test_generate_signed_url_v2_w_non_ascii_name(self):
@@ -3296,8 +3293,6 @@ class Test_Blob(unittest.TestCase):
         self._do_upload_helper(retry=DEFAULT_RETRY_IF_GENERATION_SPECIFIED)
 
     def _upload_from_file_helper(self, side_effect=None, **kwargs):
-        from google.cloud._helpers import UTC
-
         blob = self._make_one("blob-name", bucket=None)
         # Mock low-level upload helper on blob (it is tested elsewhere).
         created_json = {"updated": "2017-01-01T09:09:09.081Z"}
@@ -3328,7 +3323,7 @@ class Test_Blob(unittest.TestCase):
 
         # Check the response and side-effects.
         self.assertIsNone(ret_val)
-        new_updated = datetime.datetime(2017, 1, 1, 9, 9, 9, 81000, tzinfo=UTC)
+        new_updated = datetime.datetime(2017, 1, 1, 9, 9, 9, 81000, tzinfo=_UTC)
         self.assertEqual(blob.updated, new_updated)
 
         expected_timeout = kwargs.get("timeout", self._get_default_timeout())
@@ -5632,11 +5627,10 @@ class Test_Blob(unittest.TestCase):
 
     def test_retention_expiration_time(self):
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
 
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {"retentionExpirationTime": TIME_CREATED}
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
@@ -5723,11 +5717,10 @@ class Test_Blob(unittest.TestCase):
 
     def test_time_deleted(self):
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
 
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         TIME_DELETED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {"timeDeleted": TIME_DELETED}
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
@@ -5740,11 +5733,10 @@ class Test_Blob(unittest.TestCase):
 
     def test_time_created(self):
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
 
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {"timeCreated": TIME_CREATED}
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
@@ -5757,11 +5749,10 @@ class Test_Blob(unittest.TestCase):
 
     def test_updated(self):
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
 
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         UPDATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {"updated": UPDATED}
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
@@ -5774,22 +5765,19 @@ class Test_Blob(unittest.TestCase):
 
     def test_custom_time_getter(self):
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
 
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {"customTime": TIME_CREATED}
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
         self.assertEqual(blob.custom_time, TIMESTAMP)
 
     def test_custom_time_setter(self):
-        from google.cloud._helpers import UTC
-
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         blob = self._make_one(BLOB_NAME, bucket=bucket)
         self.assertIsNone(blob.custom_time)
         blob.custom_time = TIMESTAMP
@@ -5798,11 +5786,10 @@ class Test_Blob(unittest.TestCase):
 
     def test_custom_time_setter_none_value(self):
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
 
         BLOB_NAME = "blob-name"
         bucket = _Bucket()
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {"customTime": TIME_CREATED}
         blob = self._make_one(BLOB_NAME, bucket=bucket, properties=properties)
@@ -5941,12 +5928,10 @@ class Test_Blob(unittest.TestCase):
         self.assertIsNone(retention.retention_expiration_time)
 
     def test_object_lock_retention_configuration_w_entry(self):
-        import datetime
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
         from google.cloud.storage.blob import Retention
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
         expiration_time = now + datetime.timedelta(hours=1)
         expiration = expiration_time.strftime(_RFC3339_MICROS)
         mode = "Locked"
@@ -5977,8 +5962,6 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(retention.retention_expiration_time, expiration_time)
 
     def test_object_lock_retention_configuration_setter(self):
-        import datetime
-        from google.cloud._helpers import UTC
         from google.cloud.storage.blob import Retention
 
         BLOB_NAME = "blob-name"
@@ -5987,7 +5970,7 @@ class Test_Blob(unittest.TestCase):
         self.assertIsInstance(blob.retention, Retention)
 
         mode = "Locked"
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
         expiration_time = now + datetime.timedelta(hours=1)
         retention_config = Retention(
             blob=blob, mode=mode, retain_until_time=expiration_time

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -27,6 +27,8 @@ from google.cloud.storage.constants import PUBLIC_ACCESS_PREVENTION_INHERITED
 from google.cloud.storage.constants import PUBLIC_ACCESS_PREVENTION_UNSPECIFIED
 from google.cloud.storage.constants import RPO_DEFAULT
 from google.cloud.storage.constants import RPO_ASYNC_TURBO
+from google.cloud.storage._helpers import _NOW
+from google.cloud.storage._helpers import _UTC
 
 
 def _create_signing_credentials():
@@ -429,11 +431,8 @@ class Test_IAMConfiguration(unittest.TestCase):
         self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_ctor_explicit_ubla(self):
-        import datetime
-        from google.cloud._helpers import UTC
-
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
 
         config = self._make_one(
             bucket,
@@ -469,11 +468,8 @@ class Test_IAMConfiguration(unittest.TestCase):
         )
 
     def test_ctor_explicit_bpo(self):
-        import datetime
-        from google.cloud._helpers import UTC
-
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
 
         config = pytest.deprecated_call(
             self._make_one,
@@ -499,11 +495,8 @@ class Test_IAMConfiguration(unittest.TestCase):
             )
 
     def test_ctor_ubla_and_bpo_time(self):
-        import datetime
-        from google.cloud._helpers import UTC
-
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
 
         with self.assertRaises(ValueError):
             self._make_one(
@@ -547,13 +540,11 @@ class Test_IAMConfiguration(unittest.TestCase):
         self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_from_api_repr_w_enabled(self):
-        import datetime
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_rfc3339
 
         klass = self._get_target_class()
         bucket = self._make_bucket()
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
         resource = {
             "uniformBucketLevelAccess": {
                 "enabled": True,
@@ -2324,12 +2315,10 @@ class Test_Bucket(unittest.TestCase):
         self.assertIsNone(config.bucket_policy_only_locked_time)
 
     def test_iam_configuration_policy_w_entry(self):
-        import datetime
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_rfc3339
         from google.cloud.storage.bucket import IAMConfiguration
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
         NAME = "name"
         properties = {
             "iamConfiguration": {
@@ -2678,11 +2667,9 @@ class Test_Bucket(unittest.TestCase):
         self.assertIsNone(bucket.autoclass_terminal_storage_class_update_time)
 
     def test_autoclass_toggle_and_tsc_update_time(self):
-        import datetime
         from google.cloud._helpers import _datetime_to_rfc3339
-        from google.cloud._helpers import UTC
 
-        effective_time = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        effective_time = _NOW(_UTC)
         properties = {
             "autoclass": {
                 "enabled": True,
@@ -2805,11 +2792,9 @@ class Test_Bucket(unittest.TestCase):
         self.assertIsNone(bucket.retention_policy_effective_time)
 
     def test_retention_policy_effective_time(self):
-        import datetime
         from google.cloud._helpers import _datetime_to_rfc3339
-        from google.cloud._helpers import UTC
 
-        effective_time = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        effective_time = _NOW(_UTC)
         properties = {
             "retentionPolicy": {"effectiveTime": _datetime_to_rfc3339(effective_time)}
         }
@@ -2961,9 +2946,8 @@ class Test_Bucket(unittest.TestCase):
 
     def test_time_created(self):
         from google.cloud._helpers import _RFC3339_MICROS
-        from google.cloud._helpers import UTC
 
-        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=UTC)
+        TIMESTAMP = datetime.datetime(2014, 11, 5, 20, 34, 37, tzinfo=_UTC)
         TIME_CREATED = TIMESTAMP.strftime(_RFC3339_MICROS)
         properties = {"timeCreated": TIME_CREATED}
         bucket = self._make_one(properties=properties)
@@ -4056,7 +4040,6 @@ class Test_Bucket(unittest.TestCase):
         scheme="http",
     ):
         from urllib import parse
-        from google.cloud._helpers import UTC
         from google.cloud.storage._helpers import _bucket_bound_hostname_url
         from google.cloud.storage.blob import _API_ACCESS_ENDPOINT
 
@@ -4065,7 +4048,7 @@ class Test_Bucket(unittest.TestCase):
         delta = datetime.timedelta(hours=1)
 
         if expiration is None:
-            expiration = datetime.datetime.utcnow().replace(tzinfo=UTC) + delta
+            expiration = _NOW(_UTC) + delta
 
         client = self._make_client(_credentials=credentials)
         bucket = self._make_one(name=bucket_name, client=client)
@@ -4169,9 +4152,7 @@ class Test_Bucket(unittest.TestCase):
         self._generate_signed_url_v2_helper()
 
     def test_generate_signed_url_v2_w_expiration(self):
-        from google.cloud._helpers import UTC
-
-        expiration = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        expiration = _NOW(_UTC)
         self._generate_signed_url_v2_helper(expiration=expiration)
 
     def test_generate_signed_url_v2_w_endpoint(self):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2827,7 +2827,7 @@ def test_conformance_post_policy(test_data):
     client = Client(credentials=_FAKE_CREDENTIALS, project="PROJECT")
 
     # mocking time functions
-    with mock.patch("google.cloud.storage._signing.NOW", return_value=timestamp):
+    with mock.patch("google.cloud.storage._signing._NOW", return_value=timestamp):
         with mock.patch(
             "google.cloud.storage.client.get_expiration_seconds_v4",
             return_value=in_data["expiration"],

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -29,6 +29,8 @@ from google.auth.credentials import AnonymousCredentials
 from google.oauth2.service_account import Credentials
 
 from google.cloud.storage import _helpers
+from google.cloud.storage._helpers import _NOW
+from google.cloud.storage._helpers import _UTC
 from google.cloud.storage._helpers import STORAGE_EMULATOR_ENV_VAR
 from google.cloud.storage._helpers import _get_default_headers
 from google.cloud.storage._http import Connection
@@ -2250,8 +2252,6 @@ class TestClient(unittest.TestCase):
         timeout=None,
         retry=None,
     ):
-        import datetime
-        from google.cloud._helpers import UTC
         from google.cloud.storage.hmac_key import HMACKeyMetadata
 
         project = "PROJECT"
@@ -2259,7 +2259,7 @@ class TestClient(unittest.TestCase):
         credentials = _make_credentials()
         email = "storage-user-123@example.com"
         secret = "a" * 40
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = _NOW(_UTC)
         now_stamp = f"{now.isoformat()}Z"
 
         if explicit_project is not None:

--- a/tests/unit/test_hmac_key.py
+++ b/tests/unit/test_hmac_key.py
@@ -18,6 +18,8 @@ import mock
 
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_ETAG_IN_JSON
+from google.cloud.storage._helpers import _NOW
+from google.cloud.storage._helpers import _UTC
 
 
 class TestHMACKeyMetadata(unittest.TestCase):
@@ -173,24 +175,18 @@ class TestHMACKeyMetadata(unittest.TestCase):
         self.assertEqual(metadata._properties["state"], expected)
 
     def test_time_created_getter(self):
-        import datetime
-        from google.cloud._helpers import UTC
-
         metadata = self._make_one()
-        now = datetime.datetime.utcnow()
+        now = _NOW()
         now_stamp = f"{now.isoformat()}Z"
         metadata._properties["timeCreated"] = now_stamp
-        self.assertEqual(metadata.time_created, now.replace(tzinfo=UTC))
+        self.assertEqual(metadata.time_created, now.replace(tzinfo=_UTC))
 
     def test_updated_getter(self):
-        import datetime
-        from google.cloud._helpers import UTC
-
         metadata = self._make_one()
-        now = datetime.datetime.utcnow()
+        now = _NOW()
         now_stamp = f"{now.isoformat()}Z"
         metadata._properties["updated"] = now_stamp
-        self.assertEqual(metadata.updated, now.replace(tzinfo=UTC))
+        self.assertEqual(metadata.updated, now.replace(tzinfo=_UTC))
 
     def test_path_wo_access_id(self):
         metadata = self._make_one()

--- a/tests/unit/test_transfer_manager.py
+++ b/tests/unit/test_transfer_manager.py
@@ -841,10 +841,10 @@ def test_upload_chunks_concurrently_passes_concurrency_options():
 
 def test_upload_chunks_concurrently_with_metadata_and_encryption():
     import datetime
-    from google.cloud._helpers import UTC
+    from google.cloud.storage._helpers import _UTC
     from google.cloud._helpers import _RFC3339_MICROS
 
-    now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+    now = datetime.datetime.now(_UTC)
     now_str = now.strftime(_RFC3339_MICROS)
 
     custom_metadata = {"key_a": "value_a", "key_b": "value_b"}


### PR DESCRIPTION
Replace [`datetime.utcnow`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) which is deprecated in python 3.12

Fixes #1171 
Fixes #1194 
