### PR TITLE
feat: instrument metadata ops with OTel tracing (#2)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ You will also need to tell OpenTelemetry which exporter to use. An example to ex
 
     tracer_provider = TracerProvider()
     tracer_provider.add_span_processor(BatchSpanProcessor(CloudTraceSpanExporter()))
-    trace.set_tracer_provider(TracerProvider())
+    trace.set_tracer_provider(tracer_provider)
 
     # Optional yet recommended to instrument the requests HTTP library
     from opentelemetry.instrumentation.requests import RequestsInstrumentor

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,59 @@ Windows
     .\<your-env>\Scripts\activate
     pip install google-cloud-storage
 
+
+Tracing With OpenTelemetry
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This library uses `OpenTelemetry`_ to generate traces on calls to Google Cloud Storage.
+For information on the benefits and utility of tracing, read the `Cloud Trace Overview <https://cloud.google.com/trace/docs/overview>`_.
+
+To enable OpenTelemetry tracing in the Cloud Storage client, first install OpenTelemetry:
+
+.. code-block:: console
+
+    pip install google-cloud-storage[tracing]
+
+Set the ``ENABLE_GCS_PYTHON_CLIENT_OTEL_TRACES`` environment variable to selectively opt-in tracing for the Cloud Storage client:
+
+.. code-block:: console
+
+    export ENABLE_GCS_PYTHON_CLIENT_OTEL_TRACES=True
+
+You will also need to tell OpenTelemetry which exporter to use. An example to export traces to Google Cloud Trace can be found below.
+
+.. code-block:: console
+
+    # Install the Google Cloud Trace exporter and propagator, however you can use any exporter of your choice.
+    pip install opentelemetry-exporter-gcp-trace opentelemetry-propagator-gcp
+
+    # [Optional] Install the OpenTelemetry Requests Instrumentation to trace the underlying HTTP requests.
+    pip install opentelemetry-instrumentation-requests
+
+.. code-block:: python
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(BatchSpanProcessor(CloudTraceSpanExporter()))
+    trace.set_tracer_provider(TracerProvider())
+
+    # Optional yet recommended to instrument the requests HTTP library
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+    RequestsInstrumentor().instrument(tracer_provider=tracer_provider)
+
+In this example, tracing data will be published to the `Google Cloud Trace`_ console.
+Tracing is most effective when many libraries are instrumented to provide insight over the entire lifespan of a request.
+For a list of libraries that can be instrumented, refer to the `OpenTelemetry Registry`_.
+
+.. _OpenTelemetry: https://opentelemetry.io
+.. _OpenTelemetry Registry: https://opentelemetry.io/ecosystem/registry
+.. _Google Cloud Trace: https://cloud.google.com/trace
+
+
 Next Steps
 ~~~~~~~~~~
 

--- a/google/cloud/storage/_http.py
+++ b/google/cloud/storage/_http.py
@@ -18,7 +18,7 @@ import functools
 from google.cloud import _http
 from google.cloud.storage import __version__
 from google.cloud.storage import _helpers
-from google.cloud.storage._opentelemetry_tracing import create_span
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
 
 
 class Connection(_http.JSONConnection):
@@ -72,7 +72,7 @@ class Connection(_http.JSONConnection):
             "gccl-invocation-id": invocation_id,
         }
         call = functools.partial(super(Connection, self).api_request, *args, **kwargs)
