### PR TITLE
fix: Changed name of methods `Blob.from_string()` and `Bucket.from_string()` to `from_uri()`

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -135,6 +135,10 @@ _DOWNLOAD_AS_STRING_DEPRECATED = (
     "Blob.download_as_string() is deprecated and will be removed in future. "
     "Use Blob.download_as_bytes() instead."
 )
+_FROM_STRING_DEPRECATED = (
+    "Blob.from_string() is deprecated and will be removed in future. "
+    "Use Blob.from_uri() instead."
+)
 _GS_URL_REGEX_PATTERN = re.compile(
     r"(?P<scheme>gs)://(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"
 )
@@ -387,7 +391,7 @@ class Blob(_PropertyMixin):
         )
 
     @classmethod
-    def from_string(cls, uri, client=None):
+    def from_uri(cls, uri, client=None):
         """Get a constructor for blob object by URI.
 
         .. code-block:: python
@@ -395,7 +399,7 @@ class Blob(_PropertyMixin):
             from google.cloud import storage
             from google.cloud.storage.blob import Blob
             client = storage.Client()
-            blob = Blob.from_string("gs://bucket/object", client=client)
+            blob = Blob.from_uri("gs://bucket/object", client=client)
 
         :type uri: str
         :param uri: The blob uri following a gs://bucket/object pattern.
@@ -416,6 +420,35 @@ class Blob(_PropertyMixin):
             raise ValueError("URI pattern must be gs://bucket/object")
         bucket = Bucket(client, name=match.group("bucket_name"))
         return cls(match.group("object_name"), bucket)
+
+    @classmethod
+    def from_string(cls, uri, client=None):
+        """(Deprecated) Get a constructor for blob object by URI.
+
+        .. note::
+           Deprecated alias for :meth:`from_uri`.
+
+        .. code-block:: python
+
+            from google.cloud import storage
+            from google.cloud.storage.blob import Blob
+            client = storage.Client()
+            blob = Blob.from_string("gs://bucket/object", client=client)
+
+        :type uri: str
+        :param uri: The blob uri following a gs://bucket/object pattern.
+          Both a bucket and object name is required to construct a blob object.
+
+        :type client: :class:`~google.cloud.storage.client.Client`
+        :param client:
+            (Optional) The client to use.  Application code should
+            *always* pass ``client``.
+
+        :rtype: :class:`google.cloud.storage.blob.Blob`
+        :returns: The blob object created.
+        """
+        warnings.warn(_FROM_STRING_DEPRECATED, PendingDeprecationWarning, stacklevel=2)
+        return Blob.from_uri(uri=uri, client=client)
 
     def generate_signed_url(
         self,

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -84,6 +84,9 @@ _LOCATION_SETTER_MESSAGE = (
     "valid before the bucket is created. Instead, pass the location "
     "to `Bucket.create`."
 )
+_FROM_STRING_MESSAGE = (
+    "Bucket.from_string() is deprecated. " "Use Bucket.from_uri() instead."
+)
 
 
 def _blobs_page_start(iterator, page, response):
@@ -726,8 +729,40 @@ class Bucket(_PropertyMixin):
         return self._user_project
 
     @classmethod
+    def from_uri(cls, uri, client=None):
+        """Get a constructor for bucket object by URI.
+
+        .. code-block:: python
+
+            from google.cloud import storage
+            from google.cloud.storage.bucket import Bucket
+            client = storage.Client()
+            bucket = Bucket.from_uri("gs://bucket", client=client)
+
+        :type uri: str
+        :param uri: The bucket uri pass to get bucket object.
+
+        :type client: :class:`~google.cloud.storage.client.Client` or
+                      ``NoneType``
+        :param client: (Optional) The client to use.  Application code should
+            *always* pass ``client``.
+
+        :rtype: :class:`google.cloud.storage.bucket.Bucket`
+        :returns: The bucket object created.
+        """
+        scheme, netloc, path, query, frag = urlsplit(uri)
+
+        if scheme != "gs":
+            raise ValueError("URI scheme must be gs")
+
+        return cls(client, name=netloc)
+
+    @classmethod
     def from_string(cls, uri, client=None):
         """Get a constructor for bucket object by URI.
