### PR TITLE
chore: update the source path in owlbot.yaml

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -18,9 +18,12 @@ docker:
 deep-remove-regex:
   - /owl-bot-staging
 
+# In source, we've  used two capturing groups (v2) and (.*) to match the version
+# and the directory path.
+# In dest, we use $1 to refer to the first capturing group (v2) and $2 to refer
+# to the second capturing group (directory path).
 deep-copy-regex:
   - source: /google/storage/(v2)/storage-v2-py/(.*)
     dest: /owl-bot-staging/$1/$2
 
 begin-after-commit-hash: 6acf4a0a797f1082027985c55c4b14b60f673dd7
-

--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -19,7 +19,7 @@ deep-remove-regex:
   - /owl-bot-staging
 
 deep-copy-regex:
-  - source: /google/storage/v2/storage-v2-py/(.*)
+  - source: /google/storage/(v2)/storage-v2-py/(.*)
     dest: /owl-bot-staging/$1/$2
 
 begin-after-commit-hash: 6acf4a0a797f1082027985c55c4b14b60f673dd7


### PR DESCRIPTION
Earlier the destination path was using two capturing groups but the source only had one which prevented generated of gapic code.