### PR TITLE
fix: Make `download_ranges` compatible with `asyncio.create_task(..)`

### DIFF
--- a/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
+++ b/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
@@ -293,9 +293,9 @@ class AsyncMultiRangeDownloader:
                         read_ranges=read_ranges_for_bidi_req
                     )
                 )
-        self._download_ranges_id_to_pending_read_ids[_func_id] = (
-            read_ids_in_current_func
-        )
+        self._download_ranges_id_to_pending_read_ids[
+            _func_id
+        ] = read_ids_in_current_func
 
         while len(self._download_ranges_id_to_pending_read_ids[_func_id]) > 0:
             async with lock:

--- a/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
+++ b/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
@@ -266,7 +266,6 @@ class AsyncMultiRangeDownloader:
 
         _func_id = generate_random_56_bit_integer()
         read_ids_in_current_func = set()
-        results = []
         for i in range(0, len(read_ranges), _MAX_READ_RANGES_PER_BIDI_READ_REQUEST):
             read_ranges_segment = read_ranges[
                 i : i + _MAX_READ_RANGES_PER_BIDI_READ_REQUEST
@@ -279,7 +278,6 @@ class AsyncMultiRangeDownloader:
                 self._read_id_to_download_ranges_id[read_id] = _func_id
                 self._read_id_to_writable_buffer_dict[read_id] = read_range[2]
                 bytes_requested = read_range[1]
-                results.append(Result(bytes_requested))
                 read_ranges_for_bidi_req.append(
                     _storage_v2.ReadRange(
                         read_offset=read_range[0],

--- a/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
+++ b/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+import asyncio
 import google_crc32c
 from google.api_core import exceptions
 from google_crc32c import Checksum
@@ -29,6 +30,7 @@ from google.cloud.storage._experimental.asyncio.async_grpc_client import (
 from io import BytesIO
 from google.cloud import _storage_v2
 from google.cloud.storage.exceptions import DataCorruption
+from google.cloud.storage._helpers import generate_random_56_bit_integer
 
 
 _MAX_READ_RANGES_PER_BIDI_READ_REQUEST = 100
@@ -175,6 +177,10 @@ class AsyncMultiRangeDownloader:
         self.read_obj_str: Optional[_AsyncReadObjectStream] = None
         self._is_stream_open: bool = False
 
+        self._read_id_to_writable_buffer_dict = {}
+        self._read_id_to_dn_range_id = {}
+        self._download_ranges_id_to_pending_read_ids = {}
+
     async def open(self) -> None:
         """Opens the bidi-gRPC connection to read from the object.
 
@@ -203,8 +209,8 @@ class AsyncMultiRangeDownloader:
         return
 
     async def download_ranges(
-        self, read_ranges: List[Tuple[int, int, BytesIO]]
-    ) -> List[Result]:
+        self, read_ranges: List[Tuple[int, int, BytesIO]], lock: asyncio.Lock = None
+    ) -> None:
         """Downloads multiple byte ranges from the object into the buffers
         provided by user.
 
@@ -214,9 +220,15 @@ class AsyncMultiRangeDownloader:
             to be provided by the user, and user has to make sure appropriate
             memory is available in the application to avoid out-of-memory crash.
 
-        :rtype: List[:class:`~google.cloud.storage._experimental.asyncio.async_multi_range_downloader.Result`]
-        :returns: A list of ``Result`` objects, where each object corresponds
-                  to a requested range.
+        :type lock: asyncio.Lock
+        :param lock: (Optional) An asyncio lock to synchronize sends and recvs
+            on the underlying bidi-GRPC stream. This is required when multiple
+            coroutines are calling this method concurrently.
+
+
+        :raises ValueError: if the underlying bidi-GRPC stream is not open.
+        :raises ValueError: if the length of read_ranges is more than 1000.
+        :raises DataCorruption: if a checksum mismatch is detected while reading data.
 
         """
 
@@ -228,7 +240,11 @@ class AsyncMultiRangeDownloader:
         if not self._is_stream_open:
             raise ValueError("Underlying bidi-gRPC stream is not open")
 
-        read_id_to_writable_buffer_dict = {}
+        if lock is None:
+            lock = asyncio.Lock()
+
+        _func_id = generate_random_56_bit_integer()
+        read_ids_in_current_func = set()
         results = []
         for i in range(0, len(read_ranges), _MAX_READ_RANGES_PER_BIDI_READ_REQUEST):
             read_ranges_segment = read_ranges[
@@ -237,8 +253,10 @@ class AsyncMultiRangeDownloader:
 
             read_ranges_for_bidi_req = []
             for j, read_range in enumerate(read_ranges_segment):
-                read_id = i + j
-                read_id_to_writable_buffer_dict[read_id] = read_range[2]
+                read_id = generate_random_56_bit_integer()
+                read_ids_in_current_func.add(read_id)
+                self._read_id_to_dn_range_id[read_id] = _func_id
+                self._read_id_to_writable_buffer_dict[read_id] = read_range[2]
                 bytes_requested = read_range[1]
                 results.append(Result(bytes_requested))
                 read_ranges_for_bidi_req.append(
@@ -248,12 +266,19 @@ class AsyncMultiRangeDownloader:
                         read_id=read_id,
                     )
                 )
-            await self.read_obj_str.send(
-                _storage_v2.BidiReadObjectRequest(read_ranges=read_ranges_for_bidi_req)
-            )
+            async with lock:
+                await self.read_obj_str.send(
+                    _storage_v2.BidiReadObjectRequest(
+                        read_ranges=read_ranges_for_bidi_req
+                    )
+                )
+        self._download_ranges_id_to_pending_read_ids[_func_id] = (
+            read_ids_in_current_func
+        )
 
-        while len(read_id_to_writable_buffer_dict) > 0:
-            response = await self.read_obj_str.recv()
+        while len(self._download_ranges_id_to_pending_read_ids[_func_id]) > 0:
+            async with lock:
+                response = await self.read_obj_str.recv()
 
             if response is None:
                 raise Exception("None response received, something went wrong.")
@@ -277,16 +302,15 @@ class AsyncMultiRangeDownloader:
                     )
 
                 read_id = object_data_range.read_range.read_id
-                buffer = read_id_to_writable_buffer_dict[read_id]
+                buffer = self._read_id_to_writable_buffer_dict[read_id]
                 buffer.write(data)
-                results[read_id].bytes_written += len(data)
 
                 if object_data_range.range_end:
-                    del read_id_to_writable_buffer_dict[
-                        object_data_range.read_range.read_id
-                    ]
-
-        return results
+                    tmp_func_id = self._read_id_to_dn_range_id[read_id]
+                    self._download_ranges_id_to_pending_read_ids[tmp_func_id].remove(
+                        read_id
+                    )
+                    del self._read_id_to_dn_range_id[read_id]
 
     async def close(self):
         """

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -672,7 +672,16 @@ def _get_default_headers(
 
 
 def generate_random_56_bit_integer():
-    """Generates a secure 56 bit random integer."""
+    """Generates a secure 56 bit random integer.
+
+
+    If 64 bit int is used, sometimes the random int generated is greater than
+    max positive value of signed 64 bit int which is 2^63 -1 causing overflow
+    issues.
+
+    :rtype: int
+    :returns: A secure random 56 bit integer.
+    """
     # 7 bytes * 8 bits/byte = 56 bits
     random_bytes = secrets.token_bytes(7)
     # Convert bytes to an integer

--- a/google/cloud/storage/_helpers.py
+++ b/google/cloud/storage/_helpers.py
@@ -22,6 +22,7 @@ import datetime
 from hashlib import md5
 import os
 import sys
+import secrets
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 from uuid import uuid4
@@ -668,3 +669,11 @@ def _get_default_headers(
         "content-type": content_type,
         "x-upload-content-type": x_upload_content_type or content_type,
     }
+
+
+def generate_random_56_bit_integer():
+    """Generates a secure 56 bit random integer."""
+    # 7 bytes * 8 bits/byte = 56 bits
+    random_bytes = secrets.token_bytes(7)
+    # Convert bytes to an integer
+    return int.from_bytes(random_bytes, "big")

--- a/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -147,7 +147,7 @@ class TestAsyncMultiRangeDownloader:
 
         # Act
         buffer = BytesIO()
-        results = await mock_mrd.download_ranges([(0, 18, buffer)])
+        await mock_mrd.download_ranges([(0, 18, buffer)])
 
         # Assert
         mock_mrd.read_obj_str.send.assert_called_once_with(


### PR DESCRIPTION
Multiple `download_ranges` should be able to run via multiple async tasks in a single event loop. 

ie when a user runs a code like below , it works

```python
... # some code 
await mrd.download_ranges(...)
await mrd.download_ranges()
```
but when a user runs code like below it doesn't work. This PR is fixing this issue. More details in internal b/449916743

```python
... # some code 
task1 = asyncio.create_task(mrd.download_ranges(..))
task2 = asyncio.create_task(mrd.download_ranges(..))
_ = await asyncio.gather(task1, task2)
```

This PR achieves the above goal by

- converts `read_id_to_writable_buffer_dict` into a class attribute instead of local variable of `download_ranges`
- makes `read_id` random int, instead of ordered `i + j`
- Provide an id (random int) for each method.
- Add two more maps for keeping track of `read_id` to function_id and buffer
- Because reads on client-to-server stream can be made [one at a time](https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.StreamStreamCall.read), hence [asyncio.lock](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Lock) is used. 

