### PR TITLE
fix: Segmentation fault in tink while writing data

### DIFF
--- a/google/cloud/storage/_media/requests/download.py
+++ b/google/cloud/storage/_media/requests/download.py
@@ -387,7 +387,6 @@ class RawDownload(_request_helpers.RawRequestsMixin, _download.Download):
                     msg += content_length_msg
                     raise DataCorruption(response, msg)
 
-
     def consume(
         self,
         transport,

--- a/google/cloud/storage/fileio.py
+++ b/google/cloud/storage/fileio.py
@@ -477,7 +477,7 @@ class SlidingBuffer(object):
         self._buffer.seek(0, io.SEEK_END)
         pos = self._buffer.write(b)
         self._buffer.seek(bookmark)
-        return self._cursor + pos
+        return pos
 
     def read(self, size=-1):
         """Read and move the cursor."""

--- a/tests/unit/test_fileio.py
+++ b/tests/unit/test_fileio.py
@@ -367,12 +367,14 @@ class TestBlobWriterBinary(unittest.TestCase, _BlobWriterBase):
 
         # Write under chunk_size. This should be buffered and the upload not
         # initiated.
-        writer.write(TEST_BINARY_DATA[0:4])
+        w1 = writer.write(TEST_BINARY_DATA[0:4])
+        self.assertEqual(w1, 4)
         blob._initiate_resumable_upload.assert_not_called()
 
         # Write over chunk_size. This should result in upload initialization
         # and multiple chunks uploaded.
-        writer.write(TEST_BINARY_DATA[4:32])
+        w2 = writer.write(TEST_BINARY_DATA[4:32])
+        self.assertEqual(w2, 28)
         blob._initiate_resumable_upload.assert_called_once_with(
             blob.bucket.client,
             writer._buffer,


### PR DESCRIPTION
Tink doesn't properly validate the value returned by the python output stream's write method. Usually, this value should be smaller than the size of the data. But the write method returns the complete size of the object instead of the size of bytes of the chunk written.