### PR TITLE
fix(bucket): Move blob fails when the new blob name contains characters that need to be url encoded

### DIFF
--- a/google/cloud/storage/bucket.py
+++ b/google/cloud/storage/bucket.py
@@ -41,6 +41,7 @@ from google.cloud.storage._helpers import _virtual_hosted_style_base_url
 from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage.acl import BucketACL
 from google.cloud.storage.acl import DefaultObjectACL
+from google.cloud.storage.blob import _quote
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.constants import ARCHIVE_STORAGE_CLASS
@@ -2360,7 +2361,10 @@ class Bucket(_PropertyMixin):
             )
 
             new_blob = Blob(bucket=self, name=new_name)
-            api_path = blob.path + "/moveTo/o/" + new_blob.name
+            api_path = "{blob_path}/moveTo/o/{new_name}".format(
+                blob_path=blob.path, new_name=_quote(new_blob.name)
+            )
+
             move_result = client._post_resource(
                 api_path,
                 None,


### PR DESCRIPTION
  fix(bucket): url encode new_name parameter in move_blob()

  The move_blob() method was not URL encoding the new_name parameter
  before passing it to the API call, unlike how the blob encodes its own
  path. This caused failures when moving blobs to paths with special
  characters.

  Added URL encoding for new_name to match the blob path encoding, as
  both names must fit in the API URL format: "{blob_path}/moveTo/o/{new_name}"

  Here's an example of what fails:
  ```python
  from google.cloud import storage
  gcs = storage.Client()
  bucket = gcs.bucket("")
  blob = bucket.get_blob("test/blob.csv")
  bucket.move_blob(
      blob, 
      new_name="test/blob2.csv"
  )
  ```

  Fixes #1523