+
+        .. note::
+           Deprecated alias for :meth:`from_uri`.
 
         .. code-block:: python
 
@@ -747,12 +782,8 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The bucket object created.
         """
-        scheme, netloc, path, query, frag = urlsplit(uri)
-
-        if scheme != "gs":
-            raise ValueError("URI scheme must be gs")
-
-        return cls(client, name=netloc)
+        warnings.warn(_FROM_STRING_MESSAGE, PendingDeprecationWarning, stacklevel=2)
+        return Bucket.from_uri(uri=uri, client=client)
 
     def blob(
         self,

--- a/google/cloud/storage/client.py
+++ b/google/cloud/storage/client.py
@@ -1148,7 +1148,7 @@ class Client(ClientWithProject):
         """
 
         if not isinstance(blob_or_uri, Blob):
-            blob_or_uri = Blob.from_string(blob_or_uri)
+            blob_or_uri = Blob.from_uri(blob_or_uri)
 
         blob_or_uri._prep_and_do_download(
             file_obj,

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -5876,7 +5876,49 @@ class Test_Blob(unittest.TestCase):
         self.assertIsNone(blob.soft_delete_time)
         self.assertIsNone(blob.hard_delete_time)
 
-    def test_from_string_w_valid_uri(self):
+    def test_from_uri_w_valid_uri(self):
+        from google.cloud.storage.blob import Blob
+
+        client = self._make_client()
+        basic_uri = "gs://bucket_name/b"
+        blob = Blob.from_uri(basic_uri, client)
+
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.client, client)
+        self.assertEqual(blob.name, "b")
+        self.assertEqual(blob.bucket.name, "bucket_name")
+
+        nested_uri = "gs://bucket_name/path1/path2/b#name"
+        blob = Blob.from_uri(nested_uri, client)
+
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.client, client)
+        self.assertEqual(blob.name, "path1/path2/b#name")
+        self.assertEqual(blob.bucket.name, "bucket_name")
+
+    def test_from_uri_w_invalid_uri(self):
+        from google.cloud.storage.blob import Blob
+
+        client = self._make_client()
+
+        with pytest.raises(ValueError):
+            Blob.from_uri("http://bucket_name/b", client)
+
+    def test_from_uri_w_domain_name_bucket(self):
+        from google.cloud.storage.blob import Blob
+
+        client = self._make_client()
+        uri = "gs://buckets.example.com/b"
+        blob = Blob.from_uri(uri, client)
+
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.client, client)
+        self.assertEqual(blob.name, "b")
+        self.assertEqual(blob.bucket.name, "buckets.example.com")
+
+    @mock.patch("warnings.warn")
+    def test_from_string(self, mock_warn):
+        from google.cloud.storage.blob import _FROM_STRING_DEPRECATED
         from google.cloud.storage.blob import Blob
 
         client = self._make_client()
@@ -5896,25 +5938,11 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.name, "path1/path2/b#name")
         self.assertEqual(blob.bucket.name, "bucket_name")
 
-    def test_from_string_w_invalid_uri(self):
-        from google.cloud.storage.blob import Blob
-
-        client = self._make_client()
-
-        with pytest.raises(ValueError):
-            Blob.from_string("http://bucket_name/b", client)
-
-    def test_from_string_w_domain_name_bucket(self):
-        from google.cloud.storage.blob import Blob
-
-        client = self._make_client()
-        uri = "gs://buckets.example.com/b"
-        blob = Blob.from_string(uri, client)
-
-        self.assertIsInstance(blob, Blob)
-        self.assertIs(blob.client, client)
-        self.assertEqual(blob.name, "b")
-        self.assertEqual(blob.bucket.name, "buckets.example.com")
+        mock_warn.assert_any_call(
+            _FROM_STRING_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
 
     def test_open(self):
         from io import TextIOWrapper

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -4325,7 +4325,43 @@ class Test_Bucket(unittest.TestCase):
         }
         signer.assert_called_once_with(expected_creds, **expected_kwargs)
 
