### PR TITLE
docs: update the documentation of move_blob function

### DIFF
--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -2255,10 +2255,7 @@ class Bucket(_PropertyMixin):
         timeout=_DEFAULT_TIMEOUT,
         retry=DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
     ):
-        """Move a blob to a new name within a single HNS bucket.
-
-        *This feature is currently only supported for HNS (Heirarchical
-        Namespace) buckets.*
+        """Move a blob to a new name atomically.
 
         If :attr:`user_project` is set on the bucket, bills the API request to that project.
 


### PR DESCRIPTION
Currently the move_blob documentation says it is only enabled for HNS buckets which is not true. The function works for non HNS enabled buckets as well. Updated the documentation with the new details.
