### PR TITLE
feat(experimental): add write resumption strategy

### DIFF
--- a/google/cloud/storage/_experimental/asyncio/retry/writes_resumption_strategy.py
+++ b/google/cloud/storage/_experimental/asyncio/retry/writes_resumption_strategy.py
@@ -47,7 +47,7 @@ class _WriteState:
         self.user_buffer = user_buffer
         self.persisted_size: int = 0
         self.bytes_sent: int = 0
-        self.write_handle: Union[bytes, Any, None] = None
+        self.write_handle: Union[bytes, storage_type.BidiWriteHandle, None] = None
         self.routing_token: Optional[str] = None
         self.is_complete: bool = False
 
@@ -64,9 +64,6 @@ class _WriteResumptionStrategy(_BaseResumptionStrategy):
         AppendObjectSpec. If resuming, the `write_handle` is added to that spec.
         """
         write_state: _WriteState = state["write_state"]
-
-        # Mark that we have generated the first request for this stream attempt
-        state["first_request"] = False
 
         if write_state.write_handle:
             write_state.spec.write_handle = write_state.write_handle
@@ -141,6 +138,3 @@ class _WriteResumptionStrategy(_BaseResumptionStrategy):
         # Reset the user buffer to the last known good byte.
         write_state.user_buffer.seek(write_state.persisted_size)
         write_state.bytes_sent = write_state.persisted_size
-
-        # Mark next pass as a retry (not the absolute first request)
-        state["first_request"] = False

--- a/google/cloud/storage/_experimental/asyncio/retry/writes_resumption_strategy.py
+++ b/google/cloud/storage/_experimental/asyncio/retry/writes_resumption_strategy.py
@@ -1,0 +1,146 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, IO, Iterable, Optional, Union
+
+import google_crc32c
+from google.cloud._storage_v2.types import storage as storage_type
+from google.cloud._storage_v2.types.storage import BidiWriteObjectRedirectedError
+from google.cloud.storage._experimental.asyncio.retry.base_strategy import (
+    _BaseResumptionStrategy,
+)
+
+
+class _WriteState:
+    """A helper class to track the state of a single upload operation.
+
+    Attributes:
+        spec (AppendObjectSpec): The specification for the object to write.
+        chunk_size (int): The size of chunks to read from the buffer.
+        user_buffer (IO[bytes]): The data source.
+        persisted_size (int): The amount of data confirmed as persisted by the server.
+        bytes_sent (int): The amount of data currently sent in the active stream.
+        write_handle (bytes | BidiWriteHandle | None): The handle for the append session.
+        routing_token (str | None): Token for routing to the correct backend.
+        is_complete (bool): Whether the upload has finished.
+    """
+
+    def __init__(
+        self,
+        spec: storage_type.AppendObjectSpec,
+        chunk_size: int,
+        user_buffer: IO[bytes],
+    ):
+        self.spec = spec
+        self.chunk_size = chunk_size
+        self.user_buffer = user_buffer
+        self.persisted_size: int = 0
+        self.bytes_sent: int = 0
+        self.write_handle: Union[bytes, Any, None] = None
+        self.routing_token: Optional[str] = None
+        self.is_complete: bool = False
+
+
+class _WriteResumptionStrategy(_BaseResumptionStrategy):
+    """The concrete resumption strategy for bidi writes."""
+
+    def generate_requests(
+        self, state: Dict[str, Any]
+    ) -> Iterable[storage_type.BidiWriteObjectRequest]:
+        """Generates BidiWriteObjectRequests to resume or continue the upload.
+
+        For Appendable Objects, every stream opening should send an
+        AppendObjectSpec. If resuming, the `write_handle` is added to that spec.
+        """
+        write_state: _WriteState = state["write_state"]
+
+        # Mark that we have generated the first request for this stream attempt
+        state["first_request"] = False
+
+        if write_state.write_handle:
+            write_state.spec.write_handle = write_state.write_handle
+
+        if write_state.routing_token:
+            write_state.spec.routing_token = write_state.routing_token
+
+        do_state_lookup = write_state.write_handle is not None
+        yield storage_type.BidiWriteObjectRequest(
+            append_object_spec=write_state.spec, state_lookup=do_state_lookup
+        )
+
+        # The buffer should already be seeked to the correct position (persisted_size)
+        # by the `recover_state_on_failure` method before this is called.
+        while not write_state.is_complete:
+            chunk = write_state.user_buffer.read(write_state.chunk_size)
+
+            # End of File detection
+            if not chunk:
+                write_state.is_complete = True
+                yield storage_type.BidiWriteObjectRequest(
+                    write_offset=write_state.bytes_sent,
+                    finish_write=True,
+                )
+                return
+
+            checksummed_data = storage_type.ChecksummedData(content=chunk)
+            checksum = google_crc32c.Checksum(chunk)
+            checksummed_data.crc32c = int.from_bytes(checksum.digest(), "big")
+
+            request = storage_type.BidiWriteObjectRequest(
+                write_offset=write_state.bytes_sent,
+                checksummed_data=checksummed_data,
+            )
+            write_state.bytes_sent += len(chunk)
+
+            yield request
+
+    def update_state_from_response(
+        self, response: storage_type.BidiWriteObjectResponse, state: Dict[str, Any]
+    ) -> None:
+        """Processes a server response and updates the write state."""
+        write_state: _WriteState = state["write_state"]
+
+        if response.persisted_size is not None:
+            if response.persisted_size > write_state.persisted_size:
+                write_state.persisted_size = response.persisted_size
+
+        if response.write_handle:
+            write_state.write_handle = response.write_handle
+
+        if response.resource:
+            write_state.is_complete = True
+            write_state.persisted_size = response.resource.size
+
+    async def recover_state_on_failure(
+        self, error: Exception, state: Dict[str, Any]
+    ) -> None:
+        """Handles errors, specifically BidiWriteObjectRedirectedError, and rewinds state."""
+        write_state: _WriteState = state["write_state"]
+        cause = getattr(error, "cause", error)
+
+        # Extract routing token and potentially a new write handle.
+        if isinstance(cause, BidiWriteObjectRedirectedError):
+            if cause.routing_token:
+                write_state.routing_token = cause.routing_token
+
+            if hasattr(cause, "write_handle") and cause.write_handle:
+                write_state.write_handle = cause.write_handle
+
+        # We must assume any data sent beyond 'persisted_size' was lost.
+        # Reset the user buffer to the last known good byte.
+        write_state.user_buffer.seek(write_state.persisted_size)
+        write_state.bytes_sent = write_state.persisted_size
+
+        # Mark next pass as a retry (not the absolute first request)
+        state["first_request"] = False

--- a/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
+++ b/tests/unit/asyncio/retry/test_reads_resumption_strategy.py
@@ -27,7 +27,9 @@ from google.cloud.storage._experimental.asyncio.retry.reads_resumption_strategy 
 from google.cloud._storage_v2.types.storage import BidiReadObjectRedirectedError
 
 _READ_ID = 1
-LOGGER_NAME = "google.cloud.storage._experimental.asyncio.retry.reads_resumption_strategy"
+LOGGER_NAME = (
+    "google.cloud.storage._experimental.asyncio.retry.reads_resumption_strategy"
+)
 
 
 class TestDownloadState(unittest.TestCase):
@@ -309,7 +311,9 @@ class TestReadResumptionStrategy(unittest.TestCase):
         with self.assertLogs(LOGGER_NAME, level="WARNING") as cm:
             self.strategy.update_state_from_response(response, self.state)
 
-        self.assertTrue(any("missing read_range field" in output for output in cm.output))
+        self.assertTrue(
+            any("missing read_range field" in output for output in cm.output)
+        )
 
     def test_update_state_unknown_id_logs_warning(self):
         """Verify we log a warning and continue when read_id is unknown."""
@@ -320,8 +324,12 @@ class TestReadResumptionStrategy(unittest.TestCase):
         with self.assertLogs(LOGGER_NAME, level="WARNING") as cm:
             self.strategy.update_state_from_response(response, self.state)
 
-        self.assertTrue(any(f"unknown or stale read_id {unknown_id}" in output for output in cm.output))
-
+        self.assertTrue(
+            any(
+                f"unknown or stale read_id {unknown_id}" in output
+                for output in cm.output
+            )
+        )
 
     # --- Recovery Tests ---
 

--- a/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
+++ b/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
@@ -1,0 +1,328 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import unittest
+import unittest.mock as mock
+
+import pytest
+import google_crc32c
+
+from google.cloud._storage_v2.types import storage as storage_type
+from google.cloud.storage._experimental.asyncio.retry.writes_resumption_strategy import (
+    _WriteState,
+    _WriteResumptionStrategy,
+)
+from google.cloud._storage_v2.types.storage import BidiWriteObjectRedirectedError
+
+
+class TestWriteResumptionStrategy(unittest.TestCase):
+    def _get_target_class(self):
+        return _WriteResumptionStrategy
+
+    def _make_one(self, *args, **kwargs):
+        return self._get_target_class()(*args, **kwargs)
+
+    def test_ctor(self):
+        strategy = self._make_one()
+        self.assertIsInstance(strategy, self._get_target_class())
+
+    def test_generate_requests_initial(self):
+        """
+        Verify the initial request sequence for a new upload.
+        - First request is AppendObjectSpec with state_lookup=False.
+        - Following requests are data chunks.
+        - Final request has finish_write=True.
+        """
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"0123456789")
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+        state = {
+            "write_state": _WriteState(
+                mock_spec, chunk_size=4, user_buffer=mock_buffer
+            ),
+            "first_request": True,
+        }
+
+        requests = list(strategy.generate_requests(state))
+
+        self.assertEqual(requests[0].append_object_spec, mock_spec)
+        self.assertFalse(requests[0].state_lookup)
+        self.assertFalse(requests[0].append_object_spec.write_handle)
+
+        self.assertEqual(requests[1].write_offset, 0)
+        self.assertEqual(requests[1].checksummed_data.content, b"0123")
+        self.assertEqual(requests[2].write_offset, 4)
+        self.assertEqual(requests[2].checksummed_data.content, b"4567")
+        self.assertEqual(requests[3].write_offset, 8)
+        self.assertEqual(requests[3].checksummed_data.content, b"89")
+
+        self.assertEqual(requests[4].write_offset, 10)
+        self.assertTrue(requests[4].finish_write)
+
+        self.assertEqual(len(requests), 5)
+
+    def test_generate_requests_empty_file(self):
+        """
+        Verify the request sequence for an empty file upload.
+        - First request is AppendObjectSpec.
+        - Second and final request has finish_write=True.
+        """
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"")
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+        state = {
+            "write_state": _WriteState(
+                mock_spec, chunk_size=4, user_buffer=mock_buffer
+            ),
+            "first_request": True,
+        }
+
+        requests = list(strategy.generate_requests(state))
+
+        self.assertEqual(requests[0].append_object_spec, mock_spec)
+        self.assertFalse(requests[0].state_lookup)
+
+        self.assertEqual(requests[1].write_offset, 0)
+        self.assertTrue(requests[1].finish_write)
+
+        self.assertEqual(len(requests), 2)
+
+    def test_generate_requests_resumption(self):
+        """
+        Verify request sequence when resuming an upload.
+        - First request is AppendObjectSpec with write_handle and state_lookup=True.
+        - Data streaming starts from the persisted_size.
+        """
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"0123456789")
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+
+        write_state = _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
+        write_state.persisted_size = 4
+        write_state.bytes_sent = 4
+        write_state.write_handle = storage_type.BidiWriteHandle(handle=b"test-handle")
+        mock_buffer.seek(4)
+
+        state = {"write_state": write_state, "first_request": True}
+
+        requests = list(strategy.generate_requests(state))
+
+        self.assertEqual(
+            requests[0].append_object_spec.write_handle.handle, b"test-handle"
+        )
+        self.assertTrue(requests[0].state_lookup)
+
+        self.assertEqual(requests[1].write_offset, 4)
+        self.assertEqual(requests[1].checksummed_data.content, b"4567")
+        self.assertEqual(requests[2].write_offset, 8)
+        self.assertEqual(requests[2].checksummed_data.content, b"89")
+
+        self.assertEqual(requests[3].write_offset, 10)
+        self.assertTrue(requests[3].finish_write)
+
+        self.assertEqual(len(requests), 4)
+
+    @pytest.mark.asyncio
+    async def test_generate_requests_after_failure_and_recovery(self):
+        """
+        Verify a complex scenario:
+        1. Start upload.
+        2. Receive a persisted_size update.
+        3. Encounter an error.
+        4. Recover state.
+        5. Generate new requests for resumption.
+        """
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"0123456789abcdef")
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+        state = {
+            "write_state": _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
+        }
+        write_state = state["write_state"]
+
+        write_state.bytes_sent = 8
+        mock_buffer.seek(8)
+
+        strategy.update_state_from_response(
+            storage_type.BidiWriteObjectResponse(
+                persisted_size=4, write_handle=b"handle-1"
+            ),
+            state,
+        )
+        self.assertEqual(write_state.persisted_size, 4)
+        self.assertEqual(write_state.write_handle, b"handle-1")
+
+        await strategy.recover_state_on_failure(Exception("network error"), state)
+
+        self.assertEqual(mock_buffer.tell(), 4)
+        self.assertEqual(write_state.bytes_sent, 4)
+
+        requests = list(strategy.generate_requests(state))
+
+        self.assertTrue(requests[0].state_lookup)
+        self.assertEqual(requests[0].append_object_spec.write_handle, b"handle-1")
+
+        self.assertEqual(requests[1].write_offset, 4)
+        self.assertEqual(requests[1].checksummed_data.content, b"4567")
+        self.assertEqual(requests[2].write_offset, 8)
+        self.assertEqual(requests[2].checksummed_data.content, b"89ab")
+        self.assertEqual(requests[3].write_offset, 12)
+        self.assertEqual(requests[3].checksummed_data.content, b"cdef")
+
+        self.assertEqual(requests[4].write_offset, 16)
+        self.assertTrue(requests[4].finish_write)
+        self.assertEqual(len(requests), 5)
+
+    def test_update_state_from_response(self):
+        """
+        Verify that the write state is correctly updated based on server responses.
+        """
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"0123456789")
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+        state = {
+            "write_state": _WriteState(
+                mock_spec, chunk_size=4, user_buffer=mock_buffer
+            ),
+        }
+        write_state = state["write_state"]
+
+        response1 = storage_type.BidiWriteObjectResponse(
+            write_handle=storage_type.BidiWriteHandle(handle=b"handle-1")
+        )
+        strategy.update_state_from_response(response1, state)
+        self.assertEqual(write_state.write_handle.handle, b"handle-1")
+
+        response2 = storage_type.BidiWriteObjectResponse(persisted_size=1024)
+        strategy.update_state_from_response(response2, state)
+        self.assertEqual(write_state.persisted_size, 1024)
+
+        final_resource = storage_type.Object(name="test-object", bucket="b", size=2048)
+        response3 = storage_type.BidiWriteObjectResponse(resource=final_resource)
+        strategy.update_state_from_response(response3, state)
+        self.assertTrue(write_state.is_complete)
+        self.assertEqual(write_state.persisted_size, 2048)
+
+    def test_update_state_from_response_ignores_smaller_persisted_size(self):
+        strategy = self._make_one()
+        state = {
+            "write_state": _WriteState(None, 0, None),
+        }
+        write_state = state["write_state"]
+        write_state.persisted_size = 2048
+
+        response = storage_type.BidiWriteObjectResponse(persisted_size=1024)
+        strategy.update_state_from_response(response, state)
+
+        self.assertEqual(write_state.persisted_size, 2048)
+
+    @pytest.mark.asyncio
+    async def test_recover_state_on_failure_rewinds_state(self):
+        """
+        Verify that on failure, the buffer is seeked to persisted_size
+        and bytes_sent is reset.
+        """
+        strategy = self._make_one()
+        mock_buffer = mock.MagicMock(spec=io.BytesIO)
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+
+        write_state = _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
+        write_state.persisted_size = 100
+        write_state.bytes_sent = 200
+        state = {"write_state": write_state}
+
+        await strategy.recover_state_on_failure(Exception("any error"), state)
+
+        mock_buffer.seek.assert_called_once_with(100)
+        self.assertEqual(write_state.bytes_sent, 100)
+
+    @pytest.mark.asyncio
+    async def test_recover_state_on_failure_handles_redirect(self):
+        """
+        Verify that on a redirect error, the routing_token is extracted and stored.
+        """
+        strategy = self._make_one()
+        mock_buffer = mock.MagicMock(spec=io.BytesIO)
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+
+        write_state = _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
+        state = {"write_state": write_state}
+
+        redirect_error = BidiWriteObjectRedirectedError(routing_token="new-token-123")
+        wrapped_error = Exception("RPC error")
+        wrapped_error.cause = redirect_error
+
+        await strategy.recover_state_on_failure(wrapped_error, state)
+
+        self.assertEqual(write_state.routing_token, "new-token-123")
+        mock_buffer.seek.assert_called_once_with(0)
+        self.assertEqual(write_state.bytes_sent, 0)
+
+    @pytest.mark.asyncio
+    async def test_recover_state_on_failure_handles_redirect_with_handle(self):
+        strategy = self._make_one()
+        mock_buffer = mock.MagicMock(spec=io.BytesIO)
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+
+        write_state = _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
+        state = {"write_state": write_state}
+
+        redirect_error = BidiWriteObjectRedirectedError(
+            routing_token="new-token-456", write_handle=b"redirect-handle"
+        )
+        wrapped_error = Exception("RPC error")
+        wrapped_error.cause = redirect_error
+
+        await strategy.recover_state_on_failure(wrapped_error, state)
+
+        self.assertEqual(write_state.routing_token, "new-token-456")
+        self.assertEqual(write_state.write_handle, b"redirect-handle")
+
+        mock_buffer.seek.assert_called_once_with(0)
+        self.assertEqual(write_state.bytes_sent, 0)
+
+    def test_generate_requests_sends_crc32c_checksum(self):
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"0123")
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+        state = {
+            "write_state": _WriteState(
+                mock_spec, chunk_size=4, user_buffer=mock_buffer
+            ),
+            "first_request": True,
+        }
+
+        requests = list(strategy.generate_requests(state))
+
+        self.assertEqual(len(requests), 3)
+
+        expected_crc = google_crc32c.Checksum(b"0123")
+        expected_crc_int = int.from_bytes(expected_crc.digest(), "big")
+        self.assertEqual(requests[1].checksummed_data.crc32c, expected_crc_int)
+
+    def test_generate_requests_with_routing_token(self):
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"")
+        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+
+        write_state = _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
+        write_state.routing_token = "redirected-token"
+        state = {"write_state": write_state, "first_request": True}
+
+        requests = list(strategy.generate_requests(state))
+
+        self.assertEqual(
+            requests[0].append_object_spec.routing_token, "redirected-token"
+        )

--- a/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
+++ b/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
@@ -218,7 +218,11 @@ class TestWriteResumptionStrategy(unittest.TestCase):
     def test_update_state_from_response_ignores_smaller_persisted_size(self):
         strategy = self._make_one()
         state = {
-            "write_state": _WriteState(None, 0, None),
+            "write_state": _WriteState(
+                mock.Mock(spec=storage_type.AppendObjectSpec),
+                0,
+                mock.Mock(spec=io.BytesIO),
+            ),
         }
         write_state = state["write_state"]
         write_state.persisted_size = 2048

--- a/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
+++ b/tests/unit/asyncio/retry/test_writes_resumption_strategy.py
@@ -38,29 +38,29 @@ class TestWriteResumptionStrategy(unittest.TestCase):
         strategy = self._make_one()
         self.assertIsInstance(strategy, self._get_target_class())
 
-    def test_generate_requests_initial(self):
+    def test_generate_requests_initial_new_object(self):
         """
