### PR TITLE
fix: remove deprecated methods in samples and tests

### DIFF
--- a/docs/snippets.py
+++ b/docs/snippets.py
@@ -39,7 +39,7 @@ def storage_get_started(to_delete):
     bucket = client.get_bucket("bucket-id-here")
     # Then do other things...
     blob = bucket.get_blob("/remote/path/to/file.txt")
-    assert blob.download_as_string() == b"My old contents!"
+    assert blob.download_as_bytes() == b"My old contents!"
     blob.upload_from_string("New contents!")
     blob2 = bucket.blob("/remote/path/storage.txt")
     blob2.upload_from_filename(filename="/local/path.txt")

--- a/samples/snippets/encryption_test.py
+++ b/samples/snippets/encryption_test.py
@@ -125,4 +125,4 @@ def test_object_csek_to_cmek(test_blob):
         BUCKET, test_blob_name, TEST_ENCRYPTION_KEY_2, KMS_KEY
     )
 
-    assert cmek_blob.download_as_string(), test_blob_content
+    assert cmek_blob.download_as_bytes(), test_blob_content

--- a/samples/snippets/rpo_test.py
+++ b/samples/snippets/rpo_test.py
@@ -26,12 +26,13 @@ import storage_set_rpo_default
 @pytest.fixture
 def dual_region_bucket():
     """Yields a dual region bucket that is deleted after the test completes."""
+    storage_client = storage.Client()
     bucket = None
+    location = "NAM4"
     while bucket is None or bucket.exists():
         bucket_name = f"bucket-lock-{uuid.uuid4()}"
-        bucket = storage.Client().bucket(bucket_name)
-        bucket.location = "NAM4"
-    bucket.create()
+        bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket, location=location)
     yield bucket
     bucket.delete(force=True)
 

--- a/samples/snippets/rpo_test.py
+++ b/samples/snippets/rpo_test.py
@@ -26,13 +26,12 @@ import storage_set_rpo_default
 @pytest.fixture
 def dual_region_bucket():
     """Yields a dual region bucket that is deleted after the test completes."""
-    storage_client = storage.Client()
     bucket = None
     location = "NAM4"
     while bucket is None or bucket.exists():
         bucket_name = f"bucket-lock-{uuid.uuid4()}"
-        bucket = storage_client.bucket(bucket_name)
-    storage_client.create_bucket(bucket, location=location)
+        bucket = storage.Client().bucket(bucket_name)
+    bucket.create(location=location)
     yield bucket
     bucket.delete(force=True)
 

--- a/samples/snippets/storage_create_bucket_turbo_replication.py
+++ b/samples/snippets/storage_create_bucket_turbo_replication.py
@@ -37,7 +37,7 @@ def create_bucket_turbo_replication(bucket_name):
     bucket = storage_client.bucket(bucket_name)
     bucket_location = "NAM4"
     bucket.rpo = RPO_ASYNC_TURBO
-    storage_client.create_bucket(bucket, location=bucket_location)
+    bucket.create(location=bucket_location)
 
     print(f"{bucket.name} created with the recovery point objective (RPO) set to {bucket.rpo} in {bucket.location}.")
 

--- a/samples/snippets/storage_create_bucket_turbo_replication.py
+++ b/samples/snippets/storage_create_bucket_turbo_replication.py
@@ -35,9 +35,9 @@ def create_bucket_turbo_replication(bucket_name):
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
-    bucket.location = "NAM4"
+    bucket_location = "NAM4"
     bucket.rpo = RPO_ASYNC_TURBO
-    bucket.create()
+    storage_client.create_bucket(bucket, location=bucket_location)
 
     print(f"{bucket.name} created with the recovery point objective (RPO) set to {bucket.rpo} in {bucket.location}.")
 

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -761,7 +761,7 @@ def test_blob_upload_download_crc32_md5_hash(
 
     download_blob = shared_bucket.blob("MyBuffer")
 
-    assert download_blob.download_as_string() == payload
+    assert download_blob.download_as_bytes() == payload
     assert download_blob.crc32c == blob.crc32c
     assert download_blob.md5_hash == blob.md5_hash
 

--- a/tests/system/test_bucket.py
+++ b/tests/system/test_bucket.py
@@ -410,9 +410,9 @@ def test_bucket_copy_blob_w_metageneration_match(
 ):
     payload = b"DEADBEEF"
     bucket_name = _helpers.unique_name("generation-match")
-    created = _helpers.retry_429_503(storage_client.create_bucket)(
-        bucket_name, requester_pays=True
-    )
+    bucket = storage_client.bucket(bucket_name)
+    bucket.requester_pays = True
+    created = _helpers.retry_429_503(storage_client.create_bucket)(bucket)
     buckets_to_delete.append(created)
     assert created.name == bucket_name
 


### PR DESCRIPTION
Fixes #1195 🦕
