### PR TITLE
feat: Add support for `https://storage.googleapis.com/` URLs in `Blob.from_string()`

### DIFF
--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -137,7 +137,7 @@ _DOWNLOAD_AS_STRING_DEPRECATED = (
     "Use Blob.download_as_bytes() instead."
 )
 _GS_URL_REGEX_PATTERN = re.compile(
-    r"(?P<scheme>gs)://(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"
+    r"(?P<scheme>gs|https)://(?:storage\.(?:mtls\.)?googleapis\.com/)?(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"
 )
 
 _DEFAULT_CHUNKSIZE = 104857600  # 1024 * 1024 B * 100 = 100 MB
@@ -399,7 +399,7 @@ class Blob(_PropertyMixin):
             blob = Blob.from_string("gs://bucket/object", client=client)
 
         :type uri: str
-        :param uri: The blob uri following a gs://bucket/object pattern.
+        :param uri: The blob uri following a gs://bucket/object or https://storage.googleapis.com/bucket/object pattern.
           Both a bucket and object name is required to construct a blob object.
 
         :type client: :class:`~google.cloud.storage.client.Client`
@@ -414,7 +414,9 @@ class Blob(_PropertyMixin):
 
         match = _GS_URL_REGEX_PATTERN.match(uri)
         if not match:
-            raise ValueError("URI pattern must be gs://bucket/object")
+            raise ValueError(
+                "URI pattern must be gs://bucket/object or https://storage.googleapis.com/bucket/object"
+            )
         bucket = Bucket(client, name=match.group("bucket_name"))
         return cls(match.group("object_name"), bucket)
 

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -419,7 +419,9 @@ class Blob(_PropertyMixin):
                 endpoint = client.api_endpoint
             else:
                 endpoint = _get_default_storage_base_url()
-            endpoint = endpoint.removeprefix("https://")
+
+            if endpoint.startswith("https://"):
+                endpoint = endpoint[len("https://"):]
 
             storage_url_regex_pattern = re.compile(
                 rf"(?P<scheme>https)://{re.escape(endpoint)}/(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -413,6 +413,13 @@ class Blob(_PropertyMixin):
         from google.cloud.storage.bucket import Bucket
 
         match = _GS_URL_REGEX_PATTERN.match(uri)
+
+        if client is not None:
+            custom_url_regex_pattern = re.compile(
+                rf"(?:{client.api_endpoint})?(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"
+            )
+            match = match or custom_url_regex_pattern.match(uri)
+
         if not match:
             raise ValueError(
                 "URI pattern must be gs://bucket/object or https://storage.googleapis.com/bucket/object"

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -421,7 +421,7 @@ class Blob(_PropertyMixin):
                 endpoint = _get_default_storage_base_url()
 
             if endpoint.startswith("https://"):
-                endpoint = endpoint[len("https://"):]
+                endpoint = endpoint[len("https://") :]
 
             storage_url_regex_pattern = re.compile(
                 rf"(?P<scheme>https)://{re.escape(endpoint)}/(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -5951,6 +5951,19 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.name, "b")
         self.assertEqual(blob.bucket.name, "bucket_name")
 
+    def test_from_string_w_custom_api_endpoint(self):
+        from google.cloud.storage.blob import Blob
+
+        client = self._make_client(api_endpoint="storage-example.p.googleapis.com")
+
+        authenticated_url = "https://storage-example.p.googleapis.com/bucket_name/b"
+        blob = Blob.from_string(authenticated_url, client)
+
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.client, client)
+        self.assertEqual(blob.name, "b")
+        self.assertEqual(blob.bucket.name, "bucket_name")
+
     def test_open(self):
         from io import TextIOWrapper
         from google.cloud.storage.fileio import BlobReader

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -5916,6 +5916,41 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.name, "b")
         self.assertEqual(blob.bucket.name, "buckets.example.com")
 
+    def test_from_string_w_public_url(self):
+        from google.cloud.storage.blob import Blob
+
+        client = self._make_client()
+        public_url = "https://storage.googleapis.com/bucket_name/b"
+        blob = Blob.from_string(public_url, client)
+
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.client, client)
+        self.assertEqual(blob.name, "b")
+        self.assertEqual(blob.bucket.name, "bucket_name")
+
+        nested_public_url = (
+            "https://storage.googleapis.com/bucket_name/path1/path2/b#name"
+        )
+        blob = Blob.from_string(nested_public_url, client)
+
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.client, client)
+        self.assertEqual(blob.name, "path1/path2/b#name")
+        self.assertEqual(blob.bucket.name, "bucket_name")
+
+    def test_from_string_w_authenticated_url(self):
+        from google.cloud.storage.blob import Blob
+
+        client = self._make_client()
+
+        authenticated_url = "https://storage.mtls.googleapis.com/bucket_name/b"
+        blob = Blob.from_string(authenticated_url, client)
+
+        self.assertIsInstance(blob, Blob)
+        self.assertIs(blob.client, client)
+        self.assertEqual(blob.name, "b")
+        self.assertEqual(blob.bucket.name, "bucket_name")
+
     def test_open(self):
         from io import TextIOWrapper
         from google.cloud.storage.fileio import BlobReader

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -5941,7 +5941,7 @@ class Test_Blob(unittest.TestCase):
     def test_from_string_w_authenticated_url(self):
         from google.cloud.storage.blob import Blob
 
-        client = self._make_client()
+        client = self._make_client(api_endpoint="storage.mtls.googleapis.com")
 
         authenticated_url = "https://storage.mtls.googleapis.com/bucket_name/b"
         blob = Blob.from_string(authenticated_url, client)


### PR DESCRIPTION
Allow creating `Blob`s from `https://storage.googleapis.com` URLs.

Example:

```py
Blob.from_string("https://storage.googleapis.com/bucket/object")
```

Fixes #1299