### PR TITLE
chore: make the gapic code private

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -15,6 +15,7 @@
 """This script is used to synthesize generated parts of this library."""
 
 import json
+from pathlib import Path
 
 import synthtool as s
 from synthtool import gcp
@@ -28,12 +29,6 @@ from synthtool.languages import python
 default_version = json.load(open(".repo-metadata.json", "rt")).get("default_version")
 
 for library in s.get_staging_dirs(default_version):
-    s.replace(
-        library / "google/cloud/storage_v2/__init__.py",
-        "from google.cloud.storage import gapic_version as package_version",
-        "from google.cloud.storage_v2 import gapic_version as package_version",
-    )
-
     s.move(
         [library],
         excludes=[
@@ -51,6 +46,19 @@ for library in s.get_staging_dirs(default_version):
             "tests/unit/__init__.py",
         ],
     )
+
+    source_path = Path("google/cloud/storage_v2")
+    renamed_path = Path("google/cloud/_storage_v2")
+    if source_path.exists():
+        source_path.rename(renamed_path)
+
+    if renamed_path.exists():
+        s.replace(
+            renamed_path / "__init__.py",
+            "from google.cloud.storage_v2 import gapic_version as package_version",
+            "from google.cloud._storage_v2 import gapic_version as package_version",
+        )
+
 s.remove_staging_dirs()
 
 common = gcp.CommonTemplates()


### PR DESCRIPTION
Changing the gapic directory from `storage_v2` to `_storage_v2` so that it acts as a private folder.
