### PR TITLE
chore: fix the module imports error for gapic

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -101,7 +101,7 @@ def default(session, install_extras=True):
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
     # Install all test dependencies, then install this package in-place.
-    session.install("mock", "pytest", "pytest-cov", "brotli", "grpcio", "grpcio-status", "-c", constraints_path)
+    session.install("mock", "pytest", "pytest-cov", "brotli", "grpcio", "grpcio-status", "proto-plus", "-c", constraints_path)
 
     if install_extras:
         session.install("opentelemetry-api", "opentelemetry-sdk")

--- a/owlbot.py
+++ b/owlbot.py
@@ -28,6 +28,12 @@ from synthtool.languages import python
 default_version = json.load(open(".repo-metadata.json", "rt")).get("default_version")
 
 for library in s.get_staging_dirs(default_version):
+    s.replace(
+        "google/cloud/storage_v2/__init__.py",
+        "from google.cloud.storage_v2 import gapic_version as package_version",
+        "from . import gapic_version as package_version"
+    )
+
     s.move(
         [library],
         excludes=[


### PR DESCRIPTION
There were module import errors for proto and gapic_version in the new gapic generation PR [pull/1502](https://github.com/googleapis/python-storage/pull/1502)