### PR TITLE
fix: test_blob_acl_w_metageneration_match due to Public access prevention 

### DIFF
--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -426,7 +426,6 @@ def test_blob_acl_w_metageneration_match(
     # Exercise blob ACL with metageneration/generation match
     acl = blob.acl
     acl.domain("google.com").grant_read()
-    # blob.reload()
 
     with pytest.raises(exceptions.PreconditionFailed):
         acl.save(if_metageneration_match=wrong_metageneration_number)
@@ -435,7 +434,6 @@ def test_blob_acl_w_metageneration_match(
     acl.save(if_metageneration_match=blob.metageneration)
 
     assert "READER" in acl.domain("google.com").get_roles()
-    # blob.reload()
     acl.domain("google.com").revoke_read()
 
     with pytest.raises(exceptions.PreconditionFailed):

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -409,7 +409,6 @@ def test_blob_acl_w_user_project(
     assert not acl.has_entity("allUsers")
 
 
-# error
 def test_blob_acl_w_metageneration_match(
     shared_bucket,
     blobs_to_delete,
@@ -447,7 +446,6 @@ def test_blob_acl_w_metageneration_match(
     assert "READER" not in acl.domain("google.com").get_roles()
 
 
-# error
 def test_blob_acl_upload_predefined(
     shared_bucket,
     blobs_to_delete,
@@ -478,7 +476,6 @@ def test_blob_acl_upload_predefined(
         entity = entry["entity"]
     assert count == 1
     assert entity.lstrip("user-") == service_account.service_account_email
-    # assert sum(1 for _ in acl) == 1
 
     assert sum(1 for _ in control_blob_acl) > 1
 

--- a/tests/system/test_blob.py
+++ b/tests/system/test_blob.py
@@ -454,31 +454,33 @@ def test_blob_acl_upload_predefined(
     file_data,
     service_account,
 ):
-    control = shared_bucket.blob(f"logo{uuid.uuid4().hex}")
-    control_info = file_data["logo"]
+    control_blob = shared_bucket.blob(f"logo{uuid.uuid4().hex}")
+    control_blob_info = file_data["logo"]
 
     blob = shared_bucket.blob(f"SmallFile{uuid.uuid4().hex}")
     info = file_data["simple"]
 
     try:
-        control.upload_from_filename(control_info["path"])
+        control_blob.upload_from_filename(control_blob_info["path"])
     finally:
-        blobs_to_delete.append(control)
-
+        blobs_to_delete.append(control_blob)
     try:
-        blob.upload_from_filename(info["path"], predefined_acl="publicRead")
+        blob.upload_from_filename(info["path"], predefined_acl="private")
     finally:
         blobs_to_delete.append(blob)
 
-    control_acl = control.acl
-    assert "READER" not in control_acl.all().get_roles()
+    control_blob_acl = control_blob.acl
 
     acl = blob.acl
-    assert "READER" in acl.all().get_roles()
+    count = 0
+    for entry in acl:
+        count += 1
+        entity = entry["entity"]
+    assert count == 1
+    assert entity.lstrip("user-") == service_account.service_account_email
+    # assert sum(1 for _ in acl) == 1
 
-    acl.all().revoke_read()
-    assert acl.all().get_roles() == set()
-    assert control_acl.all().get_roles() == acl.all().get_roles()
+    assert sum(1 for _ in control_blob_acl) > 1
 
 
 def test_blob_patch_metadata(


### PR DESCRIPTION
fix: test_blob_acl_w_metageneration_match

* Public access prevention has been enforced on buckets under `google.com` org. Hence predefined roles such as `allUsers` and `allAuthenticatedUsers` cannot be used for system tests. 
* Since the intention of the test `test_blob_acl_w_metageneration_match` is to test whether the library is able to set blob's acl with and without metageneration match. Hence instead of save_predefined, created a new acl (READER) for "google.com" domain asserted acl.save with / without metageneration match
* For `test_blob_acl_upload_predefined` we need predefined acl . We've 7 predefined ACLs - https://cloud.google.com/storage/docs/access-control/lists#predefined-acl   
Bottom three in the list would make the access public, `projectPrivate` is default. I chosed `private` out of the remaining 3 (`private`, `bucketOwnerRead`, `bucketOwnerFullControl`) as I faced issues in bucketOwnerRead (this would've been ideal)

 

Fixes #1521  
Fixes #1520 
