### PR TITLE
fix: cancel upload when BlobWriter exits with exception

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,12 @@ setup.py file. Applications which do not import directly from
 `google-resumable-media` can safely disregard this dependency. This backwards
 compatibility feature will be removed in a future major version update.
 
+Miscellaneous
+~~~~~~~~~~~~~
+
+- The BlobWriter class now attempts to terminate an ongoing resumable upload if
+  the writer exits with an exception.
+
 Quick Start
 -----------
 

--- a/docs/storage/exceptions.rst
+++ b/docs/storage/exceptions.rst
@@ -1,5 +1,5 @@
 Exceptions
-~~~~~~~~~
+~~~~~~~~~~
 
 .. automodule:: google.cloud.storage.exceptions
   :members:

--- a/google/cloud/storage/fileio.py
+++ b/google/cloud/storage/fileio.py
@@ -437,6 +437,19 @@ class BlobWriter(io.BufferedIOBase):
             self._upload_chunks_from_buffer(1)
         self._buffer.close()
 
+    def terminate(self):
+        """Cancel the ResumableUpload."""
+        if self._upload_and_transport:
+            upload, transport = self._upload_and_transport
+            transport.delete(upload.upload_url)
+        self._buffer.close()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            self.terminate()
+        else:
+            self.close()
+
     @property
     def closed(self):
         return self._buffer.closed


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1228