-        Verify the initial request sequence for a new upload.
-        - First request is AppendObjectSpec with state_lookup=False.
-        - Following requests are data chunks.
-        - Final request has finish_write=True.
+        Verify the initial request sequence for a new upload (WriteObjectSpec).
         """
         strategy = self._make_one()
         mock_buffer = io.BytesIO(b"0123456789")
-        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
+        # Use WriteObjectSpec for new objects
+        mock_spec = storage_type.WriteObjectSpec(
+            resource=storage_type.Object(name="test-object")
+        )
         state = {
             "write_state": _WriteState(
                 mock_spec, chunk_size=4, user_buffer=mock_buffer
             ),
-            "first_request": True,
         }
 
         requests = list(strategy.generate_requests(state))
 
-        self.assertEqual(requests[0].append_object_spec, mock_spec)
+        # Check first request (Spec)
+        self.assertEqual(requests[0].write_object_spec, mock_spec)
         self.assertFalse(requests[0].state_lookup)
-        self.assertFalse(requests[0].append_object_spec.write_handle)
 
+        # Check data chunks
         self.assertEqual(requests[1].write_offset, 0)
         self.assertEqual(requests[1].checksummed_data.content, b"0123")
         self.assertEqual(requests[2].write_offset, 4)
@@ -68,16 +68,38 @@ class TestWriteResumptionStrategy(unittest.TestCase):
         self.assertEqual(requests[3].write_offset, 8)
         self.assertEqual(requests[3].checksummed_data.content, b"89")
 
-        self.assertEqual(requests[4].write_offset, 10)
-        self.assertTrue(requests[4].finish_write)
+        # Total requests: 1 Spec + 3 Chunks
+        self.assertEqual(len(requests), 4)
 
-        self.assertEqual(len(requests), 5)
+    def test_generate_requests_initial_existing_object(self):
+        """
+        Verify the initial request sequence for appending to an existing object (AppendObjectSpec).
+        """
+        strategy = self._make_one()
+        mock_buffer = io.BytesIO(b"0123")
+        # Use AppendObjectSpec for existing objects
+        mock_spec = storage_type.AppendObjectSpec(
+            object_="test-object", bucket="test-bucket"
+        )
+        state = {
+            "write_state": _WriteState(
+                mock_spec, chunk_size=4, user_buffer=mock_buffer
+            ),
+        }
+
+        requests = list(strategy.generate_requests(state))
+
+        # Check first request (Spec)
+        self.assertEqual(requests[0].append_object_spec, mock_spec)
+        self.assertFalse(requests[0].state_lookup)
+
+        # Check data chunk
+        self.assertEqual(requests[1].write_offset, 0)
+        self.assertEqual(requests[1].checksummed_data.content, b"0123")
 
     def test_generate_requests_empty_file(self):
         """
