### PR TITLE
tests: update constraints for python 3.9 testing

### DIFF
--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,0 +1,14 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List all library dependencies and extras in this file.
+# Pin the version to the lower bound.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo==1.14.0
+google-auth==2.26.1
+google-api-core==2.15.0
+google-cloud-core==2.4.2
+google-resumable-media==2.7.2
+requests==2.22.0
+google-crc32c==1.1.3
+protobuf==3.20.2
+opentelemetry-api==1.1.0


### PR DESCRIPTION
Since Python 3.7 is no longer being tested following https://github.com/googleapis/python-storage/pull/1498 (see follow up in https://github.com/googleapis/google-cloud-python/issues/15970), we should update the constraints files for python 3.9 testing to ensure that the minimum versions of dependencies stated in setup.py are compatible.

https://github.com/googleapis/python-storage/blob/c7357305495443348c0a432db649b27e6a5d8c5b/testing/constraints-3.7.txt#L1-L6