-        with create_span(
+        with create_trace_span(
             name="Storage.Connection.api_request",
             attributes=span_attributes,
             client=self._client,

--- a/google/cloud/storage/_opentelemetry_tracing.py
+++ b/google/cloud/storage/_opentelemetry_tracing.py
@@ -42,7 +42,7 @@ _default_attributes = {
 
 
 @contextmanager
-def create_span(
+def create_trace_span(
     name, attributes=None, client=None, api_request=None, retry=None, **kwargs
 ):
     """Creates a context manager for a new span and set it as the current span

--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -15,7 +15,7 @@
 """Manage access to objects and buckets."""
 
 from google.cloud.storage._helpers import _add_generation_match_parameters
-from google.cloud.storage._opentelemetry_tracing import create_span
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
@@ -360,7 +360,7 @@ class ACL(object):
             client = self.client
         return client
 
-    @create_span(name="Storage.ACL.reload")
+    @create_trace_span(name="Storage.ACL.reload")
     def reload(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Reload the ACL data from Cloud Storage.
 
@@ -486,7 +486,7 @@ class ACL(object):
 
         self.loaded = True
 
-    @create_span(name="Storage.ACL.save")
+    @create_trace_span(name="Storage.ACL.save")
     def save(
         self,
         acl=None,
@@ -555,7 +555,7 @@ class ACL(object):
                 retry=retry,
             )
 
-    @create_span(name="Storage.ACL.savePredefined")
+    @create_trace_span(name="Storage.ACL.savePredefined")
     def save_predefined(
         self,
         predefined,
@@ -621,7 +621,7 @@ class ACL(object):
             retry=retry,
         )
 
-    @create_span(name="Storage.ACL.clear")
+    @create_trace_span(name="Storage.ACL.clear")
     def clear(
         self,
         client=None,

--- a/google/cloud/storage/acl.py
+++ b/google/cloud/storage/acl.py
@@ -15,6 +15,7 @@
 """Manage access to objects and buckets."""
 
 from google.cloud.storage._helpers import _add_generation_match_parameters
+from google.cloud.storage._opentelemetry_tracing import create_span
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED
@@ -359,6 +360,7 @@ class ACL(object):
             client = self.client
         return client
 
+    @create_span(name="Storage.ACL.reload")
     def reload(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Reload the ACL data from Cloud Storage.
 
@@ -484,6 +486,7 @@ class ACL(object):
 
         self.loaded = True
 
+    @create_span(name="Storage.ACL.save")
     def save(
         self,
         acl=None,
@@ -552,6 +555,7 @@ class ACL(object):
                 retry=retry,
             )
 
+    @create_span(name="Storage.ACL.savePredefined")
     def save_predefined(
         self,
         predefined,
@@ -617,6 +621,7 @@ class ACL(object):
             retry=retry,
         )
 
+    @create_span(name="Storage.ACL.clear")
     def clear(
         self,
         client=None,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -63,7 +63,7 @@ from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage._helpers import _NUM_RETRIES_MESSAGE
 from google.cloud.storage._helpers import _API_VERSION
 from google.cloud.storage._helpers import _virtual_hosted_style_base_url
-from google.cloud.storage._opentelemetry_tracing import create_span
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage.acl import ACL
 from google.cloud.storage.acl import ObjectACL
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
@@ -640,7 +640,7 @@ class Blob(_PropertyMixin):
             access_token=access_token,
         )
 
-    @create_span(name="Storage.Blob.exists")
+    @create_trace_span(name="Storage.Blob.exists")
     def exists(
         self,
         client=None,
@@ -746,7 +746,7 @@ class Blob(_PropertyMixin):
             return False
         return True
 
-    @create_span(name="Storage.Blob.delete")
+    @create_trace_span(name="Storage.Blob.delete")
     def delete(
         self,
         client=None,
@@ -3284,7 +3284,7 @@ class Blob(_PropertyMixin):
         except resumable_media.InvalidResponse as exc:
             _raise_from_invalid_response(exc)
 
-    @create_span(name="Storage.Blob.getIamPolicy")
+    @create_trace_span(name="Storage.Blob.getIamPolicy")
     def get_iam_policy(
         self,
         client=None,
@@ -3353,7 +3353,7 @@ class Blob(_PropertyMixin):
         )
         return Policy.from_api_repr(info)
 
-    @create_span(name="Storage.Blob.setIamPolicy")
+    @create_trace_span(name="Storage.Blob.setIamPolicy")
     def set_iam_policy(
         self,
         policy,
@@ -3415,7 +3415,7 @@ class Blob(_PropertyMixin):
         )
         return Policy.from_api_repr(info)
 
-    @create_span(name="Storage.Blob.testIamPermissions")
+    @create_trace_span(name="Storage.Blob.testIamPermissions")
     def test_iam_permissions(
         self, permissions, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):
@@ -3470,7 +3470,7 @@ class Blob(_PropertyMixin):
 
         return resp.get("permissions", [])
 
-    @create_span(name="Storage.Blob.makePublic")
+    @create_trace_span(name="Storage.Blob.makePublic")
     def make_public(
         self,
         client=None,
@@ -3524,7 +3524,7 @@ class Blob(_PropertyMixin):
             retry=retry,
         )
 
-    @create_span(name="Storage.Blob.makePrivate")
+    @create_trace_span(name="Storage.Blob.makePrivate")
     def make_private(
         self,
         client=None,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -63,6 +63,7 @@ from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage._helpers import _NUM_RETRIES_MESSAGE
 from google.cloud.storage._helpers import _API_VERSION
 from google.cloud.storage._helpers import _virtual_hosted_style_base_url
+from google.cloud.storage._opentelemetry_tracing import create_span
 from google.cloud.storage.acl import ACL
 from google.cloud.storage.acl import ObjectACL
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
@@ -639,6 +640,7 @@ class Blob(_PropertyMixin):
             access_token=access_token,
         )
 
+    @create_span(name="Storage.Blob.exists")
     def exists(
         self,
         client=None,
@@ -744,6 +746,7 @@ class Blob(_PropertyMixin):
             return False
         return True
 
+    @create_span(name="Storage.Blob.delete")
     def delete(
         self,
         client=None,
@@ -3281,6 +3284,7 @@ class Blob(_PropertyMixin):
         except resumable_media.InvalidResponse as exc:
             _raise_from_invalid_response(exc)
 
+    @create_span(name="Storage.Blob.getIamPolicy")
     def get_iam_policy(
         self,
         client=None,
@@ -3349,6 +3353,7 @@ class Blob(_PropertyMixin):
         )
         return Policy.from_api_repr(info)
 
+    @create_span(name="Storage.Blob.setIamPolicy")
     def set_iam_policy(
         self,
         policy,
@@ -3410,6 +3415,7 @@ class Blob(_PropertyMixin):
         )
         return Policy.from_api_repr(info)
 
+    @create_span(name="Storage.Blob.testIamPermissions")
     def test_iam_permissions(
         self, permissions, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):
@@ -3464,6 +3470,7 @@ class Blob(_PropertyMixin):
 
         return resp.get("permissions", [])
 
+    @create_span(name="Storage.Blob.makePublic")
     def make_public(
         self,
         client=None,
@@ -3517,6 +3524,7 @@ class Blob(_PropertyMixin):
             retry=retry,
         )
 
+    @create_span(name="Storage.Blob.makePrivate")
     def make_private(
         self,
         client=None,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -38,6 +38,7 @@ from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage._helpers import _bucket_bound_hostname_url
 from google.cloud.storage._helpers import _virtual_hosted_style_base_url
+from google.cloud.storage._opentelemetry_tracing import create_span
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
 from google.cloud.storage.blob import Blob
@@ -827,6 +828,7 @@ class Bucket(_PropertyMixin):
             notification_id=notification_id,
         )
 
+    @create_span(name="Storage.Bucket.exists")
     def exists(
         self,
         client=None,
@@ -911,6 +913,7 @@ class Bucket(_PropertyMixin):
             return False
         return True
 
+    @create_span(name="Storage.Bucket.create")
     def create(
         self,
         client=None,
@@ -986,6 +989,7 @@ class Bucket(_PropertyMixin):
             retry=retry,
         )
 
+    @create_span(name="Storage.Bucket.update")
     def update(
         self,
         client=None,
@@ -1030,6 +1034,7 @@ class Bucket(_PropertyMixin):
             retry=retry,
         )
 
+    @create_span(name="Storage.Bucket.reload")
     def reload(
         self,
         client=None,
@@ -1091,6 +1096,7 @@ class Bucket(_PropertyMixin):
             retry=retry,
         )
 
+    @create_span(name="Storage.Bucket.patch")
     def patch(
         self,
         client=None,
@@ -1174,6 +1180,7 @@ class Bucket(_PropertyMixin):
 
         return self.path_helper(self.name)
 
+    @create_span(name="Storage.Bucket.getBlob")
     def get_blob(
         self,
         blob_name,
@@ -1290,6 +1297,7 @@ class Bucket(_PropertyMixin):
         else:
             return blob
 
+    @create_span(name="Storage.Bucket.listBlobs")
     def list_blobs(
         self,
         max_results=None,
@@ -1425,6 +1433,7 @@ class Bucket(_PropertyMixin):
             soft_deleted=soft_deleted,
         )
 
+    @create_span(name="Storage.Bucket.listNotifications")
     def list_notifications(
         self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):
@@ -1462,6 +1471,7 @@ class Bucket(_PropertyMixin):
         iterator.bucket = self
         return iterator
 
+    @create_span(name="Storage.Bucket.getNotification")
     def get_notification(
         self,
         notification_id,
@@ -1499,6 +1509,7 @@ class Bucket(_PropertyMixin):
         notification.reload(client=client, timeout=timeout, retry=retry)
         return notification
 
+    @create_span(name="Storage.Bucket.delete")
     def delete(
         self,
         force=False,
@@ -1605,6 +1616,7 @@ class Bucket(_PropertyMixin):
             _target_object=None,
         )
 
+    @create_span(name="Storage.Bucket.deleteBlob")
     def delete_blob(
         self,
         blob_name,
@@ -1685,6 +1697,7 @@ class Bucket(_PropertyMixin):
             _target_object=None,
         )
 
+    @create_span(name="Storage.Bucket.deleteBlobs")
     def delete_blobs(
         self,
         blobs,
@@ -2085,6 +2098,7 @@ class Bucket(_PropertyMixin):
             )
         return new_blob
 
+    @create_span(name="Storage.Bucket.restore_blob")
     def restore_blob(
         self,
         blob_name,
@@ -2957,6 +2971,7 @@ class Bucket(_PropertyMixin):
         """
         return self.configure_website(None, None)
 
+    @create_span(name="Storage.Bucket.getIamPolicy")
     def get_iam_policy(
         self,
         client=None,
@@ -3019,6 +3034,7 @@ class Bucket(_PropertyMixin):
         )
         return Policy.from_api_repr(info)
 
+    @create_span(name="Storage.Bucket.setIamPolicy")
     def set_iam_policy(
         self,
         policy,
@@ -3075,6 +3091,7 @@ class Bucket(_PropertyMixin):
 
         return Policy.from_api_repr(info)
 
+    @create_span(name="Storage.Bucket.testIamPermissions")
     def test_iam_permissions(
         self, permissions, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):
@@ -3122,6 +3139,7 @@ class Bucket(_PropertyMixin):
         )
         return resp.get("permissions", [])
 
+    @create_span(name="Storage.Bucket.makePublic")
     def make_public(
         self,
         recursive=False,
@@ -3219,6 +3237,7 @@ class Bucket(_PropertyMixin):
                     timeout=timeout,
                 )
 
+    @create_span(name="Storage.Bucket.makePrivate")
     def make_private(
         self,
         recursive=False,
@@ -3366,6 +3385,7 @@ class Bucket(_PropertyMixin):
 
         return fields
 
+    @create_span(name="Storage.Bucket.lockRetentionPolicy")
     def lock_retention_policy(
         self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -38,7 +38,7 @@ from google.cloud.storage._signing import generate_signed_url_v2
 from google.cloud.storage._signing import generate_signed_url_v4
 from google.cloud.storage._helpers import _bucket_bound_hostname_url
 from google.cloud.storage._helpers import _virtual_hosted_style_base_url
-from google.cloud.storage._opentelemetry_tracing import create_span
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
 from google.cloud.storage.blob import Blob
@@ -828,7 +828,7 @@ class Bucket(_PropertyMixin):
             notification_id=notification_id,
         )
 
-    @create_span(name="Storage.Bucket.exists")
+    @create_trace_span(name="Storage.Bucket.exists")
     def exists(
         self,
         client=None,
@@ -913,7 +913,7 @@ class Bucket(_PropertyMixin):
             return False
         return True
 
-    @create_span(name="Storage.Bucket.create")
+    @create_trace_span(name="Storage.Bucket.create")
     def create(
         self,
         client=None,
@@ -989,7 +989,7 @@ class Bucket(_PropertyMixin):
             retry=retry,
         )
 
-    @create_span(name="Storage.Bucket.update")
+    @create_trace_span(name="Storage.Bucket.update")
     def update(
         self,
         client=None,
@@ -1034,7 +1034,7 @@ class Bucket(_PropertyMixin):
             retry=retry,
         )
 
-    @create_span(name="Storage.Bucket.reload")
+    @create_trace_span(name="Storage.Bucket.reload")
     def reload(
         self,
         client=None,
@@ -1096,7 +1096,7 @@ class Bucket(_PropertyMixin):
             retry=retry,
         )
 
-    @create_span(name="Storage.Bucket.patch")
+    @create_trace_span(name="Storage.Bucket.patch")
     def patch(
         self,
         client=None,
@@ -1180,7 +1180,7 @@ class Bucket(_PropertyMixin):
 
         return self.path_helper(self.name)
 
-    @create_span(name="Storage.Bucket.getBlob")
+    @create_trace_span(name="Storage.Bucket.getBlob")
     def get_blob(
         self,
         blob_name,
@@ -1297,7 +1297,7 @@ class Bucket(_PropertyMixin):
         else:
             return blob
 
-    @create_span(name="Storage.Bucket.listBlobs")
+    @create_trace_span(name="Storage.Bucket.listBlobs")
     def list_blobs(
         self,
         max_results=None,
@@ -1433,7 +1433,7 @@ class Bucket(_PropertyMixin):
             soft_deleted=soft_deleted,
         )
 
-    @create_span(name="Storage.Bucket.listNotifications")
+    @create_trace_span(name="Storage.Bucket.listNotifications")
     def list_notifications(
         self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):
@@ -1471,7 +1471,7 @@ class Bucket(_PropertyMixin):
         iterator.bucket = self
         return iterator
 
-    @create_span(name="Storage.Bucket.getNotification")
+    @create_trace_span(name="Storage.Bucket.getNotification")
     def get_notification(
         self,
         notification_id,
@@ -1509,7 +1509,7 @@ class Bucket(_PropertyMixin):
         notification.reload(client=client, timeout=timeout, retry=retry)
         return notification
 
-    @create_span(name="Storage.Bucket.delete")
+    @create_trace_span(name="Storage.Bucket.delete")
     def delete(
         self,
         force=False,
@@ -1616,7 +1616,7 @@ class Bucket(_PropertyMixin):
             _target_object=None,
         )
 
-    @create_span(name="Storage.Bucket.deleteBlob")
+    @create_trace_span(name="Storage.Bucket.deleteBlob")
     def delete_blob(
         self,
         blob_name,
@@ -1697,7 +1697,7 @@ class Bucket(_PropertyMixin):
             _target_object=None,
         )
 
-    @create_span(name="Storage.Bucket.deleteBlobs")
+    @create_trace_span(name="Storage.Bucket.deleteBlobs")
     def delete_blobs(
         self,
         blobs,
@@ -2098,7 +2098,7 @@ class Bucket(_PropertyMixin):
             )
         return new_blob
 
-    @create_span(name="Storage.Bucket.restore_blob")
+    @create_trace_span(name="Storage.Bucket.restore_blob")
     def restore_blob(
         self,
         blob_name,
@@ -2971,7 +2971,7 @@ class Bucket(_PropertyMixin):
         """
         return self.configure_website(None, None)
 
-    @create_span(name="Storage.Bucket.getIamPolicy")
+    @create_trace_span(name="Storage.Bucket.getIamPolicy")
     def get_iam_policy(
         self,
         client=None,
@@ -3034,7 +3034,7 @@ class Bucket(_PropertyMixin):
         )
         return Policy.from_api_repr(info)
 
-    @create_span(name="Storage.Bucket.setIamPolicy")
+    @create_trace_span(name="Storage.Bucket.setIamPolicy")
     def set_iam_policy(
         self,
         policy,
@@ -3091,7 +3091,7 @@ class Bucket(_PropertyMixin):
 
         return Policy.from_api_repr(info)
 
-    @create_span(name="Storage.Bucket.testIamPermissions")
+    @create_trace_span(name="Storage.Bucket.testIamPermissions")
     def test_iam_permissions(
         self, permissions, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):
@@ -3139,7 +3139,7 @@ class Bucket(_PropertyMixin):
         )
         return resp.get("permissions", [])
 
-    @create_span(name="Storage.Bucket.makePublic")
+    @create_trace_span(name="Storage.Bucket.makePublic")
     def make_public(
         self,
         recursive=False,
@@ -3237,7 +3237,7 @@ class Bucket(_PropertyMixin):
                     timeout=timeout,
                 )
 
-    @create_span(name="Storage.Bucket.makePrivate")
+    @create_trace_span(name="Storage.Bucket.makePrivate")
     def make_private(
         self,
         recursive=False,
@@ -3385,7 +3385,7 @@ class Bucket(_PropertyMixin):
 
         return fields
 
-    @create_span(name="Storage.Bucket.lockRetentionPolicy")
+    @create_trace_span(name="Storage.Bucket.lockRetentionPolicy")
     def lock_retention_policy(
         self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -483,9 +483,20 @@ class Client(ClientWithProject):
         timeout=_DEFAULT_TIMEOUT,
         retry=DEFAULT_RETRY,
     ):
-        api_request = functools.partial(
-            self._connection.api_request, timeout=timeout, retry=retry
-        )
+        kwargs = {
+            "method": "GET",
+            "path": path,
+            "timeout": timeout,
+        }
+        with create_span(
+            name="Storage.Client._list_resource_returns_iterator",
+            client=self,
+            api_request=kwargs,
+            retry=retry,
+        ):
+            api_request = functools.partial(
+                self._connection.api_request, timeout=timeout, retry=retry
+            )
         return page_iterator.HTTPIterator(
             client=self,
             api_request=api_request,
@@ -800,6 +811,7 @@ class Client(ClientWithProject):
             bucket = Bucket(self, name=bucket_or_name)
         return bucket
 
+    @create_span(name="Storage.Client.getBucket")
     def get_bucket(
         self,
         bucket_or_name,
@@ -865,6 +877,7 @@ class Client(ClientWithProject):
         )
         return bucket
 
+    @create_span(name="Storage.Client.lookupBucket")
     def lookup_bucket(
         self,
         bucket_name,
@@ -912,6 +925,7 @@ class Client(ClientWithProject):
         except NotFound:
             return None
 
+    @create_span(name="Storage.Client.createBucket")
     def create_bucket(
         self,
         bucket_or_name,
@@ -1169,6 +1183,7 @@ class Client(ClientWithProject):
             retry=retry,
         )
 
+    @create_span(name="Storage.Client.listBlobs")
     def list_blobs(
         self,
         bucket_or_name,
@@ -1358,6 +1373,7 @@ class Client(ClientWithProject):
         iterator.prefixes = set()
         return iterator
 
+    @create_span(name="Storage.Client.listBuckets")
     def list_buckets(
         self,
         max_results=None,
@@ -1463,6 +1479,7 @@ class Client(ClientWithProject):
             retry=retry,
         )
 
+    @create_span(name="Storage.Client.createHmacKey")
     def create_hmac_key(
         self,
         service_account_email,
@@ -1527,6 +1544,7 @@ class Client(ClientWithProject):
         secret = api_response["secret"]
         return metadata, secret
 
+    @create_span(name="Storage.Client.listHmacKeys")
     def list_hmac_keys(
         self,
         max_results=None,
@@ -1596,6 +1614,7 @@ class Client(ClientWithProject):
             retry=retry,
         )
 
+    @create_span(name="Storage.Client.getHmacKeyMetadata")
     def get_hmac_key_metadata(
         self, access_id, project_id=None, user_project=None, timeout=_DEFAULT_TIMEOUT
     ):

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -41,7 +41,7 @@ from google.cloud.storage._helpers import _DEFAULT_SCHEME
 from google.cloud.storage._helpers import _STORAGE_HOST_TEMPLATE
 from google.cloud.storage._helpers import _NOW
 from google.cloud.storage._helpers import _UTC
-from google.cloud.storage._opentelemetry_tracing import create_span
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
 
 from google.cloud.storage._http import Connection
 from google.cloud.storage._signing import (
@@ -338,7 +338,7 @@ class Client(ClientWithProject):
         """
         return self._batch_stack.top
 
-    @create_span(name="Storage.Client.getServiceAccountEmail")
+    @create_trace_span(name="Storage.Client.getServiceAccountEmail")
     def get_service_account_email(
         self, project=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
     ):
@@ -488,7 +488,7 @@ class Client(ClientWithProject):
             "path": path,
             "timeout": timeout,
         }
-        with create_span(
+        with create_trace_span(
             name="Storage.Client._list_resource_returns_iterator",
             client=self,
             api_request=kwargs,
@@ -811,7 +811,7 @@ class Client(ClientWithProject):
             bucket = Bucket(self, name=bucket_or_name)
         return bucket
 
-    @create_span(name="Storage.Client.getBucket")
+    @create_trace_span(name="Storage.Client.getBucket")
     def get_bucket(
         self,
         bucket_or_name,
@@ -877,7 +877,7 @@ class Client(ClientWithProject):
         )
         return bucket
 
-    @create_span(name="Storage.Client.lookupBucket")
+    @create_trace_span(name="Storage.Client.lookupBucket")
     def lookup_bucket(
         self,
         bucket_name,
@@ -925,7 +925,7 @@ class Client(ClientWithProject):
         except NotFound:
             return None
 
-    @create_span(name="Storage.Client.createBucket")
+    @create_trace_span(name="Storage.Client.createBucket")
     def create_bucket(
         self,
         bucket_or_name,
@@ -1183,7 +1183,7 @@ class Client(ClientWithProject):
             retry=retry,
         )
 
-    @create_span(name="Storage.Client.listBlobs")
+    @create_trace_span(name="Storage.Client.listBlobs")
     def list_blobs(
         self,
         bucket_or_name,
@@ -1373,7 +1373,7 @@ class Client(ClientWithProject):
         iterator.prefixes = set()
         return iterator
 
-    @create_span(name="Storage.Client.listBuckets")
+    @create_trace_span(name="Storage.Client.listBuckets")
     def list_buckets(
         self,
         max_results=None,
@@ -1479,7 +1479,7 @@ class Client(ClientWithProject):
             retry=retry,
         )
 
-    @create_span(name="Storage.Client.createHmacKey")
+    @create_trace_span(name="Storage.Client.createHmacKey")
     def create_hmac_key(
         self,
         service_account_email,
@@ -1544,7 +1544,7 @@ class Client(ClientWithProject):
         secret = api_response["secret"]
         return metadata, secret
 
-    @create_span(name="Storage.Client.listHmacKeys")
+    @create_trace_span(name="Storage.Client.listHmacKeys")
     def list_hmac_keys(
         self,
         max_results=None,
@@ -1614,7 +1614,7 @@ class Client(ClientWithProject):
             retry=retry,
         )
 
-    @create_span(name="Storage.Client.getHmacKeyMetadata")
+    @create_trace_span(name="Storage.Client.getHmacKeyMetadata")
     def get_hmac_key_metadata(
         self, access_id, project_id=None, user_project=None, timeout=_DEFAULT_TIMEOUT
     ):

--- a/google/cloud/storage/hmac_key.py
+++ b/google/cloud/storage/hmac_key.py
@@ -20,7 +20,7 @@ See [HMAC keys documentation](https://cloud.google.com/storage/docs/authenticati
 from google.cloud.exceptions import NotFound
 from google.cloud._helpers import _rfc3339_nanos_to_datetime
 
-from google.cloud.storage._opentelemetry_tracing import create_span
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_ETAG_IN_JSON
@@ -188,7 +188,7 @@ class HMACKeyMetadata(object):
         """
         return self._user_project
 
-    @create_span(name="Storage.HmacKey.exists")
+    @create_trace_span(name="Storage.HmacKey.exists")
     def exists(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Determine whether or not the key for this metadata exists.
 
@@ -221,7 +221,7 @@ class HMACKeyMetadata(object):
         else:
             return True
 
-    @create_span(name="Storage.HmacKey.reload")
+    @create_trace_span(name="Storage.HmacKey.reload")
     def reload(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Reload properties from Cloud Storage.
 
@@ -249,7 +249,7 @@ class HMACKeyMetadata(object):
             retry=retry,
         )
 
-    @create_span(name="Storage.HmacKey.update")
+    @create_trace_span(name="Storage.HmacKey.update")
     def update(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY_IF_ETAG_IN_JSON):
         """Save writable properties to Cloud Storage.
 
@@ -278,7 +278,7 @@ class HMACKeyMetadata(object):
             retry=retry,
         )
 
-    @create_span(name="Storage.HmacKey.delete")
+    @create_trace_span(name="Storage.HmacKey.delete")
     def delete(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Delete the key from Cloud Storage.
 

--- a/google/cloud/storage/hmac_key.py
+++ b/google/cloud/storage/hmac_key.py
@@ -20,6 +20,7 @@ See [HMAC keys documentation](https://cloud.google.com/storage/docs/authenticati
 from google.cloud.exceptions import NotFound
 from google.cloud._helpers import _rfc3339_nanos_to_datetime
 
+from google.cloud.storage._opentelemetry_tracing import create_span
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud.storage.retry import DEFAULT_RETRY_IF_ETAG_IN_JSON
@@ -187,6 +188,7 @@ class HMACKeyMetadata(object):
         """
         return self._user_project
 
+    @create_span(name="Storage.HmacKey.exists")
     def exists(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Determine whether or not the key for this metadata exists.
 
@@ -219,6 +221,7 @@ class HMACKeyMetadata(object):
         else:
             return True
 
+    @create_span(name="Storage.HmacKey.reload")
     def reload(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Reload properties from Cloud Storage.
 
@@ -246,6 +249,7 @@ class HMACKeyMetadata(object):
             retry=retry,
         )
 
+    @create_span(name="Storage.HmacKey.update")
     def update(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY_IF_ETAG_IN_JSON):
         """Save writable properties to Cloud Storage.
 
@@ -274,6 +278,7 @@ class HMACKeyMetadata(object):
             retry=retry,
         )
 
+    @create_span(name="Storage.HmacKey.delete")
     def delete(self, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Delete the key from Cloud Storage.
 

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -21,7 +21,7 @@ import re
 
 from google.api_core.exceptions import NotFound
 
-from google.cloud.storage._opentelemetry_tracing import create_span
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
 
@@ -231,7 +231,7 @@ class BucketNotification(object):
         self._properties.clear()
         self._properties.update(response)
 
-    @create_span(name="Storage.BucketNotification.create")
+    @create_trace_span(name="Storage.BucketNotification.create")
     def create(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=None):
         """API wrapper: create the notification.
 
@@ -284,7 +284,7 @@ class BucketNotification(object):
             retry=retry,
         )
 
-    @create_span(name="Storage.BucketNotification.exists")
+    @create_trace_span(name="Storage.BucketNotification.exists")
     def exists(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Test whether this notification exists.
 
@@ -332,7 +332,7 @@ class BucketNotification(object):
         else:
             return True
 
-    @create_span(name="Storage.BucketNotification.reload")
+    @create_trace_span(name="Storage.BucketNotification.reload")
     def reload(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Update this notification from the server configuration.
 
@@ -375,7 +375,7 @@ class BucketNotification(object):
         )
         self._set_properties(response)
 
-    @create_span(name="Storage.BucketNotification.delete")
+    @create_trace_span(name="Storage.BucketNotification.delete")
     def delete(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Delete this notification.
 

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -21,6 +21,7 @@ import re
 
 from google.api_core.exceptions import NotFound
 
+from google.cloud.storage._opentelemetry_tracing import create_span
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import DEFAULT_RETRY
 
@@ -230,6 +231,7 @@ class BucketNotification(object):
         self._properties.clear()
         self._properties.update(response)
 
+    @create_span(name="Storage.BucketNotification.create")
     def create(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=None):
         """API wrapper: create the notification.
 
@@ -282,6 +284,7 @@ class BucketNotification(object):
             retry=retry,
         )
 
+    @create_span(name="Storage.BucketNotification.exists")
     def exists(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Test whether this notification exists.
 
@@ -329,6 +332,7 @@ class BucketNotification(object):
         else:
             return True
 
+    @create_span(name="Storage.BucketNotification.reload")
     def reload(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Update this notification from the server configuration.
 
@@ -371,6 +375,7 @@ class BucketNotification(object):
         )
         self._set_properties(response)
 
+    @create_span(name="Storage.BucketNotification.delete")
     def delete(self, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY):
         """Delete this notification.
 

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -62,7 +62,7 @@ def test_opentelemetry_not_installed(setup, monkeypatch):
     monkeypatch.setitem(sys.modules, "opentelemetry", None)
     importlib.reload(_opentelemetry_tracing)
     # Test no-ops when OpenTelemetry is not installed.
-    with _opentelemetry_tracing.create_span("No-ops w/o opentelemetry") as span:
+    with _opentelemetry_tracing.create_trace_span("No-ops w/o opentelemetry") as span:
         assert span is None
     assert not _opentelemetry_tracing.HAS_OPENTELEMETRY
 
@@ -72,14 +72,14 @@ def test_opentelemetry_no_trace_optin(setup):
     assert not _opentelemetry_tracing.enable_otel_traces
     # Test no-ops when user has not opt-in.
     # This prevents customers accidentally being billed for tracing.
-    with _opentelemetry_tracing.create_span("No-ops w/o opt-in") as span:
+    with _opentelemetry_tracing.create_trace_span("No-ops w/o opt-in") as span:
         assert span is None
 
 
 def test_enable_trace_yield_span(setup, setup_optin):
     assert _opentelemetry_tracing.HAS_OPENTELEMETRY
     assert _opentelemetry_tracing.enable_otel_traces
-    with _opentelemetry_tracing.create_span("No-ops for opentelemetry") as span:
+    with _opentelemetry_tracing.create_trace_span("No-ops for opentelemetry") as span:
         assert span is not None
 
 
@@ -96,7 +96,7 @@ def test_enable_trace_call(setup, setup_optin):
     }
     expected_attributes.update(extra_attributes)
 
-    with _opentelemetry_tracing.create_span(
+    with _opentelemetry_tracing.create_trace_span(
         "OtelTracing.Test", attributes=extra_attributes
     ) as span:
         span.set_attribute("after_setup_attribute", 1)
@@ -122,7 +122,7 @@ def test_enable_trace_error(setup, setup_optin):
     expected_attributes.update(extra_attributes)
 
     with pytest.raises(GoogleAPICallError):
-        with _opentelemetry_tracing.create_span(
+        with _opentelemetry_tracing.create_trace_span(
             "OtelTracing.Test", attributes=extra_attributes
         ) as span:
             from google.cloud.exceptions import NotFound
@@ -161,7 +161,7 @@ def test_get_final_attributes(setup, setup_optin):
     with mock.patch("google.cloud.storage.client.Client") as test_client:
         test_client.project = "test_project"
         test_client._connection.API_BASE_URL = "https://testOtel.org"
-        with _opentelemetry_tracing.create_span(
+        with _opentelemetry_tracing.create_trace_span(
             test_span_name,
             attributes=test_span_attributes,
             client=test_client,
@@ -192,7 +192,7 @@ def test_set_conditional_retry_attr(setup, setup_optin):
         "retry": f"multiplier{retry_policy._multiplier}/deadline{retry_policy._deadline}/max{retry_policy._maximum}/initial{retry_policy._initial}/predicate{conditional_predicate}",
     }
 
-    with _opentelemetry_tracing.create_span(
+    with _opentelemetry_tracing.create_trace_span(
         test_span_name,
         retry=retry_obj,
     ) as span:


### PR DESCRIPTION
part 2 
- instrument metadata operations, as scoped, with OTel tracing decorator
- rename decorator to `create_trace_span` per review session
- add OTel tracing section with instructions in README

Fixes internal b/330755934
