### PR TITLE
chore: improve docs for list_files_with_prefix

### DIFF
--- a/samples/snippets/storage_list_files_with_prefix.py
+++ b/samples/snippets/storage_list_files_with_prefix.py
@@ -46,12 +46,23 @@ def list_blobs_with_prefix(bucket_name, prefix, delimiter=None):
     that lists the "subfolders" under `a/`:
 
         a/b/
+
+
+    Note: If you only want to list prefixes a/b/ and don't want to iterate over
+    blobs, you can do
+
+    ```
+    for page in blobs.pages:
+        print(page.prefixes)
+    ```
     """
 
     storage_client = storage.Client()
 
     # Note: Client.list_blobs requires at least package version 1.17.0.
-    blobs = storage_client.list_blobs(bucket_name, prefix=prefix, delimiter=delimiter)
+    blobs = storage_client.list_blobs(
+        bucket_name, prefix=prefix, delimiter=delimiter
+    )
 
     # Note: The call returns a response only when the iterator is consumed.
     print("Blobs:")


### PR DESCRIPTION
If a user wants to just list prefixes without listing the blob names they can do so by following the updated documentation.


Fixes internal b/434195405
