### PR TITLE
tests: update default runtime used for tests

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -9,7 +9,7 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'Kokoro'
     - 'cla/google'
-    - 'Kokoro system-3.8'
+    - 'Kokoro system-3.12'
     - 'OwlBot Post Processor'
 - pattern: python2
   requiresCodeOwnerReviews: true

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,3 @@ system_tests/local_test_setup
 # Make sure a generated file isn't accidentally committed.
 pylintrc
 pylintrc.test
-
-# Docker files
-get-docker.sh

--- a/.kokoro/presubmit/system-3.12.cfg
+++ b/.kokoro/presubmit/system-3.12.cfg
@@ -3,7 +3,7 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.8"
+    value: "system-3.12"
 }
 
 # Credentials needed to test universe domain.

--- a/google/cloud/storage/notification.py
+++ b/google/cloud/storage/notification.py
@@ -257,7 +257,7 @@ class BucketNotification(object):
         with create_trace_span(name="Storage.BucketNotification.create"):
             if self.notification_id is not None:
                 raise ValueError(
-                    f"notification_id already set to {self.notification_id}; must be None to create a Notification."
+                    f"notification_id already set to {self.notification_id}; must be None to create a Notification."  # noqa: E702
                 )
 
             client = self._require_client(client)

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 DEFAULT_PYTHON_VERSION = "3.12"
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.12"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-CONFORMANCE_TEST_PYTHON_VERSIONS = ["3.8"]
+CONFORMANCE_TEST_PYTHON_VERSIONS = ["3.12"]
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,10 +35,6 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 # Error if a python version is missing
 nox.options.error_on_missing_interpreters = True
-# Use venv backend which doesn't include bundled setuptools
-# for CVE-2025-47273, CVE-2024-6345.
-# See https://github.com/python/cpython/issues/135374
-nox.options.default_venv_backend = 'venv'
 
 nox.options.sessions = [
     "blacken",

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,7 +84,7 @@ def blacken(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.install("docutils", "pygments")
+    session.install("docutils", "pygments", "setuptools>=79.0.1")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ BLACK_VERSION = "black==23.7.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.12"
-SYSTEM_TEST_PYTHON_VERSIONS = ["3.8"]
+SYSTEM_TEST_PYTHON_VERSIONS = ["3.12"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 CONFORMANCE_TEST_PYTHON_VERSIONS = ["3.8"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black==23.7.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.12"
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.8"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 CONFORMANCE_TEST_PYTHON_VERSIONS = ["3.8"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -74,7 +74,9 @@ def lint(session):
     session.run("flake8", "google", "tests")
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+# Use a python runtime which is available in the owlbot post processor here
+# https://github.com/googleapis/synthtool/blob/master/docker/owlbot/python/Dockerfile
+@nox.session(python=["3.10", DEFAULT_PYTHON_VERSION])
 def blacken(session):
     """Run black.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,7 +44,15 @@ nox.options.sessions = [
     "lint",
     "lint_setup_py",
     "system",
-    "unit",
+    # Exclude unit-3.7/unit-3.8 from testing since there is
+    # no patch for setuptools for CVE-2025-47273/CVE-2024-6345.
+    #"unit-3.7",
+    #"unit-3.8",
+    "unit-3.9",
+    "unit-3.10",
+    "unit-3.11",
+    "unit-3.12",
+    "unit-3.13",
     # cover must be last to avoid error `No data to report`
     "cover",
 ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,6 +35,10 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 # Error if a python version is missing
 nox.options.error_on_missing_interpreters = True
+# Use venv backend which doesn't include bundled setuptools
+# for CVE-2025-47273, CVE-2024-6345.
+# See https://github.com/python/cpython/issues/135374
+nox.options.default_venv_backend = 'venv'
 
 nox.options.sessions = [
     "blacken",

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,10 +44,8 @@ nox.options.sessions = [
     "lint",
     "lint_setup_py",
     "system",
-    # Exclude unit-3.7/unit-3.8 from testing since there is
-    # no patch for setuptools for CVE-2025-47273/CVE-2024-6345.
-    #"unit-3.7",
-    #"unit-3.8",
+    # TODO(https://github.com/googleapis/python-storage/issues/1499):
+    # Remove or restore testing for Python 3.7/3.8
     "unit-3.9",
     "unit-3.10",
     "unit-3.11",

--- a/owlbot.py
+++ b/owlbot.py
@@ -104,4 +104,6 @@ s.replace(
 
 python.py_samples(skip_readmes=True)
 
-s.shell.run(["nox", "-s", "blacken"], hide_output=False)
+# Use a python runtime which is available in the owlbot post processor here
+# https://github.com/googleapis/synthtool/blob/master/docker/owlbot/python/Dockerfile
+s.shell.run(["nox", "-s", "blacken-3.10"], hide_output=False)

--- a/tests/resumable_media/system/requests/test_download.py
+++ b/tests/resumable_media/system/requests/test_download.py
@@ -324,7 +324,9 @@ class TestDownload(object):
             check_tombstoned(download, authorized_transport)
 
     @pytest.mark.parametrize("checksum", ["auto", "md5", "crc32c", None])
-    def test_single_shot_download_to_stream(self, add_files, authorized_transport, checksum):
+    def test_single_shot_download_to_stream(
+        self, add_files, authorized_transport, checksum
+    ):
         for info in ALL_FILES:
             actual_contents = self._get_contents(info)
             blob_name = get_blob_name(info)

--- a/tests/resumable_media/unit/requests/test_download.py
+++ b/tests/resumable_media/unit/requests/test_download.py
@@ -1370,7 +1370,9 @@ def _mock_response(status_code=http.client.OK, chunks=None, headers=None):
         response.__enter__.return_value = response
         response.__exit__.return_value = None
         response.iter_content.return_value = iter(chunks)
-        response.raw.read = mock.Mock(side_effect=lambda *args, **kwargs: b"".join(chunks))
+        response.raw.read = mock.Mock(
+            side_effect=lambda *args, **kwargs: b"".join(chunks)
+        )
         return response
     else:
         return mock.Mock(

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -2099,7 +2099,7 @@ class Test_Blob(unittest.TestCase):
 
         properties = {}
         if charset is not None:
-            properties["contentType"] = f"text/plain; charset={charset}"
+            properties["contentType"] = f"text/plain; charset={charset}"  # noqa: E702
         elif no_charset:
             properties = {"contentType": "text/plain"}
 

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -4094,7 +4094,7 @@ class Test_Bucket(unittest.TestCase):
                     break
             else:  # pragma: NO COVER
                 self.fail(
-                    f"Condition {expected_condition} not found in {policy_conditions}"
+                    f"Condition {expected_condition} not found in {policy_conditions}"  # noqa: E713
                 )
 
         return policy_fields, policy


### PR DESCRIPTION
This PR includes the following fixes to the test environment:

- Fix presubmits following the changes in https://github.com/googleapis/testing-infra-docker/pull/491 which removes setuptools which don't include a patch for CVE-2025-47273/CVE-2025-47273
- Move from Python 3.8 to Python 3.12 as the default runtime for most tests
- Remove `unit-3.7` / `unit-3.8` from the default nox session/presubmits. See https://github.com/googleapis/google-cloud-python/issues/15970 where we will follow up on this