-        Verify the request sequence for an empty file upload.
-        - First request is AppendObjectSpec.
-        - Second and final request has finish_write=True.
+        Verify request sequence for an empty file. Should just be the Spec.
         """
         strategy = self._make_one()
         mock_buffer = io.BytesIO(b"")
@@ -86,24 +108,16 @@ class TestWriteResumptionStrategy(unittest.TestCase):
             "write_state": _WriteState(
                 mock_spec, chunk_size=4, user_buffer=mock_buffer
             ),
-            "first_request": True,
         }
 
         requests = list(strategy.generate_requests(state))
 
+        self.assertEqual(len(requests), 1)
         self.assertEqual(requests[0].append_object_spec, mock_spec)
-        self.assertFalse(requests[0].state_lookup)
-
-        self.assertEqual(requests[1].write_offset, 0)
-        self.assertTrue(requests[1].finish_write)
-
-        self.assertEqual(len(requests), 2)
 
     def test_generate_requests_resumption(self):
         """
         Verify request sequence when resuming an upload.
-        - First request is AppendObjectSpec with write_handle and state_lookup=True.
-        - Data streaming starts from the persisted_size.
         """
         strategy = self._make_one()
         mock_buffer = io.BytesIO(b"0123456789")
@@ -115,34 +129,26 @@ class TestWriteResumptionStrategy(unittest.TestCase):
         write_state.write_handle = storage_type.BidiWriteHandle(handle=b"test-handle")
         mock_buffer.seek(4)
 
-        state = {"write_state": write_state, "first_request": True}
+        state = {"write_state": write_state}
 
         requests = list(strategy.generate_requests(state))
 
+        # Check first request has handle and lookup
         self.assertEqual(
             requests[0].append_object_spec.write_handle.handle, b"test-handle"
         )
         self.assertTrue(requests[0].state_lookup)
 
+        # Check data starts from offset 4
         self.assertEqual(requests[1].write_offset, 4)
         self.assertEqual(requests[1].checksummed_data.content, b"4567")
         self.assertEqual(requests[2].write_offset, 8)
         self.assertEqual(requests[2].checksummed_data.content, b"89")
 
-        self.assertEqual(requests[3].write_offset, 10)
-        self.assertTrue(requests[3].finish_write)
-
-        self.assertEqual(len(requests), 4)
-
     @pytest.mark.asyncio
     async def test_generate_requests_after_failure_and_recovery(self):
         """