-    def test_get_bucket_from_string_w_valid_uri(self):
+    def test_get_bucket_from_uri_w_valid_uri(self):
+        from google.cloud.storage.bucket import Bucket
+
+        client = self._make_client()
+        BUCKET_NAME = "BUCKET_NAME"
+        uri = "gs://" + BUCKET_NAME
+
+        bucket = Bucket.from_uri(uri, client)
+
+        self.assertIsInstance(bucket, Bucket)
+        self.assertIs(bucket.client, client)
+        self.assertEqual(bucket.name, BUCKET_NAME)
+
+    def test_get_bucket_from_uri_w_invalid_uri(self):
+        from google.cloud.storage.bucket import Bucket
+
+        client = self._make_client()
+
+        with pytest.raises(ValueError, match="URI scheme must be gs"):
+            Bucket.from_uri("http://bucket_name", client)
+
+    def test_get_bucket_from_uri_w_domain_name_bucket(self):
+        from google.cloud.storage.bucket import Bucket
+
+        client = self._make_client()
+        BUCKET_NAME = "buckets.example.com"
+        uri = "gs://" + BUCKET_NAME
+
+        bucket = Bucket.from_uri(uri, client)
+
+        self.assertIsInstance(bucket, Bucket)
+        self.assertIs(bucket.client, client)
+        self.assertEqual(bucket.name, BUCKET_NAME)
+
+    @mock.patch("warnings.warn")
+    def test_get_bucket_from_string(self, mock_warn):
+        from google.cloud.storage.bucket import _FROM_STRING_MESSAGE
         from google.cloud.storage.bucket import Bucket
 
         client = self._make_client()
@@ -4337,27 +4373,11 @@ class Test_Bucket(unittest.TestCase):
         self.assertIsInstance(bucket, Bucket)
         self.assertIs(bucket.client, client)
         self.assertEqual(bucket.name, BUCKET_NAME)
-
-    def test_get_bucket_from_string_w_invalid_uri(self):
-        from google.cloud.storage.bucket import Bucket
-
-        client = self._make_client()
-
-        with pytest.raises(ValueError, match="URI scheme must be gs"):
-            Bucket.from_string("http://bucket_name", client)
-
-    def test_get_bucket_from_string_w_domain_name_bucket(self):
-        from google.cloud.storage.bucket import Bucket
-
-        client = self._make_client()
-        BUCKET_NAME = "buckets.example.com"
-        uri = "gs://" + BUCKET_NAME
-
-        bucket = Bucket.from_string(uri, client)
-
-        self.assertIsInstance(bucket, Bucket)
-        self.assertIs(bucket.client, client)
-        self.assertEqual(bucket.name, BUCKET_NAME)
+        mock_warn.assert_any_call(
+            _FROM_STRING_MESSAGE,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
 
     def test_generate_signed_url_no_version_passed_warning(self):
         self._generate_signed_url_helper()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1784,7 +1784,7 @@ class TestClient(unittest.TestCase):
             _helpers, "_get_invocation_id", return_value=GCCL_INVOCATION_TEST_CONST
         ):
             with mock.patch(
-                "google.cloud.storage.client.Blob.from_string", return_value=blob
+                "google.cloud.storage.client.Blob.from_uri", return_value=blob
             ):
                 client.download_blob_to_file(
                     "gs://bucket_name/path/to/object", file_obj


### PR DESCRIPTION
- Other methods use "string" to refer to the actual content of the Blob, not the uri. The updated method name is more intuitive for developers.
- Marked `from_string()` as deprecated and mapped functionality to `from_uri()`.

Original reasoning for `from_string()` naming in [#7693](https://github.com/googleapis/google-cloud-python/issues/7693)