### PR TITLE
feat(experimental): add async grpc client

### DIFF
--- a/google/cloud/storage/_experimental/async_grpc_client.py
+++ b/google/cloud/storage/_experimental/async_grpc_client.py
@@ -16,6 +16,7 @@
 
 from google.cloud import _storage_v2 as storage_v2
 
+
 class AsyncGrpcClient:
     """An asynchronous client for interacting with Google Cloud Storage using the gRPC API.
 
@@ -61,7 +62,9 @@ class AsyncGrpcClient:
         client_options=None,
         attempt_direct_path=True,
     ):
-        transport_cls = storage_v2.StorageAsyncClient.get_transport_class("grpc_asyncio")
+        transport_cls = storage_v2.StorageAsyncClient.get_transport_class(
+            "grpc_asyncio"
+        )
         channel = transport_cls.create_channel(attempt_direct_path=attempt_direct_path)
         transport = transport_cls(credentials=credentials, channel=channel)
 
@@ -71,3 +74,16 @@ class AsyncGrpcClient:
             client_info=client_info,
             client_options=client_options,
         )
+
+    @property
+    def grpc_client(self):
+        """The underlying gRPC client.
+
+        This property gives users direct access to the `_storage_v2.StorageAsyncClient`
+         instance. This can be useful for accessing
+        newly added or experimental RPCs that are not yet exposed through
+        the high-level GrpcClient.
+        Returns:
+            google.cloud._storage_v2.StorageAsyncClient: The configured GAPIC client.
+        """
+        return self._grpc_client

--- a/google/cloud/storage/_experimental/async_grpc_client.py
+++ b/google/cloud/storage/_experimental/async_grpc_client.py
@@ -14,7 +14,7 @@
 
 """An async client for interacting with Google Cloud Storage using the gRPC API."""
 
-from google.cloud import storage_v2
+from google.cloud import _storage_v2 as storage_v2
 
 class AsyncGrpcClient:
     """An asynchronous client for interacting with Google Cloud Storage using the gRPC API.

--- a/google/cloud/storage/_experimental/async_grpc_client.py
+++ b/google/cloud/storage/_experimental/async_grpc_client.py
@@ -62,11 +62,8 @@ class AsyncGrpcClient:
         attempt_direct_path=True,
     ):
         transport_cls = storage_v2.StorageAsyncClient.get_transport_class("grpc_asyncio")