-        Verify a complex scenario:
-        1. Start upload.
-        2. Receive a persisted_size update.
-        3. Encounter an error.
-        4. Recover state.
-        5. Generate new requests for resumption.
+        Verify recovery and resumption flow.
         """
         strategy = self._make_one()
         mock_buffer = io.BytesIO(b"0123456789abcdef")
@@ -157,12 +163,11 @@ class TestWriteResumptionStrategy(unittest.TestCase):
 
         strategy.update_state_from_response(
             storage_type.BidiWriteObjectResponse(
-                persisted_size=4, write_handle=b"handle-1"
+                persisted_size=4,
+                write_handle=storage_type.BidiWriteHandle(handle=b"handle-1"),
             ),
             state,
         )
-        self.assertEqual(write_state.persisted_size, 4)
-        self.assertEqual(write_state.write_handle, b"handle-1")
 
         await strategy.recover_state_on_failure(Exception("network error"), state)
 
@@ -172,23 +177,15 @@ class TestWriteResumptionStrategy(unittest.TestCase):
         requests = list(strategy.generate_requests(state))
 
         self.assertTrue(requests[0].state_lookup)
-        self.assertEqual(requests[0].append_object_spec.write_handle, b"handle-1")
+        self.assertEqual(
+            requests[0].append_object_spec.write_handle.handle, b"handle-1"
+        )
 
         self.assertEqual(requests[1].write_offset, 4)
         self.assertEqual(requests[1].checksummed_data.content, b"4567")
-        self.assertEqual(requests[2].write_offset, 8)
-        self.assertEqual(requests[2].checksummed_data.content, b"89ab")
-        self.assertEqual(requests[3].write_offset, 12)
-        self.assertEqual(requests[3].checksummed_data.content, b"cdef")
-
-        self.assertEqual(requests[4].write_offset, 16)
-        self.assertTrue(requests[4].finish_write)
-        self.assertEqual(len(requests), 5)
 
     def test_update_state_from_response(self):
-        """
-        Verify that the write state is correctly updated based on server responses.
-        """
+        """Verify state updates from server responses."""
         strategy = self._make_one()
         mock_buffer = io.BytesIO(b"0123456789")
         mock_spec = storage_type.AppendObjectSpec(object_="test-object")
@@ -233,29 +230,9 @@ class TestWriteResumptionStrategy(unittest.TestCase):
         self.assertEqual(write_state.persisted_size, 2048)
 
     @pytest.mark.asyncio
-    async def test_recover_state_on_failure_rewinds_state(self):
-        """
-        Verify that on failure, the buffer is seeked to persisted_size
-        and bytes_sent is reset.
-        """
-        strategy = self._make_one()
-        mock_buffer = mock.MagicMock(spec=io.BytesIO)
-        mock_spec = storage_type.AppendObjectSpec(object_="test-object")
-
-        write_state = _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
-        write_state.persisted_size = 100
-        write_state.bytes_sent = 200
-        state = {"write_state": write_state}
-
-        await strategy.recover_state_on_failure(Exception("any error"), state)
-
-        mock_buffer.seek.assert_called_once_with(100)
-        self.assertEqual(write_state.bytes_sent, 100)
-
-    @pytest.mark.asyncio
     async def test_recover_state_on_failure_handles_redirect(self):
         """
