### PR TITLE
fix: Send entire object checksum at Resumable Upload Initiation Request

### DIFF
--- a/google/cloud/storage/_media/_upload.py
+++ b/google/cloud/storage/_media/_upload.py
@@ -336,9 +336,7 @@ class MultipartUpload(UploadBase):
         if checksum_object is not None:
             checksum_object.update(data)
             actual_checksum = _helpers.prepare_checksum_digest(checksum_object.digest())
-
             metadata_key = _helpers._get_metadata_key(self._checksum_type)
-            print("this is the metadata_key", metadata_key)
             metadata[metadata_key] = actual_checksum
 
         content, multipart_boundary = construct_multipart_request(
@@ -578,16 +576,9 @@ class ResumableUpload(UploadBase):
             self._get_status_code,
             callback=self._make_invalid,
         )
-        # print()
         self._resumable_url = _helpers.header_required(
             response, "location", self._get_headers
         )
-        print("*" * 50)
-        print(
-            "this is the response of initiate RU",
-            self._resumable_url,
-        )
-        print("*" * 50)
 
     def initiate(
         self,

--- a/google/cloud/storage/_media/requests/upload.py
+++ b/google/cloud/storage/_media/requests/upload.py
@@ -67,9 +67,7 @@ class SimpleUpload(_request_helpers.RequestsMixin, _upload.SimpleUpload):
         Returns:
             ~requests.Response: The HTTP response returned by ``transport``.
         """
-        method, url, payload, headers = self._prepare_request(
-            data, content_type
-        )
+        method, url, payload, headers = self._prepare_request(data, content_type)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -81,9 +79,7 @@ class SimpleUpload(_request_helpers.RequestsMixin, _upload.SimpleUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
 
 class MultipartUpload(_request_helpers.RequestsMixin, _upload.MultipartUpload):
@@ -162,9 +158,7 @@ class MultipartUpload(_request_helpers.RequestsMixin, _upload.MultipartUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
 
 class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
@@ -427,7 +421,6 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
             total_bytes=total_bytes,
             stream_final=stream_final,
         )
-        print("IRU", payload, headers)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -439,9 +432,7 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
     def transmit_next_chunk(
         self,
@@ -534,9 +525,7 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
     def recover(self, transport):
         """Recover from a failure and check the status of the current upload.
@@ -574,9 +563,7 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
 
 class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
@@ -663,9 +650,7 @@ class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
     def finalize(
         self,
@@ -703,9 +688,7 @@ class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
     def cancel(
         self,
@@ -745,9 +728,7 @@ class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
 
 
 class XMLMPUPart(_request_helpers.RequestsMixin, _upload.XMLMPUPart):
@@ -787,6 +768,4 @@ class XMLMPUPart(_request_helpers.RequestsMixin, _upload.XMLMPUPart):
 
             return result
 
-        return _request_helpers.wait_and_retry(
-            retriable_request, self._retry_strategy
-        )
+        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)

--- a/google/cloud/storage/_media/requests/upload.py
+++ b/google/cloud/storage/_media/requests/upload.py
@@ -67,7 +67,9 @@ class SimpleUpload(_request_helpers.RequestsMixin, _upload.SimpleUpload):
         Returns:
             ~requests.Response: The HTTP response returned by ``transport``.
         """
-        method, url, payload, headers = self._prepare_request(data, content_type)
+        method, url, payload, headers = self._prepare_request(
+            data, content_type
+        )
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -79,7 +81,9 @@ class SimpleUpload(_request_helpers.RequestsMixin, _upload.SimpleUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
 
 class MultipartUpload(_request_helpers.RequestsMixin, _upload.MultipartUpload):
@@ -158,7 +162,9 @@ class MultipartUpload(_request_helpers.RequestsMixin, _upload.MultipartUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
 
 class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
@@ -421,6 +427,7 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
             total_bytes=total_bytes,
             stream_final=stream_final,
         )
+        print("IRU", payload, headers)
 
         # Wrap the request business logic in a function to be retried.
         def retriable_request():
@@ -432,7 +439,9 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
     def transmit_next_chunk(
         self,
@@ -525,7 +534,9 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
     def recover(self, transport):
         """Recover from a failure and check the status of the current upload.
@@ -563,7 +574,9 @@ class ResumableUpload(_request_helpers.RequestsMixin, _upload.ResumableUpload):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
 
 class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
@@ -650,7 +663,9 @@ class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
     def finalize(
         self,
@@ -688,7 +703,9 @@ class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
     def cancel(
         self,
@@ -728,7 +745,9 @@ class XMLMPUContainer(_request_helpers.RequestsMixin, _upload.XMLMPUContainer):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )
 
 
 class XMLMPUPart(_request_helpers.RequestsMixin, _upload.XMLMPUPart):
@@ -768,4 +787,6 @@ class XMLMPUPart(_request_helpers.RequestsMixin, _upload.XMLMPUPart):
 
             return result
 
-        return _request_helpers.wait_and_retry(retriable_request, self._retry_strategy)
+        return _request_helpers.wait_and_retry(
+            retriable_request, self._retry_strategy
+        )

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -14,8 +14,7 @@
 
 # pylint: disable=too-many-lines
 
-"""Create / interact with Google Cloud Storage blobs.
-"""
+"""Create / interact with Google Cloud Storage blobs."""
 
 import base64
 import copy
@@ -81,7 +80,9 @@ from google.cloud.storage.fileio import BlobWriter
 
 
 _DEFAULT_CONTENT_TYPE = "application/octet-stream"
-_DOWNLOAD_URL_TEMPLATE = "{hostname}/download/storage/{api_version}{path}?alt=media"
+_DOWNLOAD_URL_TEMPLATE = (
+    "{hostname}/download/storage/{api_version}{path}?alt=media"
+)
 _BASE_UPLOAD_TEMPLATE = (
     "{hostname}/upload/storage/{api_version}{bucket_path}/o?uploadType="
 )
@@ -105,7 +106,8 @@ _WRITABLE_FIELDS = (
     "storageClass",
 )
 _READ_LESS_THAN_SIZE = (
-    "Size {:d} was specified but the file-like object only had " "{:d} bytes remaining."
+    "Size {:d} was specified but the file-like object only had "
+    "{:d} bytes remaining."
 )
 _CHUNKED_DOWNLOAD_CHECKSUM_MESSAGE = (
     "A checksum of type `{}` was requested, but checksumming is not available "
@@ -214,6 +216,7 @@ class Blob(_PropertyMixin):
         encryption_key=None,
         kms_key_name=None,
         generation=None,
+        crc32c_checksum=None,
     ):
         """
         property :attr:`name`
@@ -236,6 +239,10 @@ class Blob(_PropertyMixin):
 
         if generation is not None:
             self._properties["generation"] = generation
+
+        if crc32c_checksum is not None:
+            print("adding checksum")
+            self._properties["crc32c"] = crc32c_checksum
 
     @property
     def bucket(self):
@@ -265,9 +272,14 @@ class Blob(_PropertyMixin):
         :raises: :class:`ValueError` if ``value`` is not ``None`` and is not a
                  multiple of 256 KB.
         """
-        if value is not None and value > 0 and value % self._CHUNK_SIZE_MULTIPLE != 0:
+        if (
+            value is not None
+            and value > 0
+            and value % self._CHUNK_SIZE_MULTIPLE != 0
+        ):
             raise ValueError(
-                "Chunk size must be a multiple of %d." % (self._CHUNK_SIZE_MULTIPLE,)
+                "Chunk size must be a multiple of %d."
+                % (self._CHUNK_SIZE_MULTIPLE,)
             )
         self._chunk_size = value
 
@@ -446,7 +458,9 @@ class Blob(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The blob object created.
         """
-        warnings.warn(_FROM_STRING_DEPRECATED, PendingDeprecationWarning, stacklevel=2)
+        warnings.warn(
+            _FROM_STRING_DEPRECATED, PendingDeprecationWarning, stacklevel=2
+        )
         return Blob.from_uri(uri=uri, client=client)
 
     def generate_signed_url(
@@ -635,7 +649,9 @@ class Blob(_PropertyMixin):
             resource = f"/{self.bucket.name}/{quoted_name}"
 
         if credentials is None:
-            client = self._require_client(client)  # May be redundant, but that's ok.
+            client = self._require_client(
+                client
+            )  # May be redundant, but that's ok.
             credentials = client._credentials
 
         client = self._require_client(client)
@@ -949,7 +965,9 @@ class Blob(_PropertyMixin):
         self._properties[_CONTENT_TYPE_FIELD] = response.headers.get(
             "Content-Type", None
         )
-        self._properties["cacheControl"] = response.headers.get("Cache-Control", None)
+        self._properties["cacheControl"] = response.headers.get(
+            "Cache-Control", None
+        )
         self._properties["storageClass"] = response.headers.get(
             "X-Goog-Storage-Class", None
         )
@@ -957,7 +975,9 @@ class Blob(_PropertyMixin):
             "Content-Language", None
         )
         self._properties["etag"] = response.headers.get("ETag", None)
-        self._properties["generation"] = response.headers.get("X-goog-generation", None)
+        self._properties["generation"] = response.headers.get(
+            "X-goog-generation", None
+        )
         self._properties["metageneration"] = response.headers.get(
             "X-goog-metageneration", None
         )
@@ -967,7 +987,9 @@ class Blob(_PropertyMixin):
         if x_goog_hash:
             digests = {}
             for encoded_digest in x_goog_hash.split(","):
-                match = re.match(r"(crc32c|md5)=([\w\d/\+/]+={0,3})", encoded_digest)
+                match = re.match(
+                    r"(crc32c|md5)=([\w\d/\+/]+={0,3})", encoded_digest
+                )
                 if match:
                     method, digest = match.groups()
                     digests[method] = digest
@@ -1643,7 +1665,9 @@ class Blob(_PropertyMixin):
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
         warnings.warn(
-            _DOWNLOAD_AS_STRING_DEPRECATED, PendingDeprecationWarning, stacklevel=2
+            _DOWNLOAD_AS_STRING_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
         )
         with create_trace_span(name="Storage.Blob.downloadAsString"):
             return self.download_as_bytes(
@@ -1780,7 +1804,9 @@ class Blob(_PropertyMixin):
                 return data.decode(encoding)
 
             if self.content_type is not None:
-                msg = HeaderParser().parsestr("Content-Type: " + self.content_type)
+                msg = HeaderParser().parsestr(
+                    "Content-Type: " + self.content_type
+                )
                 params = dict(msg.get_params()[1:])
                 if "charset" in params:
                     return data.decode(params["charset"])
@@ -1850,7 +1876,9 @@ class Blob(_PropertyMixin):
 
         return object_metadata
 
-    def _get_upload_arguments(self, client, content_type, filename=None, command=None):
+    def _get_upload_arguments(
+        self, client, content_type, filename=None, command=None
+    ):
         """Get required arguments for performing an upload.
 
         The content type returned will be determined in order of precedence:
@@ -1999,12 +2027,22 @@ class Blob(_PropertyMixin):
         transport = self._get_transport(client)
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
+
+        # self._changes.add("crc32c")
         info = self._get_upload_arguments(client, content_type, command=command)
         headers, object_metadata, content_type = info
 
+        if "crc32c" in self._properties:
+            object_metadata["crc32c"] = self._properties["crc32c"]
+        print("*" * 50)
+        print("object metadata here in MPU JSON - ", object_metadata)
+        print("*" * 50)
+
         hostname = _get_host_name(client._connection)
         base_url = _MULTIPART_URL_TEMPLATE.format(
-            hostname=hostname, bucket_path=self.bucket.path, api_version=_API_VERSION
+            hostname=hostname,
+            bucket_path=self.bucket.path,
+            api_version=_API_VERSION,
         )
         name_value_pairs = []
 
@@ -2029,10 +2067,14 @@ class Blob(_PropertyMixin):
             name_value_pairs.append(("ifGenerationMatch", if_generation_match))
 
         if if_generation_not_match is not None:
-            name_value_pairs.append(("ifGenerationNotMatch", if_generation_not_match))
+            name_value_pairs.append(
+                ("ifGenerationNotMatch", if_generation_not_match)
+            )
 
         if if_metageneration_match is not None:
-            name_value_pairs.append(("ifMetagenerationMatch", if_metageneration_match))
+            name_value_pairs.append(
+                ("ifMetagenerationMatch", if_metageneration_match)
+            )
 
         if if_metageneration_not_match is not None:
             name_value_pairs.append(
@@ -2190,14 +2232,24 @@ class Blob(_PropertyMixin):
         transport = self._get_transport(client)
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
+        # self._changes.add("crc32c")
         info = self._get_upload_arguments(client, content_type, command=command)
         headers, object_metadata, content_type = info
         if extra_headers is not None:
             headers.update(extra_headers)
 
+        if "crc32c" in self._properties:
+            object_metadata["crc32c"] = self._properties["crc32c"]
+
+        print("*" * 50)
+        print("object metadata here in IRU - ", object_metadata)
+        print("*" * 50)
+
         hostname = _get_host_name(client._connection)
         base_url = _RESUMABLE_URL_TEMPLATE.format(
-            hostname=hostname, bucket_path=self.bucket.path, api_version=_API_VERSION
+            hostname=hostname,
+            bucket_path=self.bucket.path,
+            api_version=_API_VERSION,
         )
         name_value_pairs = []
 
@@ -2222,10 +2274,14 @@ class Blob(_PropertyMixin):
             name_value_pairs.append(("ifGenerationMatch", if_generation_match))
 
         if if_generation_not_match is not None:
-            name_value_pairs.append(("ifGenerationNotMatch", if_generation_not_match))
+            name_value_pairs.append(
+                ("ifGenerationNotMatch", if_generation_not_match)
+            )
 
         if if_metageneration_match is not None:
-            name_value_pairs.append(("ifMetagenerationMatch", if_metageneration_match))
+            name_value_pairs.append(
+                ("ifMetagenerationMatch", if_metageneration_match)
+            )
 
         if if_metageneration_not_match is not None:
             name_value_pairs.append(
@@ -2234,7 +2290,11 @@ class Blob(_PropertyMixin):
 
         upload_url = _add_query_parameters(base_url, name_value_pairs)
         upload = ResumableUpload(
-            upload_url, chunk_size, headers=headers, checksum=checksum, retry=retry
+            upload_url,
+            chunk_size,
+            headers=headers,
+            checksum=checksum,
+            retry=retry,
         )
 
         upload.initiate(
@@ -2382,7 +2442,9 @@ class Blob(_PropertyMixin):
         ):
             while not upload.finished:
                 try:
-                    response = upload.transmit_next_chunk(transport, timeout=timeout)
+                    response = upload.transmit_next_chunk(
+                        transport, timeout=timeout
+                    )
                 except DataCorruption:
                     # Attempt to delete the corrupted object.
                     self.delete()
@@ -2513,7 +2575,9 @@ class Blob(_PropertyMixin):
                 "ifGenerationMatch": if_generation_match,
                 "ifMetagenerationMatch": if_metageneration_match,
             }
-            retry = retry.get_retry_policy_if_conditions_met(query_params=query_params)
+            retry = retry.get_retry_policy_if_conditions_met(
+                query_params=query_params
+            )
 
         if size is not None and size <= _MAX_MULTIPART_SIZE:
             response = self._do_multipart_upload(
@@ -2849,7 +2913,9 @@ class Blob(_PropertyMixin):
                 retry=retry,
             )
 
-    def _handle_filename_and_upload(self, filename, content_type=None, *args, **kwargs):
+    def _handle_filename_and_upload(
+        self, filename, content_type=None, *args, **kwargs
+    ):
         """Upload this blob's contents from the content of a named file.
 
         :type filename: str
@@ -3247,7 +3313,9 @@ class Blob(_PropertyMixin):
         :raises: :class:`google.cloud.exceptions.GoogleCloudError`
                  if the session creation response returns an error status.
         """
-        with create_trace_span(name="Storage.Blob.createResumableUploadSession"):
+        with create_trace_span(
+            name="Storage.Blob.createResumableUploadSession"
+        ):
             # Handle ConditionalRetryPolicy.
             if isinstance(retry, ConditionalRetryPolicy):
                 # Conditional retries are designed for non-media calls, which change
@@ -3352,7 +3420,9 @@ class Blob(_PropertyMixin):
                 query_params["userProject"] = self.user_project
 
             if requested_policy_version is not None:
-                query_params["optionsRequestedPolicyVersion"] = requested_policy_version
+                query_params["optionsRequestedPolicyVersion"] = (
+                    requested_policy_version
+                )
 
             info = client._get_resource(
                 f"{self.path}/iam",
@@ -3426,7 +3496,11 @@ class Blob(_PropertyMixin):
             return Policy.from_api_repr(info)
 
     def test_iam_permissions(
-        self, permissions, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
+        self,
+        permissions,
+        client=None,
+        timeout=_DEFAULT_TIMEOUT,
+        retry=DEFAULT_RETRY,
     ):
         """API call:  test permissions
 
@@ -3692,8 +3766,13 @@ class Blob(_PropertyMixin):
                 raise ValueError(_COMPOSE_IF_SOURCE_GENERATION_MISMATCH_ERROR)
 
             source_objects = []
-            for source, source_generation in zip(sources, if_source_generation_match):
-                source_object = {"name": source.name, "generation": source.generation}
+            for source, source_generation in zip(
+                sources, if_source_generation_match
+            ):
+                source_object = {
+                    "name": source.name,
+                    "generation": source.generation,
+                }
 
                 preconditions = {}
                 if source_generation is not None:
@@ -3836,7 +3915,9 @@ class Blob(_PropertyMixin):
         with create_trace_span(name="Storage.Blob.rewrite"):
             client = self._require_client(client)
             headers = _get_encryption_headers(self._encryption_key)
-            headers.update(_get_encryption_headers(source._encryption_key, source=True))
+            headers.update(
+                _get_encryption_headers(source._encryption_key, source=True)
+            )
 
             query_params = self._query_params
             if "generation" in query_params:
@@ -4154,7 +4235,10 @@ class Blob(_PropertyMixin):
                         "encoding, errors and newline arguments are for text mode only"
                     )
                 return BlobWriter(
-                    self, chunk_size=chunk_size, ignore_flush=ignore_flush, **kwargs
+                    self,
+                    chunk_size=chunk_size,
+                    ignore_flush=ignore_flush,
+                    **kwargs,
                 )
             elif mode in ("r", "rt"):
                 if ignore_flush:
@@ -4370,7 +4454,9 @@ class Blob(_PropertyMixin):
                 "ifGenerationMatch": if_generation_match,
                 "ifMetagenerationMatch": if_metageneration_match,
             }
-            retry = retry.get_retry_policy_if_conditions_met(query_params=query_params)
+            retry = retry.get_retry_policy_if_conditions_met(
+                query_params=query_params
+            )
 
         client = self._require_client(client)
 
@@ -4390,7 +4476,9 @@ class Blob(_PropertyMixin):
         )
         # Add any client attached custom headers to be sent with the request.
         headers = {
-            **_get_default_headers(client._connection.user_agent, command=command),
+            **_get_default_headers(
+                client._connection.user_agent, command=command
+            ),
             **headers,
             **client._extra_headers,
         }
@@ -4537,7 +4625,9 @@ class Blob(_PropertyMixin):
         :param value: The blob metadata to set.
         """
         if value is not None:
-            value = {k: str(v) if v is not None else None for k, v in value.items()}
+            value = {
+                k: str(v) if v is not None else None for k, v in value.items()
+            }
         self._patch_property("metadata", value)
 
     @property
@@ -4882,9 +4972,13 @@ def _raise_from_invalid_response(error):
     else:
         error_message = str(error)
 
-    message = f"{response.request.method} {response.request.url}: {error_message}"
+    message = (
+        f"{response.request.method} {response.request.url}: {error_message}"
+    )
 
-    raise exceptions.from_http_status(response.status_code, message, response=response)
+    raise exceptions.from_http_status(
+        response.status_code, message, response=response
+    )
 
 
 def _add_query_parameters(base_url, name_value_pairs):
@@ -4944,7 +5038,9 @@ class Retention(dict):
         data["retainUntilTime"] = retain_until_time
 
         if retention_expiration_time is not None:
-            retention_expiration_time = _datetime_to_rfc3339(retention_expiration_time)
+            retention_expiration_time = _datetime_to_rfc3339(
+                retention_expiration_time
+            )
         data["retentionExpirationTime"] = retention_expiration_time
 
         super(Retention, self).__init__(data)

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -238,7 +238,6 @@ class Blob(_PropertyMixin):
             self._properties["generation"] = generation
 
         if crc32c_checksum is not None:
-            print("adding checksum")
             self._properties["crc32c"] = crc32c_checksum
 
     @property
@@ -2006,15 +2005,11 @@ class Blob(_PropertyMixin):
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
 
-        # self._changes.add("crc32c")
         info = self._get_upload_arguments(client, content_type, command=command)
         headers, object_metadata, content_type = info
 
         if "crc32c" in self._properties:
             object_metadata["crc32c"] = self._properties["crc32c"]
-        print("*" * 50)
-        print("object metadata here in MPU JSON - ", object_metadata)
-        print("*" * 50)
 
         hostname = _get_host_name(client._connection)
         base_url = _MULTIPART_URL_TEMPLATE.format(
@@ -2206,7 +2201,6 @@ class Blob(_PropertyMixin):
         transport = self._get_transport(client)
         if "metadata" in self._properties and "metadata" not in self._changes:
             self._changes.add("metadata")
-        # self._changes.add("crc32c")
         info = self._get_upload_arguments(client, content_type, command=command)
         headers, object_metadata, content_type = info
         if extra_headers is not None:
@@ -2214,10 +2208,6 @@ class Blob(_PropertyMixin):
 
         if "crc32c" in self._properties:
             object_metadata["crc32c"] = self._properties["crc32c"]
-
-        print("*" * 50)
-        print("object metadata here in IRU - ", object_metadata)
-        print("*" * 50)
 
         hostname = _get_host_name(client._connection)
         base_url = _RESUMABLE_URL_TEMPLATE.format(
@@ -2413,9 +2403,7 @@ class Blob(_PropertyMixin):
             while not upload.finished:
                 try:
                     response = upload.transmit_next_chunk(transport, timeout=timeout)
-
                 except DataCorruption:
-                    print("Data corruption detected during resumable upload.")
                     # Attempt to delete the corrupted object.
                     self.delete()
                     raise
@@ -2547,7 +2535,6 @@ class Blob(_PropertyMixin):
             }
             retry = retry.get_retry_policy_if_conditions_met(query_params=query_params)
 
-        # if not (size is not None and size <= _MAX_MULTIPART_SIZE):
         if size is not None and size <= _MAX_MULTIPART_SIZE:
             response = self._do_multipart_upload(
                 client,

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -141,8 +141,8 @@ _GS_URL_REGEX_PATTERN = re.compile(
     r"(?P<scheme>gs)://(?P<bucket_name>[a-z0-9_.-]+)/(?P<object_name>.+)"
 )
 
-_DEFAULT_CHUNKSIZE = 104857600  # 1024 * 1024 B * 100 = 100 MB
-_MAX_MULTIPART_SIZE = 8388608  # 8 MB
+_DEFAULT_CHUNKSIZE = 104857600  # 1024 * 1024 B * 100 = 100 MiB
+_MAX_MULTIPART_SIZE = 8388608  # 8 MiB
 
 _logger = logging.getLogger(__name__)
 
@@ -180,6 +180,14 @@ class Blob(_PropertyMixin):
     :type generation: long
     :param generation:
         (Optional) If present, selects a specific revision of this object.
+
+    :type crc32c_checksum: str
+    :param crc32c_checksum:
+            (Optional) If set, the CRC32C checksum of the blob's content.
+            CRC32c checksum, as described in RFC 4960, Appendix B; encoded using
+            base64 in big-endian byte order. See
+            Apenndix B: https://datatracker.ietf.org/doc/html/rfc4960#appendix-B
+            base64: https://datatracker.ietf.org/doc/html/rfc4648#section-4
     """
 
     _chunk_size = None  # Default value for each instance.

--- a/google/cloud/storage/blob.py
+++ b/google/cloud/storage/blob.py
@@ -80,9 +80,7 @@ from google.cloud.storage.fileio import BlobWriter
 
 
 _DEFAULT_CONTENT_TYPE = "application/octet-stream"
-_DOWNLOAD_URL_TEMPLATE = (
-    "{hostname}/download/storage/{api_version}{path}?alt=media"
-)
+_DOWNLOAD_URL_TEMPLATE = "{hostname}/download/storage/{api_version}{path}?alt=media"
 _BASE_UPLOAD_TEMPLATE = (
     "{hostname}/upload/storage/{api_version}{bucket_path}/o?uploadType="
 )
@@ -106,8 +104,7 @@ _WRITABLE_FIELDS = (
     "storageClass",
 )
 _READ_LESS_THAN_SIZE = (
-    "Size {:d} was specified but the file-like object only had "
-    "{:d} bytes remaining."
+    "Size {:d} was specified but the file-like object only had " "{:d} bytes remaining."
 )
 _CHUNKED_DOWNLOAD_CHECKSUM_MESSAGE = (
     "A checksum of type `{}` was requested, but checksumming is not available "
@@ -272,14 +269,9 @@ class Blob(_PropertyMixin):
         :raises: :class:`ValueError` if ``value`` is not ``None`` and is not a
                  multiple of 256 KB.
         """
-        if (
-            value is not None
-            and value > 0
-            and value % self._CHUNK_SIZE_MULTIPLE != 0
-        ):
+        if value is not None and value > 0 and value % self._CHUNK_SIZE_MULTIPLE != 0:
             raise ValueError(
-                "Chunk size must be a multiple of %d."
-                % (self._CHUNK_SIZE_MULTIPLE,)
+                "Chunk size must be a multiple of %d." % (self._CHUNK_SIZE_MULTIPLE,)
             )
         self._chunk_size = value
 
@@ -458,9 +450,7 @@ class Blob(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The blob object created.
         """
-        warnings.warn(
-            _FROM_STRING_DEPRECATED, PendingDeprecationWarning, stacklevel=2
-        )
+        warnings.warn(_FROM_STRING_DEPRECATED, PendingDeprecationWarning, stacklevel=2)
         return Blob.from_uri(uri=uri, client=client)
 
     def generate_signed_url(
@@ -649,9 +639,7 @@ class Blob(_PropertyMixin):
             resource = f"/{self.bucket.name}/{quoted_name}"
 
         if credentials is None:
-            client = self._require_client(
-                client
-            )  # May be redundant, but that's ok.
+            client = self._require_client(client)  # May be redundant, but that's ok.
             credentials = client._credentials
 
         client = self._require_client(client)
@@ -965,9 +953,7 @@ class Blob(_PropertyMixin):
         self._properties[_CONTENT_TYPE_FIELD] = response.headers.get(
             "Content-Type", None
         )
-        self._properties["cacheControl"] = response.headers.get(
-            "Cache-Control", None
-        )
+        self._properties["cacheControl"] = response.headers.get("Cache-Control", None)
         self._properties["storageClass"] = response.headers.get(
             "X-Goog-Storage-Class", None
         )
@@ -975,9 +961,7 @@ class Blob(_PropertyMixin):
             "Content-Language", None
         )
         self._properties["etag"] = response.headers.get("ETag", None)
-        self._properties["generation"] = response.headers.get(
-            "X-goog-generation", None
-        )
+        self._properties["generation"] = response.headers.get("X-goog-generation", None)
         self._properties["metageneration"] = response.headers.get(
             "X-goog-metageneration", None
         )
@@ -987,9 +971,7 @@ class Blob(_PropertyMixin):
         if x_goog_hash:
             digests = {}
             for encoded_digest in x_goog_hash.split(","):
-                match = re.match(
-                    r"(crc32c|md5)=([\w\d/\+/]+={0,3})", encoded_digest
-                )
+                match = re.match(r"(crc32c|md5)=([\w\d/\+/]+={0,3})", encoded_digest)
                 if match:
                     method, digest = match.groups()
                     digests[method] = digest
@@ -1804,9 +1786,7 @@ class Blob(_PropertyMixin):
                 return data.decode(encoding)
 
             if self.content_type is not None:
-                msg = HeaderParser().parsestr(
-                    "Content-Type: " + self.content_type
-                )
+                msg = HeaderParser().parsestr("Content-Type: " + self.content_type)
                 params = dict(msg.get_params()[1:])
                 if "charset" in params:
                     return data.decode(params["charset"])
@@ -1876,9 +1856,7 @@ class Blob(_PropertyMixin):
 
         return object_metadata
 
-    def _get_upload_arguments(
-        self, client, content_type, filename=None, command=None
-    ):
+    def _get_upload_arguments(self, client, content_type, filename=None, command=None):
         """Get required arguments for performing an upload.
 
         The content type returned will be determined in order of precedence:
@@ -2067,14 +2045,10 @@ class Blob(_PropertyMixin):
             name_value_pairs.append(("ifGenerationMatch", if_generation_match))
 
         if if_generation_not_match is not None:
-            name_value_pairs.append(
-                ("ifGenerationNotMatch", if_generation_not_match)
-            )
+            name_value_pairs.append(("ifGenerationNotMatch", if_generation_not_match))
 
         if if_metageneration_match is not None:
-            name_value_pairs.append(
-                ("ifMetagenerationMatch", if_metageneration_match)
-            )
+            name_value_pairs.append(("ifMetagenerationMatch", if_metageneration_match))
 
         if if_metageneration_not_match is not None:
             name_value_pairs.append(
@@ -2274,14 +2248,10 @@ class Blob(_PropertyMixin):
             name_value_pairs.append(("ifGenerationMatch", if_generation_match))
 
         if if_generation_not_match is not None:
-            name_value_pairs.append(
-                ("ifGenerationNotMatch", if_generation_not_match)
-            )
+            name_value_pairs.append(("ifGenerationNotMatch", if_generation_not_match))
 
         if if_metageneration_match is not None:
-            name_value_pairs.append(
-                ("ifMetagenerationMatch", if_metageneration_match)
-            )
+            name_value_pairs.append(("ifMetagenerationMatch", if_metageneration_match))
 
         if if_metageneration_not_match is not None:
             name_value_pairs.append(
@@ -2442,10 +2412,10 @@ class Blob(_PropertyMixin):
         ):
             while not upload.finished:
                 try:
-                    response = upload.transmit_next_chunk(
-                        transport, timeout=timeout
-                    )
+                    response = upload.transmit_next_chunk(transport, timeout=timeout)
+
                 except DataCorruption:
+                    print("Data corruption detected during resumable upload.")
                     # Attempt to delete the corrupted object.
                     self.delete()
                     raise
@@ -2575,10 +2545,9 @@ class Blob(_PropertyMixin):
                 "ifGenerationMatch": if_generation_match,
                 "ifMetagenerationMatch": if_metageneration_match,
             }
-            retry = retry.get_retry_policy_if_conditions_met(
-                query_params=query_params
-            )
+            retry = retry.get_retry_policy_if_conditions_met(query_params=query_params)
 
+        # if not (size is not None and size <= _MAX_MULTIPART_SIZE):
         if size is not None and size <= _MAX_MULTIPART_SIZE:
             response = self._do_multipart_upload(
                 client,
@@ -2913,9 +2882,7 @@ class Blob(_PropertyMixin):
                 retry=retry,
             )
 
-    def _handle_filename_and_upload(
-        self, filename, content_type=None, *args, **kwargs
-    ):
+    def _handle_filename_and_upload(self, filename, content_type=None, *args, **kwargs):
         """Upload this blob's contents from the content of a named file.
 
         :type filename: str
@@ -3313,9 +3280,7 @@ class Blob(_PropertyMixin):
         :raises: :class:`google.cloud.exceptions.GoogleCloudError`
                  if the session creation response returns an error status.
         """
-        with create_trace_span(
-            name="Storage.Blob.createResumableUploadSession"
-        ):
+        with create_trace_span(name="Storage.Blob.createResumableUploadSession"):
             # Handle ConditionalRetryPolicy.
             if isinstance(retry, ConditionalRetryPolicy):
                 # Conditional retries are designed for non-media calls, which change
@@ -3420,9 +3385,7 @@ class Blob(_PropertyMixin):
                 query_params["userProject"] = self.user_project
 
             if requested_policy_version is not None:
-                query_params["optionsRequestedPolicyVersion"] = (
-                    requested_policy_version
-                )
+                query_params["optionsRequestedPolicyVersion"] = requested_policy_version
 
             info = client._get_resource(
                 f"{self.path}/iam",
@@ -3766,9 +3729,7 @@ class Blob(_PropertyMixin):
                 raise ValueError(_COMPOSE_IF_SOURCE_GENERATION_MISMATCH_ERROR)
 
             source_objects = []
-            for source, source_generation in zip(
-                sources, if_source_generation_match
-            ):
+            for source, source_generation in zip(sources, if_source_generation_match):
                 source_object = {
                     "name": source.name,
                     "generation": source.generation,
@@ -3915,9 +3876,7 @@ class Blob(_PropertyMixin):
         with create_trace_span(name="Storage.Blob.rewrite"):
             client = self._require_client(client)
             headers = _get_encryption_headers(self._encryption_key)
-            headers.update(
-                _get_encryption_headers(source._encryption_key, source=True)
-            )
+            headers.update(_get_encryption_headers(source._encryption_key, source=True))
 
             query_params = self._query_params
             if "generation" in query_params:
@@ -4454,9 +4413,7 @@ class Blob(_PropertyMixin):
                 "ifGenerationMatch": if_generation_match,
                 "ifMetagenerationMatch": if_metageneration_match,
             }
-            retry = retry.get_retry_policy_if_conditions_met(
-                query_params=query_params
-            )
+            retry = retry.get_retry_policy_if_conditions_met(query_params=query_params)
 
         client = self._require_client(client)
 
@@ -4476,9 +4433,7 @@ class Blob(_PropertyMixin):
         )
         # Add any client attached custom headers to be sent with the request.
         headers = {
-            **_get_default_headers(
-                client._connection.user_agent, command=command
-            ),
+            **_get_default_headers(client._connection.user_agent, command=command),
             **headers,
             **client._extra_headers,
         }
@@ -4625,9 +4580,7 @@ class Blob(_PropertyMixin):
         :param value: The blob metadata to set.
         """
         if value is not None:
-            value = {
-                k: str(v) if v is not None else None for k, v in value.items()
-            }
+            value = {k: str(v) if v is not None else None for k, v in value.items()}
         self._patch_property("metadata", value)
 
     @property
@@ -4972,13 +4925,9 @@ def _raise_from_invalid_response(error):
     else:
         error_message = str(error)
 
-    message = (
-        f"{response.request.method} {response.request.url}: {error_message}"
-    )
+    message = f"{response.request.method} {response.request.url}: {error_message}"
 
-    raise exceptions.from_http_status(
-        response.status_code, message, response=response
-    )
+    raise exceptions.from_http_status(response.status_code, message, response=response)
 
 
 def _add_query_parameters(base_url, name_value_pairs):
@@ -5038,9 +4987,7 @@ class Retention(dict):
         data["retainUntilTime"] = retain_until_time
 
         if retention_expiration_time is not None:
-            retention_expiration_time = _datetime_to_rfc3339(
-                retention_expiration_time
-            )
+            retention_expiration_time = _datetime_to_rfc3339(retention_expiration_time)
         data["retentionExpirationTime"] = retention_expiration_time
 
         super(Retention, self).__init__(data)

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -876,6 +876,7 @@ class Bucket(_PropertyMixin):
         :type generation: long
         :param generation: (Optional) If present, selects a specific revision of
                            this object.
+
         :type crc32c_checksum: str
         :param crc32c_checksum:
             (Optional) If set, the CRC32C checksum of the blob's content.

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -255,7 +255,9 @@ class LifecycleRuleConditions(dict):
             conditions["daysSinceNoncurrentTime"] = days_since_noncurrent_time
 
         if noncurrent_time_before is not None:
-            conditions["noncurrentTimeBefore"] = noncurrent_time_before.isoformat()
+            conditions["noncurrentTimeBefore"] = (
+                noncurrent_time_before.isoformat()
+            )
 
         if matches_prefix is not None:
             conditions["matchesPrefix"] = matches_prefix
@@ -384,7 +386,10 @@ class LifecycleRuleSetStorageClass(dict):
     def __init__(self, storage_class, **kw):
         conditions = LifecycleRuleConditions(**kw)
         rule = {
-            "action": {"type": "SetStorageClass", "storageClass": storage_class},
+            "action": {
+                "type": "SetStorageClass",
+                "storageClass": storage_class,
+            },
             "condition": dict(conditions),
         }
         super().__init__(rule)
@@ -482,15 +487,21 @@ class IAMConfiguration(dict):
             if uniform_bucket_level_access_enabled is not _default:
                 raise ValueError(_UBLA_BPO_ENABLED_MESSAGE)
 
-            warnings.warn(_BPO_ENABLED_MESSAGE, DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                _BPO_ENABLED_MESSAGE, DeprecationWarning, stacklevel=2
+            )
             uniform_bucket_level_access_enabled = bucket_policy_only_enabled
 
         if bucket_policy_only_locked_time is not _default:
             if uniform_bucket_level_access_locked_time is not _default:
                 raise ValueError(_UBLA_BPO_LOCK_TIME_MESSAGE)
 
-            warnings.warn(_BPO_LOCK_TIME_MESSAGE, DeprecationWarning, stacklevel=2)
-            uniform_bucket_level_access_locked_time = bucket_policy_only_locked_time
+            warnings.warn(
+                _BPO_LOCK_TIME_MESSAGE, DeprecationWarning, stacklevel=2
+            )
+            uniform_bucket_level_access_locked_time = (
+                bucket_policy_only_locked_time
+            )
 
         if uniform_bucket_level_access_enabled is _default:
             uniform_bucket_level_access_enabled = False
@@ -505,8 +516,8 @@ class IAMConfiguration(dict):
             "publicAccessPrevention": public_access_prevention,
         }
         if uniform_bucket_level_access_locked_time is not _default:
-            data["uniformBucketLevelAccess"]["lockedTime"] = _datetime_to_rfc3339(
-                uniform_bucket_level_access_locked_time
+            data["uniformBucketLevelAccess"]["lockedTime"] = (
+                _datetime_to_rfc3339(uniform_bucket_level_access_locked_time)
             )
         super(IAMConfiguration, self).__init__(data)
         self._bucket = bucket
@@ -834,7 +845,9 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The bucket object created.
         """
-        warnings.warn(_FROM_STRING_MESSAGE, PendingDeprecationWarning, stacklevel=2)
+        warnings.warn(
+            _FROM_STRING_MESSAGE, PendingDeprecationWarning, stacklevel=2
+        )
         return Bucket.from_uri(uri=uri, client=client)
 
     def blob(
@@ -844,6 +857,7 @@ class Bucket(_PropertyMixin):
         encryption_key=None,
         kms_key_name=None,
         generation=None,
+        crc32c_checksum=None,
     ):
         """Factory constructor for blob object.
 
@@ -881,6 +895,7 @@ class Bucket(_PropertyMixin):
             encryption_key=encryption_key,
             kms_key_name=kms_key_name,
             generation=generation,
+            crc32c_checksum=crc32c_checksum,
         )
 
     def notification(
@@ -1910,7 +1925,9 @@ class Bucket(_PropertyMixin):
             if_generation_match = iter(if_generation_match or [])
             if_generation_not_match = iter(if_generation_not_match or [])
             if_metageneration_match = iter(if_metageneration_match or [])
-            if_metageneration_not_match = iter(if_metageneration_not_match or [])
+            if_metageneration_not_match = iter(
+                if_metageneration_not_match or []
+            )
 
             for blob in blobs:
                 try:
@@ -1918,15 +1935,21 @@ class Bucket(_PropertyMixin):
                     generation = None
                     if not isinstance(blob_name, str):
                         blob_name = blob.name
-                        generation = blob.generation if preserve_generation else None
+                        generation = (
+                            blob.generation if preserve_generation else None
+                        )
 
                     self.delete_blob(
                         blob_name,
                         client=client,
                         generation=generation,
                         if_generation_match=next(if_generation_match, None),
-                        if_generation_not_match=next(if_generation_not_match, None),
-                        if_metageneration_match=next(if_metageneration_match, None),
+                        if_generation_not_match=next(
+                            if_generation_not_match, None
+                        ),
+                        if_metageneration_match=next(
+                            if_metageneration_match, None
+                        ),
                         if_metageneration_not_match=next(
                             if_metageneration_not_match, None
                         ),
@@ -2492,7 +2515,9 @@ class Bucket(_PropertyMixin):
         :rtype: list of dictionaries
         :returns: A sequence of mappings describing each CORS policy.
         """
-        return [copy.deepcopy(policy) for policy in self._properties.get("cors", ())]
+        return [
+            copy.deepcopy(policy) for policy in self._properties.get("cors", ())
+        ]
 
     @cors.setter
     def cors(self, entries):
@@ -2591,7 +2616,9 @@ class Bucket(_PropertyMixin):
         # so that a future .patch() call can do the correct thing.
         existing = set([k for k in self.labels.keys()])
         incoming = set([k for k in mapping.keys()])
-        self._label_removals = self._label_removals.union(existing.difference(incoming))
+        self._label_removals = self._label_removals.union(
+            existing.difference(incoming)
+        )
         mapping = {k: str(v) for k, v in mapping.items()}
 
         # Actually update the labels on the object.
@@ -2679,7 +2706,9 @@ class Bucket(_PropertyMixin):
             elif action_type == "SetStorageClass":
                 yield LifecycleRuleSetStorageClass.from_api_repr(rule)
             elif action_type == "AbortIncompleteMultipartUpload":
-                yield LifecycleRuleAbortIncompleteMultipartUpload.from_api_repr(rule)
+                yield LifecycleRuleAbortIncompleteMultipartUpload.from_api_repr(
+                    rule
+                )
             else:
                 warnings.warn(
                     "Unknown lifecycle rule type received: {}. Please upgrade to the latest version of google-cloud-storage.".format(
@@ -2794,7 +2823,9 @@ class Bucket(_PropertyMixin):
             valid before the bucket is created. Instead, pass the location
             to `Bucket.create`.
         """
-        warnings.warn(_LOCATION_SETTER_MESSAGE, DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            _LOCATION_SETTER_MESSAGE, DeprecationWarning, stacklevel=2
+        )
         self._location = value
 
     @property
@@ -2809,7 +2840,9 @@ class Bucket(_PropertyMixin):
         or if the bucket is not a dual-regions bucket.
         :rtype: list of str or ``NoneType``
         """
-        custom_placement_config = self._properties.get("customPlacementConfig", {})
+        custom_placement_config = self._properties.get(
+            "customPlacementConfig", {}
+        )
         return custom_placement_config.get("dataLocations")
 
     @property
@@ -3251,7 +3284,10 @@ class Bucket(_PropertyMixin):
         :type not_found_page: str
         :param not_found_page: The file to use when a page isn't found.
         """
-        data = {"mainPageSuffix": main_page_suffix, "notFoundPage": not_found_page}
+        data = {
+            "mainPageSuffix": main_page_suffix,
+            "notFoundPage": not_found_page,
+        }
         self._patch_property("website", data)
 
     def disable_website(self):
@@ -3314,7 +3350,9 @@ class Bucket(_PropertyMixin):
                 query_params["userProject"] = self.user_project
 
             if requested_policy_version is not None:
-                query_params["optionsRequestedPolicyVersion"] = requested_policy_version
+                query_params["optionsRequestedPolicyVersion"] = (
+                    requested_policy_version
+                )
 
             info = client._get_resource(
                 f"{self.path}/iam",
@@ -3383,7 +3421,11 @@ class Bucket(_PropertyMixin):
             return Policy.from_api_repr(info)
 
     def test_iam_permissions(
-        self, permissions, client=None, timeout=_DEFAULT_TIMEOUT, retry=DEFAULT_RETRY
+        self,
+        permissions,
+        client=None,
+        timeout=_DEFAULT_TIMEOUT,
+        retry=DEFAULT_RETRY,
     ):
         """API call:  test permissions
 
@@ -3653,7 +3695,9 @@ class Bucket(_PropertyMixin):
         _signing.ensure_signed_credentials(credentials)
 
         if expiration is None:
-            expiration = _NOW(_UTC).replace(tzinfo=None) + datetime.timedelta(hours=1)
+            expiration = _NOW(_UTC).replace(tzinfo=None) + datetime.timedelta(
+                hours=1
+            )
 
         conditions = conditions + [{"bucket": self.name}]
 
@@ -3665,7 +3709,9 @@ class Bucket(_PropertyMixin):
         encoded_policy_document = base64.b64encode(
             json.dumps(policy_document).encode("utf-8")
         )
-        signature = base64.b64encode(credentials.sign_bytes(encoded_policy_document))
+        signature = base64.b64encode(
+            credentials.sign_bytes(encoded_policy_document)
+        )
 
         fields = {
             "bucket": self.name,
@@ -3869,7 +3915,9 @@ class Bucket(_PropertyMixin):
             resource = f"/{self.name}"
 
         if credentials is None:
-            client = self._require_client(client)  # May be redundant, but that's ok.
+            client = self._require_client(
+                client
+            )  # May be redundant, but that's ok.
             credentials = client._credentials
 
         if version == "v2":
@@ -3999,4 +4047,6 @@ def _raise_if_len_differs(expected_len, **generation_match_args):
     """
     for name, value in generation_match_args.items():
         if value is not None and len(value) != expected_len:
-            raise ValueError(f"'{name}' length must be the same as 'blobs' length")
+            raise ValueError(
+                f"'{name}' length must be the same as 'blobs' length"
+            )

--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -257,9 +257,7 @@ class LifecycleRuleConditions(dict):
             conditions["daysSinceNoncurrentTime"] = days_since_noncurrent_time
 
         if noncurrent_time_before is not None:
-            conditions["noncurrentTimeBefore"] = (
-                noncurrent_time_before.isoformat()
-            )
+            conditions["noncurrentTimeBefore"] = noncurrent_time_before.isoformat()
 
         if matches_prefix is not None:
             conditions["matchesPrefix"] = matches_prefix
@@ -489,21 +487,15 @@ class IAMConfiguration(dict):
             if uniform_bucket_level_access_enabled is not _default:
                 raise ValueError(_UBLA_BPO_ENABLED_MESSAGE)
 
-            warnings.warn(
-                _BPO_ENABLED_MESSAGE, DeprecationWarning, stacklevel=2
-            )
+            warnings.warn(_BPO_ENABLED_MESSAGE, DeprecationWarning, stacklevel=2)
             uniform_bucket_level_access_enabled = bucket_policy_only_enabled
 
         if bucket_policy_only_locked_time is not _default:
             if uniform_bucket_level_access_locked_time is not _default:
                 raise ValueError(_UBLA_BPO_LOCK_TIME_MESSAGE)
 
-            warnings.warn(
-                _BPO_LOCK_TIME_MESSAGE, DeprecationWarning, stacklevel=2
-            )
-            uniform_bucket_level_access_locked_time = (
-                bucket_policy_only_locked_time
-            )
+            warnings.warn(_BPO_LOCK_TIME_MESSAGE, DeprecationWarning, stacklevel=2)
+            uniform_bucket_level_access_locked_time = bucket_policy_only_locked_time
 
         if uniform_bucket_level_access_enabled is _default:
             uniform_bucket_level_access_enabled = False
@@ -518,8 +510,8 @@ class IAMConfiguration(dict):
             "publicAccessPrevention": public_access_prevention,
         }
         if uniform_bucket_level_access_locked_time is not _default:
-            data["uniformBucketLevelAccess"]["lockedTime"] = (
-                _datetime_to_rfc3339(uniform_bucket_level_access_locked_time)
+            data["uniformBucketLevelAccess"]["lockedTime"] = _datetime_to_rfc3339(
+                uniform_bucket_level_access_locked_time
             )
         super(IAMConfiguration, self).__init__(data)
         self._bucket = bucket
@@ -847,9 +839,7 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.bucket.Bucket`
         :returns: The bucket object created.
         """
-        warnings.warn(
-            _FROM_STRING_MESSAGE, PendingDeprecationWarning, stacklevel=2
-        )
+        warnings.warn(_FROM_STRING_MESSAGE, PendingDeprecationWarning, stacklevel=2)
         return Bucket.from_uri(uri=uri, client=client)
 
     def blob(
@@ -886,6 +876,13 @@ class Bucket(_PropertyMixin):
         :type generation: long
         :param generation: (Optional) If present, selects a specific revision of
                            this object.
+        :type crc32c_checksum: str
+        :param crc32c_checksum:
+            (Optional) If set, the CRC32C checksum of the blob's content.
+            CRC32c checksum, as described in RFC 4960, Appendix B; encoded using
+            base64 in big-endian byte order. See
+            Apenndix B: https://datatracker.ietf.org/doc/html/rfc4960#appendix-B
+            base64: https://datatracker.ietf.org/doc/html/rfc4648#section-4
 
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The blob object created.
@@ -1927,9 +1924,7 @@ class Bucket(_PropertyMixin):
             if_generation_match = iter(if_generation_match or [])
             if_generation_not_match = iter(if_generation_not_match or [])
             if_metageneration_match = iter(if_metageneration_match or [])
-            if_metageneration_not_match = iter(
-                if_metageneration_not_match or []
-            )
+            if_metageneration_not_match = iter(if_metageneration_not_match or [])
 
             for blob in blobs:
                 try:
@@ -1937,21 +1932,15 @@ class Bucket(_PropertyMixin):
                     generation = None
                     if not isinstance(blob_name, str):
                         blob_name = blob.name
-                        generation = (
-                            blob.generation if preserve_generation else None
-                        )
+                        generation = blob.generation if preserve_generation else None
 
                     self.delete_blob(
                         blob_name,
                         client=client,
                         generation=generation,
                         if_generation_match=next(if_generation_match, None),
-                        if_generation_not_match=next(
-                            if_generation_not_match, None
-                        ),
-                        if_metageneration_match=next(
-                            if_metageneration_match, None
-                        ),
+                        if_generation_not_match=next(if_generation_not_match, None),
+                        if_metageneration_match=next(if_metageneration_match, None),
                         if_metageneration_not_match=next(
                             if_metageneration_not_match, None
                         ),
@@ -2517,9 +2506,7 @@ class Bucket(_PropertyMixin):
         :rtype: list of dictionaries
         :returns: A sequence of mappings describing each CORS policy.
         """
-        return [
-            copy.deepcopy(policy) for policy in self._properties.get("cors", ())
-        ]
+        return [copy.deepcopy(policy) for policy in self._properties.get("cors", ())]
 
     @cors.setter
     def cors(self, entries):
@@ -2618,9 +2605,7 @@ class Bucket(_PropertyMixin):
         # so that a future .patch() call can do the correct thing.
         existing = set([k for k in self.labels.keys()])
         incoming = set([k for k in mapping.keys()])
-        self._label_removals = self._label_removals.union(
-            existing.difference(incoming)
-        )
+        self._label_removals = self._label_removals.union(existing.difference(incoming))
         mapping = {k: str(v) for k, v in mapping.items()}
 
         # Actually update the labels on the object.
@@ -2708,9 +2693,7 @@ class Bucket(_PropertyMixin):
             elif action_type == "SetStorageClass":
                 yield LifecycleRuleSetStorageClass.from_api_repr(rule)
             elif action_type == "AbortIncompleteMultipartUpload":
-                yield LifecycleRuleAbortIncompleteMultipartUpload.from_api_repr(
-                    rule
-                )
+                yield LifecycleRuleAbortIncompleteMultipartUpload.from_api_repr(rule)
             else:
                 warnings.warn(
                     "Unknown lifecycle rule type received: {}. Please upgrade to the latest version of google-cloud-storage.".format(
@@ -2825,9 +2808,7 @@ class Bucket(_PropertyMixin):
             valid before the bucket is created. Instead, pass the location
             to `Bucket.create`.
         """
-        warnings.warn(
-            _LOCATION_SETTER_MESSAGE, DeprecationWarning, stacklevel=2
-        )
+        warnings.warn(_LOCATION_SETTER_MESSAGE, DeprecationWarning, stacklevel=2)
         self._location = value
 
     @property
@@ -2842,9 +2823,7 @@ class Bucket(_PropertyMixin):
         or if the bucket is not a dual-regions bucket.
         :rtype: list of str or ``NoneType``
         """
-        custom_placement_config = self._properties.get(
-            "customPlacementConfig", {}
-        )
+        custom_placement_config = self._properties.get("customPlacementConfig", {})
         return custom_placement_config.get("dataLocations")
 
     @property
@@ -3352,9 +3331,7 @@ class Bucket(_PropertyMixin):
                 query_params["userProject"] = self.user_project
 
             if requested_policy_version is not None:
-                query_params["optionsRequestedPolicyVersion"] = (
-                    requested_policy_version
-                )
+                query_params["optionsRequestedPolicyVersion"] = requested_policy_version
 
             info = client._get_resource(
                 f"{self.path}/iam",
@@ -3697,9 +3674,7 @@ class Bucket(_PropertyMixin):
         _signing.ensure_signed_credentials(credentials)
 
         if expiration is None:
-            expiration = _NOW(_UTC).replace(tzinfo=None) + datetime.timedelta(
-                hours=1
-            )
+            expiration = _NOW(_UTC).replace(tzinfo=None) + datetime.timedelta(hours=1)
 
         conditions = conditions + [{"bucket": self.name}]
 
@@ -3711,9 +3686,7 @@ class Bucket(_PropertyMixin):
         encoded_policy_document = base64.b64encode(
             json.dumps(policy_document).encode("utf-8")
         )
-        signature = base64.b64encode(
-            credentials.sign_bytes(encoded_policy_document)
-        )
+        signature = base64.b64encode(credentials.sign_bytes(encoded_policy_document))
 
         fields = {
             "bucket": self.name,
@@ -3917,9 +3890,7 @@ class Bucket(_PropertyMixin):
             resource = f"/{self.name}"
 
         if credentials is None:
-            client = self._require_client(
-                client
-            )  # May be redundant, but that's ok.
+            client = self._require_client(client)  # May be redundant, but that's ok.
             credentials = client._credentials
 
         if version == "v2":
@@ -4102,6 +4073,4 @@ def _raise_if_len_differs(expected_len, **generation_match_args):
     """
     for name, value in generation_match_args.items():
         if value is not None and len(value) != expected_len:
-            raise ValueError(
-                f"'{name}' length must be the same as 'blobs' length"
-            )
+            raise ValueError(f"'{name}' length must be the same as 'blobs' length")

--- a/samples/snippets/storage_upload_file.py
+++ b/samples/snippets/storage_upload_file.py
@@ -20,7 +20,9 @@ import sys
 from google.cloud import storage
 
 
-def upload_blob(bucket_name, source_file_name, destination_blob_name):
+def upload_blob(
+    bucket_name, source_file_name, destination_blob_name, user_provided_checksum
+):
     """Uploads a file to the bucket."""
     # The ID of your GCS bucket
     # bucket_name = "your-bucket-name"
@@ -31,7 +33,10 @@ def upload_blob(bucket_name, source_file_name, destination_blob_name):
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
-    blob = bucket.blob(destination_blob_name)
+    # blob = bucket.blob(destination_blob_name)  # , crc32c_checksum="5MzJCA==")
+    blob = bucket.blob(
+        destination_blob_name, crc32c_checksum=user_provided_checksum
+    )
 
     # Optional: set a generation-match precondition to avoid potential race conditions
     # and data corruptions. The request to upload is aborted if the object's
@@ -41,11 +46,11 @@ def upload_blob(bucket_name, source_file_name, destination_blob_name):
     # generation-match precondition using its generation number.
     generation_match_precondition = 0
 
-    blob.upload_from_filename(source_file_name, if_generation_match=generation_match_precondition)
-
-    print(
-        f"File {source_file_name} uploaded to {destination_blob_name}."
+    blob.upload_from_filename(
+        source_file_name, if_generation_match=generation_match_precondition
     )
+
+    print(f"File {source_file_name} uploaded to {destination_blob_name}.")
 
 
 # [END storage_upload_file]
@@ -55,4 +60,5 @@ if __name__ == "__main__":
         bucket_name=sys.argv[1],
         source_file_name=sys.argv[2],
         destination_blob_name=sys.argv[3],
+        user_provided_checksum=sys.argv[4] if len(sys.argv) > 4 else None,
     )

--- a/samples/snippets/storage_upload_file.py
+++ b/samples/snippets/storage_upload_file.py
@@ -41,11 +41,11 @@ def upload_blob(bucket_name, source_file_name, destination_blob_name):
     # generation-match precondition using its generation number.
     generation_match_precondition = 0
 
-    blob.upload_from_filename(
-        source_file_name, if_generation_match=generation_match_precondition
-    )
+    blob.upload_from_filename(source_file_name, if_generation_match=generation_match_precondition)
 
-    print(f"File {source_file_name} uploaded to {destination_blob_name}.")
+    print(
+        f"File {source_file_name} uploaded to {destination_blob_name}."
+    )
 
 
 # [END storage_upload_file]

--- a/samples/snippets/storage_upload_file.py
+++ b/samples/snippets/storage_upload_file.py
@@ -20,9 +20,7 @@ import sys
 from google.cloud import storage
 
 
-def upload_blob(
-    bucket_name, source_file_name, destination_blob_name, user_provided_checksum
-):
+def upload_blob(bucket_name, source_file_name, destination_blob_name):
     """Uploads a file to the bucket."""
     # The ID of your GCS bucket
     # bucket_name = "your-bucket-name"
@@ -33,10 +31,7 @@ def upload_blob(
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
-    # blob = bucket.blob(destination_blob_name)  # , crc32c_checksum="5MzJCA==")
-    blob = bucket.blob(
-        destination_blob_name, crc32c_checksum=user_provided_checksum
-    )
+    blob = bucket.blob(destination_blob_name)
 
     # Optional: set a generation-match precondition to avoid potential race conditions
     # and data corruptions. The request to upload is aborted if the object's
@@ -60,5 +55,4 @@ if __name__ == "__main__":
         bucket_name=sys.argv[1],
         source_file_name=sys.argv[2],
         destination_blob_name=sys.argv[3],
-        user_provided_checksum=sys.argv[4] if len(sys.argv) > 4 else None,
     )

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -30,6 +30,7 @@ _filenames = [
     ("logo", "CloudPlatform_128px_Retina.png"),
     ("big", "five-point-one-mb-file.zip"),
     ("simple", "simple.txt"),
+    ("big_9MiB", "random_9_MiB_file"),
 ]
 _file_data = {
     key: {"path": os.path.join(data_dirname, file_name)}

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -87,7 +87,7 @@ class Test_Blob(unittest.TestCase):
     def test_ctor_with_encoded_unicode(self):
         blob_name = b"wet \xe2\x9b\xb5"
         blob = self._make_one(blob_name, bucket=None)
-        unicode_name = "wet \N{SAILBOAT}"
+        unicode_name = "wet \N{sailboat}"
         self.assertNotIsInstance(blob.name, bytes)
         self.assertIsInstance(blob.name, str)
         self.assertEqual(blob.name, unicode_name)
@@ -423,7 +423,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.public_url, "https://storage.googleapis.com/name/foo~bar")
 
     def test_public_url_with_non_ascii(self):
-        blob_name = "winter \N{SNOWMAN}"
+        blob_name = "winter \N{snowman}"
         bucket = _Bucket()
         blob = self._make_one(blob_name, bucket=bucket)
         expected_url = "https://storage.googleapis.com/name/winter%20%E2%98%83"
@@ -2238,7 +2238,7 @@ class Test_Blob(unittest.TestCase):
         )
 
     def test_download_as_text_w_non_ascii_w_explicit_encoding(self):
-        expected_value = "\x0aFe"
+        expected_value = "\x0AFe"
         encoding = "utf-16"
         charset = "latin1"
         payload = expected_value.encode(encoding)
@@ -2251,7 +2251,7 @@ class Test_Blob(unittest.TestCase):
         )
 
     def test_download_as_text_w_non_ascii_wo_explicit_encoding_w_charset(self):
-        expected_value = "\x0aFe"
+        expected_value = "\x0AFe"
         charset = "utf-16"
         payload = expected_value.encode(charset)
         self._download_as_text_helper(
@@ -3728,11 +3728,11 @@ class Test_Blob(unittest.TestCase):
         self._upload_from_string_helper(data)
 
     def test_upload_from_string_w_text(self):
-        data = "\N{SNOWMAN} \N{SAILBOAT}"
+        data = "\N{snowman} \N{sailboat}"
         self._upload_from_string_helper(data)
 
     def test_upload_from_string_w_text_w_retry(self):
-        data = "\N{SNOWMAN} \N{SAILBOAT}"
+        data = "\N{snowman} \N{sailboat}"
         self._upload_from_string_helper(data, retry=DEFAULT_RETRY)
 
     def _create_resumable_upload_session_helper(
@@ -6139,7 +6139,7 @@ class Test__quote(unittest.TestCase):
         return _quote(*args, **kw)
 
     def test_bytes(self):
-        quoted = self._call_fut(b"\xde\xad\xbe\xef")
+        quoted = self._call_fut(b"\xDE\xAD\xBE\xEF")
         self.assertEqual(quoted, "%DE%AD%BE%EF")
 
     def test_unicode(self):

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -2928,6 +2928,10 @@ class Test_Blob(unittest.TestCase):
         else:
             # Check the mocks.
             blob._get_writable_metadata.assert_called_once_with()
+
+        if "crc32c" in blob._properties:
+            object_metadata["crc32c"] = blob._properties["crc32c"]
+
         payload = json.dumps(object_metadata).encode("utf-8")
 
         with patch.object(
@@ -2954,8 +2958,16 @@ class Test_Blob(unittest.TestCase):
     def test__initiate_resumable_upload_with_metadata(self):
         self._initiate_resumable_helper(metadata={"test": "test"})
 
-    def test__initiate_resumable_upload_with_metadata(self):
-        self._initiate_resumable_helper(crc32c_checksum="test-checksum")
+    def test__initiate_resumable_upload_with_user_provided_checksum(self):
+        self._initiate_resumable_helper(
+            crc32c_checksum="this-is-a-fake-checksum-for-unit-tests",
+        )
+
+    def test__initiate_resumable_upload_w_metadata_and_user_provided_checksum(self):
+        self._initiate_resumable_helper(
+            crc32c_checksum="test-checksum",
+            metadata={"my-fav-key": "my-fav-value"},
+        )
 
     def test__initiate_resumable_upload_with_custom_timeout(self):
         self._initiate_resumable_helper(timeout=9.58)

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -87,7 +87,7 @@ class Test_Blob(unittest.TestCase):
     def test_ctor_with_encoded_unicode(self):
         blob_name = b"wet \xe2\x9b\xb5"
         blob = self._make_one(blob_name, bucket=None)
-        unicode_name = "wet \N{sailboat}"
+        unicode_name = "wet \N{SAILBOAT}"
         self.assertNotIsInstance(blob.name, bytes)
         self.assertIsInstance(blob.name, str)
         self.assertEqual(blob.name, unicode_name)
@@ -423,7 +423,7 @@ class Test_Blob(unittest.TestCase):
         self.assertEqual(blob.public_url, "https://storage.googleapis.com/name/foo~bar")
 
     def test_public_url_with_non_ascii(self):
-        blob_name = "winter \N{snowman}"
+        blob_name = "winter \N{SNOWMAN}"
         bucket = _Bucket()
         blob = self._make_one(blob_name, bucket=bucket)
         expected_url = "https://storage.googleapis.com/name/winter%20%E2%98%83"
@@ -2238,7 +2238,7 @@ class Test_Blob(unittest.TestCase):
         )
 
     def test_download_as_text_w_non_ascii_w_explicit_encoding(self):
-        expected_value = "\x0AFe"
+        expected_value = "\x0aFe"
         encoding = "utf-16"
         charset = "latin1"
         payload = expected_value.encode(encoding)
@@ -2251,7 +2251,7 @@ class Test_Blob(unittest.TestCase):
         )
 
     def test_download_as_text_w_non_ascii_wo_explicit_encoding_w_charset(self):
-        expected_value = "\x0AFe"
+        expected_value = "\x0aFe"
         charset = "utf-16"
         payload = expected_value.encode(charset)
         self._download_as_text_helper(
@@ -2762,12 +2762,21 @@ class Test_Blob(unittest.TestCase):
         metadata=None,
         mtls=False,
         retry=None,
+        crc32c_checksum=None,
     ):
         from google.cloud.storage._media.requests import ResumableUpload
         from google.cloud.storage.blob import _DEFAULT_CHUNKSIZE
 
         bucket = _Bucket(name="whammy", user_project=user_project)
-        blob = self._make_one("blob-name", bucket=bucket, kms_key_name=kms_key_name)
+        if crc32c_checksum is None:
+            blob = self._make_one("blob-name", bucket=bucket, kms_key_name=kms_key_name)
+        else:
+            blob = self._make_one(
+                "blob-name",
+                bucket=bucket,
+                kms_key_name=kms_key_name,
+                crc32c_checksum=crc32c_checksum,
+            )
         if metadata:
             self.assertIsNone(blob.metadata)
             blob._properties["metadata"] = metadata
@@ -2944,6 +2953,9 @@ class Test_Blob(unittest.TestCase):
 
     def test__initiate_resumable_upload_with_metadata(self):
         self._initiate_resumable_helper(metadata={"test": "test"})
+
+    def test__initiate_resumable_upload_with_metadata(self):
+        self._initiate_resumable_helper(crc32c_checksum="test-checksum")
 
     def test__initiate_resumable_upload_with_custom_timeout(self):
         self._initiate_resumable_helper(timeout=9.58)
@@ -3704,11 +3716,11 @@ class Test_Blob(unittest.TestCase):
         self._upload_from_string_helper(data)
 
     def test_upload_from_string_w_text(self):
-        data = "\N{snowman} \N{sailboat}"
+        data = "\N{SNOWMAN} \N{SAILBOAT}"
         self._upload_from_string_helper(data)
 
     def test_upload_from_string_w_text_w_retry(self):
-        data = "\N{snowman} \N{sailboat}"
+        data = "\N{SNOWMAN} \N{SAILBOAT}"
         self._upload_from_string_helper(data, retry=DEFAULT_RETRY)
 
     def _create_resumable_upload_session_helper(
@@ -6115,7 +6127,7 @@ class Test__quote(unittest.TestCase):
         return _quote(*args, **kw)
 
     def test_bytes(self):
-        quoted = self._call_fut(b"\xDE\xAD\xBE\xEF")
+        quoted = self._call_fut(b"\xde\xad\xbe\xef")
         self.assertEqual(quoted, "%DE%AD%BE%EF")
 
     def test_unicode(self):


### PR DESCRIPTION
Send entire object checksum at Resumable Upload Initiation Request.

Entire object checksum is provided while blob instantiation. The same will be used as data integrity checks and upload will succeed only when server computed checksum and user provided checksum match.


Fixes #1524 🦕