-
-        transport = transport_cls(
-            credentials=credentials,
-            attempt_direct_path=attempt_direct_path,
-        )
+        channel = transport_cls.create_channel(attempt_direct_path=attempt_direct_path)
+        transport = transport_cls(credentials=credentials, channel=channel)
 
         return storage_v2.StorageAsyncClient(
             credentials=credentials,

--- a/google/cloud/storage/_experimental/async_grpc_client.py
+++ b/google/cloud/storage/_experimental/async_grpc_client.py
@@ -15,8 +15,6 @@
 """An async client for interacting with Google Cloud Storage using the gRPC API."""
 
 from google.cloud import storage_v2
-from google.api_core import client_options as client_options_lib
-
 
 class AsyncGrpcClient:
     """An asynchronous client for interacting with Google Cloud Storage using the gRPC API.

--- a/google/cloud/storage/_experimental/async_grpc_client.py
+++ b/google/cloud/storage/_experimental/async_grpc_client.py
@@ -36,7 +36,7 @@ class AsyncGrpcClient:
     :type attempt_direct_path: bool
     :param attempt_direct_path:
         (Optional) Whether to attempt to use DirectPath for gRPC connections.
-        Defaults to ``False``.
+        Defaults to ``True``.
     """
 
     def __init__(
@@ -45,7 +45,7 @@ class AsyncGrpcClient:
         client_info=None,
         client_options=None,
         *,
-        attempt_direct_path=False,
+        attempt_direct_path=True,
     ):
         self._grpc_client = self._create_async_grpc_client(
             credentials=credentials,
@@ -59,7 +59,7 @@ class AsyncGrpcClient:
         credentials=None,
         client_info=None,
         client_options=None,
-        attempt_direct_path=False,
+        attempt_direct_path=True,
     ):
         transport_cls = storage_v2.StorageAsyncClient.get_transport_class("grpc_asyncio")
 

--- a/google/cloud/storage/_experimental/async_grpc_client.py
+++ b/google/cloud/storage/_experimental/async_grpc_client.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An async client for interacting with Google Cloud Storage using the gRPC API."""
+
+from google.cloud import storage_v2
+from google.api_core import client_options as client_options_lib
+
+
+class AsyncGrpcClient:
+    """An asynchronous client for interacting with Google Cloud Storage using the gRPC API.
+
+    :type credentials: :class:`~google.auth.credentials.Credentials`
+    :param credentials: (Optional) The OAuth2 Credentials to use for this
+                        client. If not passed, falls back to the default
+                        inferred from the environment.
+
+    :type client_info: :class:`~google.api_core.client_info.ClientInfo`
+    :param client_info:
+        The client info used to send a user-agent string along with API
+        requests. If ``None``, then default info will be used.
+
+    :type client_options: :class:`~google.api_core.client_options.ClientOptions` or :class:`dict`
+    :param client_options: (Optional) Client options used to set user options
+        on the client.
+
+    :type attempt_direct_path: bool
+    :param attempt_direct_path:
+        (Optional) Whether to attempt to use DirectPath for gRPC connections.
+        Defaults to ``False``.
+    """
+
+    def __init__(
+        self,
+        credentials=None,
+        client_info=None,
+        client_options=None,
+        *,
+        attempt_direct_path=False,
+    ):
+        self._grpc_client = self._create_async_grpc_client(
+            credentials=credentials,
+            client_info=client_info,
+            client_options=client_options,
+            attempt_direct_path=attempt_direct_path,
+        )
+
+    def _create_async_grpc_client(
+        self,
+        credentials=None,
+        client_info=None,
+        client_options=None,
+        attempt_direct_path=False,
+    ):
+        transport_cls = storage_v2.StorageAsyncClient.get_transport_class("grpc_asyncio")
+
+        transport = transport_cls(
+            credentials=credentials,
+            attempt_direct_path=attempt_direct_path,
+        )
+
+        return storage_v2.StorageAsyncClient(
+            credentials=credentials,
+            transport=transport,
+            client_info=client_info,
+            client_options=client_options,
+        )

--- a/tests/unit/test_async_grpc_client.py
+++ b/tests/unit/test_async_grpc_client.py
@@ -18,7 +18,7 @@ from google.auth import credentials as auth_credentials
 
 
 class TestAsyncGrpcClient(unittest.TestCase):
-    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
+    @mock.patch("google.cloud.storage_v2._experimental.StorageAsyncClient")
     def test_constructor_defaults_to_cloudpath(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 
@@ -32,7 +32,7 @@ class TestAsyncGrpcClient(unittest.TestCase):
             credentials=mock_creds, attempt_direct_path=False
         )
 
-    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
+    @mock.patch("google.cloud.storage_v2._experimental.StorageAsyncClient")
     def test_constructor_respects_directpath_true(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 

--- a/tests/unit/test_async_grpc_client.py
+++ b/tests/unit/test_async_grpc_client.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+from google.auth import credentials as auth_credentials
+
+
+class TestAsyncGrpcClient(unittest.TestCase):
+    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
+    def test_constructor_defaults_to_cloudpath(self, mock_async_storage_client):
+        from google.cloud.storage._experimental import async_grpc_client
+
+        mock_transport_cls = mock.MagicMock()
+        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_creds = mock.Mock(spec=auth_credentials.Credentials)
+
+        async_grpc_client.AsyncGrpcClient(credentials=mock_creds)
+
+        mock_transport_cls.assert_called_once_with(
+            credentials=mock_creds, attempt_direct_path=False
+        )
+
+    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
+    def test_constructor_respects_directpath_true(self, mock_async_storage_client):
+        from google.cloud.storage._experimental import async_grpc_client
+
+        mock_transport_cls = mock.MagicMock()
+        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_creds = mock.Mock(spec=auth_credentials.Credentials)
+
+        async_grpc_client.AsyncGrpcClient(
+            credentials=mock_creds, attempt_direct_path=True
+        )
+
+        mock_transport_cls.assert_called_once_with(
+            credentials=mock_creds, attempt_direct_path=True
+        )

--- a/tests/unit/test_async_grpc_client.py
+++ b/tests/unit/test_async_grpc_client.py
@@ -29,11 +29,11 @@ class TestAsyncGrpcClient(unittest.TestCase):
         async_grpc_client.AsyncGrpcClient(credentials=mock_creds)
 
         mock_transport_cls.assert_called_once_with(
-            credentials=mock_creds, attempt_direct_path=False
+            credentials=mock_creds, attempt_direct_path=True
         )
 
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
-    def test_constructor_respects_directpath_true(self, mock_async_storage_client):
+    def test_constructor_when_directpath_is_false(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 
         mock_transport_cls = mock.MagicMock()
@@ -41,9 +41,9 @@ class TestAsyncGrpcClient(unittest.TestCase):
         mock_creds = mock.Mock(spec=auth_credentials.Credentials)
 
         async_grpc_client.AsyncGrpcClient(
-            credentials=mock_creds, attempt_direct_path=True
+            credentials=mock_creds, attempt_direct_path=False
         )
 
         mock_transport_cls.assert_called_once_with(
-            credentials=mock_creds, attempt_direct_path=True
+            credentials=mock_creds, attempt_direct_path=False
         )

--- a/tests/unit/test_async_grpc_client.py
+++ b/tests/unit/test_async_grpc_client.py
@@ -18,7 +18,7 @@ from google.auth import credentials as auth_credentials
 
 
 class TestAsyncGrpcClient(unittest.TestCase):
-    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
+    @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
     def test_constructor_defaults_to_cloudpath(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 
@@ -32,7 +32,7 @@ class TestAsyncGrpcClient(unittest.TestCase):
             credentials=mock_creds, attempt_direct_path=False
         )
 
-    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
+    @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
     def test_constructor_respects_directpath_true(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 

--- a/tests/unit/test_async_grpc_client.py
+++ b/tests/unit/test_async_grpc_client.py
@@ -17,16 +17,20 @@ from unittest import mock
 from google.auth import credentials as auth_credentials
 
 
+def _make_credentials(spec=None):
+    if spec is None:
+        return mock.Mock(spec=auth_credentials.Credentials)
+    return mock.Mock(spec=spec)
+
+
 class TestAsyncGrpcClient(unittest.TestCase):
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
     def test_constructor_default_options(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 
         mock_transport_cls = mock.MagicMock()
-        mock_async_storage_client.get_transport_class.return_value = (
-            mock_transport_cls
-        )
-        mock_creds = mock.Mock(spec=auth_credentials.Credentials)
+        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_creds = _make_credentials()
 
         async_grpc_client.AsyncGrpcClient(credentials=mock_creds)
 
@@ -53,10 +57,8 @@ class TestAsyncGrpcClient(unittest.TestCase):
         from google.cloud.storage._experimental import async_grpc_client
 
         mock_transport_cls = mock.MagicMock()
-        mock_async_storage_client.get_transport_class.return_value = (
-            mock_transport_cls
-        )
-        mock_creds = mock.Mock(spec=auth_credentials.Credentials)
+        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_creds = _make_credentials()
 
         async_grpc_client.AsyncGrpcClient(
             credentials=mock_creds, attempt_direct_path=False
@@ -69,3 +71,15 @@ class TestAsyncGrpcClient(unittest.TestCase):
         mock_transport_cls.assert_called_once_with(
             credentials=mock_creds, channel=mock_channel
         )
+
+    @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
+    def test_grpc_client_property(self, mock_async_storage_client):
+        from google.cloud.storage._experimental import async_grpc_client
+
+        mock_creds = _make_credentials()
+
+        client = async_grpc_client.AsyncGrpcClient(credentials=mock_creds)
+
+        retrieved_client = client.grpc_client
+
+        self.assertIs(retrieved_client, mock_async_storage_client.return_value)

--- a/tests/unit/test_async_grpc_client.py
+++ b/tests/unit/test_async_grpc_client.py
@@ -18,7 +18,7 @@ from google.auth import credentials as auth_credentials
 
 
 class TestAsyncGrpcClient(unittest.TestCase):
-    @mock.patch("google.cloud.storage_v2._experimental.StorageAsyncClient")
+    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
     def test_constructor_defaults_to_cloudpath(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 
@@ -32,7 +32,7 @@ class TestAsyncGrpcClient(unittest.TestCase):
             credentials=mock_creds, attempt_direct_path=False
         )
 
-    @mock.patch("google.cloud.storage_v2._experimental.StorageAsyncClient")
+    @mock.patch("google.cloud.storage_v2.StorageAsyncClient")
     def test_constructor_respects_directpath_true(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 

--- a/tests/unit/test_async_grpc_client.py
+++ b/tests/unit/test_async_grpc_client.py
@@ -19,31 +19,53 @@ from google.auth import credentials as auth_credentials
 
 class TestAsyncGrpcClient(unittest.TestCase):
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
-    def test_constructor_defaults_to_cloudpath(self, mock_async_storage_client):
+    def test_constructor_default_options(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 
         mock_transport_cls = mock.MagicMock()
-        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_async_storage_client.get_transport_class.return_value = (
+            mock_transport_cls
+        )
         mock_creds = mock.Mock(spec=auth_credentials.Credentials)
 
         async_grpc_client.AsyncGrpcClient(credentials=mock_creds)
 
+        mock_async_storage_client.get_transport_class.assert_called_once_with(
+            "grpc_asyncio"
+        )
+        mock_transport_cls.create_channel.assert_called_once_with(
+            attempt_direct_path=True
+        )
+        mock_channel = mock_transport_cls.create_channel.return_value
         mock_transport_cls.assert_called_once_with(
-            credentials=mock_creds, attempt_direct_path=True
+            credentials=mock_creds, channel=mock_channel
+        )
+        mock_transport = mock_transport_cls.return_value
+        mock_async_storage_client.assert_called_once_with(
+            credentials=mock_creds,
+            transport=mock_transport,
+            client_options=None,
+            client_info=None,
         )
 
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
-    def test_constructor_when_directpath_is_false(self, mock_async_storage_client):
+    def test_constructor_disables_directpath(self, mock_async_storage_client):
         from google.cloud.storage._experimental import async_grpc_client
 
         mock_transport_cls = mock.MagicMock()
-        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_async_storage_client.get_transport_class.return_value = (
+            mock_transport_cls
+        )
         mock_creds = mock.Mock(spec=auth_credentials.Credentials)
 
         async_grpc_client.AsyncGrpcClient(
             credentials=mock_creds, attempt_direct_path=False
         )
 
+        mock_transport_cls.create_channel.assert_called_once_with(
+            attempt_direct_path=False
+        )
+        mock_channel = mock_transport_cls.create_channel.return_value
         mock_transport_cls.assert_called_once_with(
-            credentials=mock_creds, attempt_direct_path=False
+            credentials=mock_creds, channel=mock_channel
         )


### PR DESCRIPTION
Add async grpc client to allow users to interact with GCS using the gRPC APIs asynchronously.