-        Verify that on a redirect error, the routing_token is extracted and stored.
+        Verify redirection error handling.
         """
         strategy = self._make_one()
         mock_buffer = mock.MagicMock(spec=io.BytesIO)
@@ -271,11 +248,11 @@ class TestWriteResumptionStrategy(unittest.TestCase):
         await strategy.recover_state_on_failure(wrapped_error, state)
 
         self.assertEqual(write_state.routing_token, "new-token-123")
-        mock_buffer.seek.assert_called_once_with(0)
-        self.assertEqual(write_state.bytes_sent, 0)
+        mock_buffer.seek.assert_called_with(0)
 
     @pytest.mark.asyncio
     async def test_recover_state_on_failure_handles_redirect_with_handle(self):
+        """Verify redirection that includes a write handle."""
         strategy = self._make_one()
         mock_buffer = mock.MagicMock(spec=io.BytesIO)
         mock_spec = storage_type.AppendObjectSpec(object_="test-object")
@@ -294,8 +271,7 @@ class TestWriteResumptionStrategy(unittest.TestCase):
         self.assertEqual(write_state.routing_token, "new-token-456")
         self.assertEqual(write_state.write_handle, b"redirect-handle")
 
-        mock_buffer.seek.assert_called_once_with(0)
-        self.assertEqual(write_state.bytes_sent, 0)
+        mock_buffer.seek.assert_called_with(0)
 
     def test_generate_requests_sends_crc32c_checksum(self):
         strategy = self._make_one()
@@ -305,12 +281,9 @@ class TestWriteResumptionStrategy(unittest.TestCase):
             "write_state": _WriteState(
                 mock_spec, chunk_size=4, user_buffer=mock_buffer
             ),
-            "first_request": True,
         }
 
         requests = list(strategy.generate_requests(state))
-
-        self.assertEqual(len(requests), 3)
 
         expected_crc = google_crc32c.Checksum(b"0123")
         expected_crc_int = int.from_bytes(expected_crc.digest(), "big")
@@ -323,7 +296,7 @@ class TestWriteResumptionStrategy(unittest.TestCase):
 
         write_state = _WriteState(mock_spec, chunk_size=4, user_buffer=mock_buffer)
         write_state.routing_token = "redirected-token"
-        state = {"write_state": write_state, "first_request": True}
+        state = {"write_state": write_state}
 
         requests = list(strategy.generate_requests(state))
 

--- a/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -143,7 +143,6 @@ class TestAsyncMultiRangeDownloader:
                     )
                 ]
             ),
-            None,
             _storage_v2.BidiReadObjectResponse(
                 object_data_ranges=[
                     _storage_v2.ObjectRangeData(

--- a/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -36,7 +36,6 @@ _TEST_READ_HANDLE = b"test-handle"
 
 
 class TestAsyncMultiRangeDownloader:
-
     def create_read_ranges(self, num_ranges):
         ranges = []
         for i in range(num_ranges):

--- a/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -36,6 +36,7 @@ _TEST_READ_HANDLE = b"test-handle"
 
 
 class TestAsyncMultiRangeDownloader:
+
     def create_read_ranges(self, num_ranges):
         ranges = []
         for i in range(num_ranges):
@@ -143,6 +144,7 @@ class TestAsyncMultiRangeDownloader:
                     )
                 ]
             ),
+            None,
             _storage_v2.BidiReadObjectResponse(
                 object_data_ranges=[
                     _storage_v2.ObjectRangeData(


### PR DESCRIPTION
Adding writes resumption strategy which will be used for error handling of bidi writes operation. 
