### PR TITLE
Feat: download_to_filename deletes the empty file on a 404

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,8 @@ Miscellaneous
 - Retry behavior is now identical between media operations (uploads and
   downloads) and other operations, and custom predicates are now supported for
   media operations as well.
+- Blob.download_as_filename() will now delete the empty file if it results in a
+  google.cloud.exceptions.NotFound exception (HTTP 404).
 
 Quick Start
 -----------

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -1252,8 +1252,8 @@ class Blob(_PropertyMixin):
                     **kwargs,
                 )
 
-        except DataCorruption:
-            # Delete the corrupt downloaded file.
+        except (DataCorruption, NotFound):
+            # Delete the corrupt or empty downloaded file.
             os.remove(filename)
             raise
 


### PR DESCRIPTION
Fixes #1342 🦕

BEGIN_COMMIT_OVERRIDE
feat!: Blob.download_to_filename() deletes the empty destination file on a 404
END_COMMIT_OVERRIDE