### PR TITLE
chore: add owlbot for gapic generation

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -19,7 +19,7 @@ deep-remove-regex:
   - /owl-bot-staging
 
 deep-copy-regex:
-  - source: /google/storage/v2/.*-py/(.*)
+  - source: /google/storage/v2/storage-v2-py/(.*)
     dest: /owl-bot-staging/$1/$2
 
 begin-after-commit-hash: 6acf4a0a797f1082027985c55c4b14b60f673dd7

--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -18,12 +18,8 @@ docker:
 deep-remove-regex:
   - /owl-bot-staging
 
-# exclude google/storage/v1
-deep-preserve-regex:
-  - /owl-bot-staging/v1
-
 deep-copy-regex:
-  - source: /google/storage/(v.*)/.*-py/(.*)
+  - source: /google/storage/v2/.*-py/(.*)
     dest: /owl-bot-staging/$1/$2
 
 begin-after-commit-hash: 6acf4a0a797f1082027985c55c4b14b60f673dd7

--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -15,5 +15,16 @@
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-python:latest
 
+deep-remove-regex:
+  - /owl-bot-staging
+
+# exclude google/storage/v1
+deep-preserve-regex:
+  - /owl-bot-staging/v1
+
+deep-copy-regex:
+  - source: /google/storage/(v.*)/.*-py/(.*)
+    dest: /owl-bot-staging/$1/$2
+
 begin-after-commit-hash: 6acf4a0a797f1082027985c55c4b14b60f673dd7
 

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,7 +11,7 @@
     "distribution_name": "google-cloud-storage",
     "api_id": "storage.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
+    "default_version": "v2",
     "codeowner_team": "@googleapis/gcs-sdk-team",
     "api_shortname": "storage",
     "api_description": "is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally."


### PR DESCRIPTION
Add the configuration in owlbot.yaml to output the generation of gapic client in python-storage repository.