### PR TITLE
tests: unflake ud system test to only run in prod and hmac sample test

### DIFF
--- a/samples/snippets/hmac_samples_test.py
+++ b/samples/snippets/hmac_samples_test.py
@@ -64,7 +64,10 @@ def new_hmac_key():
     if not hmac_key.state == "INACTIVE":
         hmac_key.state = "INACTIVE"
         hmac_key.update()
-    hmac_key.delete()
+    try:
+        hmac_key.delete()
+    except google.api_core.exceptions.BadRequest:
+        pass
 
 
 def test_list_keys(capsys, new_hmac_key):

--- a/tests/system/test_client.py
+++ b/tests/system/test_client.py
@@ -186,6 +186,10 @@ def test_download_blob_to_file_w_etag(
     assert buffer.getvalue() == payload
 
 
+@pytest.mark.skipif(
+    _helpers.is_api_endpoint_override,
+    reason="Credentials not yet supported in preprod testing.",
+)
 def test_client_universe_domain(
     universe_domain_client,
     test_universe_location,


### PR DESCRIPTION
- Universe domain tests will run in kokoro presubmit and continuous builds only in prod. Secrets are not shared in preprod cbuild, so skipping test in preprod cbuild. Confirmed that tests pass in prod [presubmit](https://fusion2.corp.google.com/invocations/68f7dca9-6444-4965-8e5c-4ce1f092a811/targets) and [continous](https://fusion2.corp.google.com/invocations/a772eb75-b6e0-4400-8e65-2e52292b9442/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-storage%2Fcontinuous%2Fcontinuous;config=default/log)

- Unflake hmac sample test - handle cleanup where keys are already deleted

Fixes #1349 🦕
