### PR TITLE
feat: compute chunk wise checksum for bidi_writes

### DIFF
--- a/google/cloud/storage/_experimental/asyncio/_utils.py
+++ b/google/cloud/storage/_experimental/asyncio/_utils.py
@@ -1,6 +1,6 @@
 import google_crc32c
 
-from google.cloud.storage import exceptions
+from google.api_core import exceptions
 
 def raise_if_no_fast_crc32c():
     """Check if the C-accelerated version of google-crc32c is available.

--- a/google/cloud/storage/_experimental/asyncio/_utils.py
+++ b/google/cloud/storage/_experimental/asyncio/_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import google_crc32c
 
 from google.api_core import exceptions

--- a/google/cloud/storage/_experimental/asyncio/_utils.py
+++ b/google/cloud/storage/_experimental/asyncio/_utils.py
@@ -1,0 +1,20 @@
+import google_crc32c
+
+from google.cloud.storage import exceptions
+
+def raise_if_no_fast_crc32c():
+    """Check if the C-accelerated version of google-crc32c is available.
+
+    If not, raise an error to prevent silent performance degradation.
+    
+    raises google.api_core.exceptions.NotFound: If the C extension is not available.
+    returns: True if the C extension is available.
+    rtype: bool
+    
+    """
+    if google_crc32c.implementation != "c":
+        raise exceptions.NotFound(
+            "The google-crc32c package is not installed with C support. "
+            "Bidi reads require the C extension for data integrity checks."
+            "For more information, see https://github.com/googleapis/python-crc32c."
+        )

--- a/google/cloud/storage/_experimental/asyncio/_utils.py
+++ b/google/cloud/storage/_experimental/asyncio/_utils.py
@@ -20,15 +20,15 @@ def raise_if_no_fast_crc32c():
     """Check if the C-accelerated version of google-crc32c is available.
 
     If not, raise an error to prevent silent performance degradation.
-    
-    raises google.api_core.exceptions.NotFound: If the C extension is not available.
+
+    raises google.api_core.exceptions.FailedPrecondition: If the C extension is not available.
     returns: True if the C extension is available.
     rtype: bool
     
     """
     if google_crc32c.implementation != "c":
-        raise exceptions.NotFound(
+        raise exceptions.FailedPrecondition(
             "The google-crc32c package is not installed with C support. "
-            "Bidi reads require the C extension for data integrity checks."
+            "C extension is required for faster data integrity checks."
             "For more information, see https://github.com/googleapis/python-crc32c."
         )

--- a/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
+++ b/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
@@ -21,9 +21,13 @@ GA(Generally Available) yet, please contact your TAM (Technical Account Manager)
 if you want to use these Rapid Storage APIs.
 
 """
+import time
 from typing import Optional, Union
+
 from google.api_core import exceptions
-from google_crc32c import Checksum, implementation as crc32c_impl
+from google_crc32c import Checksum
+
+from ._utils import raise_if_no_fast_crc32c
 from google.cloud import _storage_v2
 from google.cloud.storage._experimental.asyncio.async_grpc_client import (
     AsyncGrpcClient,
@@ -102,14 +106,7 @@ class AsyncAppendableObjectWriter:
         :param write_handle: (Optional) An existing handle for writing the object.
                             If provided, opening the bidi-gRPC connection will be faster.
         """
-        # Verify that the fast, C-accelerated version of crc32c is available.
-        # If not, raise an error to prevent silent performance degradation.
-        if crc32c_impl != "c":
-            raise exceptions.NotFound(
-                "The google-crc32c package is not installed with C support. "
-                "Bidi reads require the C extension for data integrity checks."
-                "For more information, see https://github.com/googleapis/python-crc32c."
-            )
+        raise_if_no_fast_crc32c()
         self.client = client
         self.bucket_name = bucket_name
         self.object_name = object_name

--- a/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
+++ b/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
@@ -21,10 +21,8 @@ GA(Generally Available) yet, please contact your TAM (Technical Account Manager)
 if you want to use these Rapid Storage APIs.
 
 """
-import time
 from typing import Optional, Union
 
-from google.api_core import exceptions
 from google_crc32c import Checksum
 
 from ._utils import raise_if_no_fast_crc32c

--- a/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
+++ b/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
@@ -22,6 +22,8 @@ if you want to use these Rapid Storage APIs.
 
 """
 from typing import Optional, Union
+from google.api_core import exceptions
+from google_crc32c import Checksum, implementation as crc32c_impl
 from google.cloud import _storage_v2
 from google.cloud.storage._experimental.asyncio.async_grpc_client import (
     AsyncGrpcClient,
@@ -100,6 +102,14 @@ class AsyncAppendableObjectWriter:
         :param write_handle: (Optional) An existing handle for writing the object.
                             If provided, opening the bidi-gRPC connection will be faster.
         """
+        # Verify that the fast, C-accelerated version of crc32c is available.
+        # If not, raise an error to prevent silent performance degradation.
+        if crc32c_impl != "c":
+            raise exceptions.NotFound(
+                "The google-crc32c package is not installed with C support. "
+                "Bidi reads require the C extension for data integrity checks."
+                "For more information, see https://github.com/googleapis/python-crc32c."
+            )
         self.client = client
         self.bucket_name = bucket_name
         self.object_name = object_name
@@ -191,11 +201,13 @@ class AsyncAppendableObjectWriter:
         bytes_to_flush = 0
         while start_idx < total_bytes:
             end_idx = min(start_idx + _MAX_CHUNK_SIZE_BYTES, total_bytes)
+            data_chunk = data[start_idx:end_idx]
             await self.write_obj_stream.send(
                 _storage_v2.BidiWriteObjectRequest(
                     write_offset=self.offset,
                     checksummed_data=_storage_v2.ChecksummedData(
-                        content=data[start_idx:end_idx]
+                        content=data_chunk,
+                        crc32c=int.from_bytes(Checksum(data_chunk).digest(), "big"),
                     ),
                 )
             )

--- a/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
+++ b/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import asyncio
 from typing import List, Optional, Tuple
 
-from google.api_core import exceptions
 from google_crc32c import Checksum
 
 from ._utils import raise_if_no_fast_crc32c

--- a/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
+++ b/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
@@ -14,12 +14,12 @@
 
 from __future__ import annotations
 import asyncio
-import google_crc32c
+from typing import List, Optional, Tuple
+
 from google.api_core import exceptions
 from google_crc32c import Checksum
 
-from typing import List, Optional, Tuple
-
+from ._utils import raise_if_no_fast_crc32c
 from google.cloud.storage._experimental.asyncio.async_read_object_stream import (
     _AsyncReadObjectStream,
 )
@@ -160,14 +160,7 @@ class AsyncMultiRangeDownloader:
         :param read_handle: (Optional) An existing read handle.
         """
 
-        # Verify that the fast, C-accelerated version of crc32c is available.
-        # If not, raise an error to prevent silent performance degradation.
-        if google_crc32c.implementation != "c":
-            raise exceptions.NotFound(
-                "The google-crc32c package is not installed with C support. "
-                "Bidi reads require the C extension for data integrity checks."
-                "For more information, see https://github.com/googleapis/python-crc32c."
-            )
+        raise_if_no_fast_crc32c()
 
         self.client = client
         self.bucket_name = bucket_name

--- a/tests/system/test_notification.py
+++ b/tests/system/test_notification.py
@@ -69,6 +69,7 @@ def notification_topic(storage_client, publisher_client, topic_path, no_mtls):
     publisher_client.set_iam_policy(request={"resource": topic_path, "policy": policy})
 
 
+@pytest.mark.skip(reason="until b/470069573 is fixed")
 def test_notification_create_minimal(
     storage_client,
     buckets_to_delete,
@@ -94,6 +95,7 @@ def test_notification_create_minimal(
         notification.delete()
 
 
+@pytest.mark.skip(reason="until b/470069573 is fixed")
 def test_notification_create_explicit(
     storage_client,
     buckets_to_delete,
@@ -128,6 +130,7 @@ def test_notification_create_explicit(
         notification.delete()
 
 
+@pytest.mark.skip(reason="until b/470069573 is fixed")
 def test_notification_create_w_user_project(
     storage_client,
     buckets_to_delete,
@@ -156,6 +159,7 @@ def test_notification_create_w_user_project(
         notification.delete()
 
 
+@pytest.mark.skip(reason="until b/470069573 is fixed")
 def test_notification_create_wo_topic_name(
     storage_client,
     buckets_to_delete,
@@ -184,6 +188,7 @@ def test_notification_create_wo_topic_name(
         notification.create()
 
 
+@pytest.mark.skip(reason="until b/470069573 is fixed")
 def test_bucket_get_notification(
     storage_client,
     buckets_to_delete,

--- a/tests/unit/asyncio/test_async_appendable_object_writer.py
+++ b/tests/unit/asyncio/test_async_appendable_object_writer.py
@@ -95,7 +95,7 @@ def test_init_raises_if_crc32c_c_extension_is_missing(
 ):
     mock_google_crc32c.implementation = "python"
 
-    with pytest.raises(exceptions.NotFound) as exc_info:
+    with pytest.raises(exceptions.FailedPrecondition) as exc_info:
         AsyncAppendableObjectWriter(mock_grpc_client, "bucket", "object")
 
     assert "The google-crc32c package is not installed with C support" in str(

--- a/tests/unit/asyncio/test_async_appendable_object_writer.py
+++ b/tests/unit/asyncio/test_async_appendable_object_writer.py
@@ -15,6 +15,8 @@
 import pytest
 from unittest import mock
 
+from google_crc32c import Checksum
+
 from google.api_core import exceptions
 from google.cloud.storage._experimental.asyncio.async_appendable_object_writer import (
     AsyncAppendableObjectWriter,
@@ -452,10 +454,15 @@ async def test_append_sends_data_in_chunks(mock_write_object_stream, mock_client
     # First chunk
     assert first_call[0][0].write_offset == 100
     assert len(first_call[0][0].checksummed_data.content) == _MAX_CHUNK_SIZE_BYTES
-
+    assert first_call[0][0].checksummed_data.crc32c == int.from_bytes(
+        Checksum(data[:_MAX_CHUNK_SIZE_BYTES]).digest()
+    )
     # Second chunk
     assert second_call[0][0].write_offset == 100 + _MAX_CHUNK_SIZE_BYTES
     assert len(second_call[0][0].checksummed_data.content) == 1
+    assert second_call[0][0].checksummed_data.crc32c == int.from_bytes(
+        Checksum(data[_MAX_CHUNK_SIZE_BYTES:]).digest()
+    )
 
     assert writer.offset == 100 + len(data)
     writer.simple_flush.assert_not_awaited()

--- a/tests/unit/asyncio/test_async_appendable_object_writer.py
+++ b/tests/unit/asyncio/test_async_appendable_object_writer.py
@@ -455,13 +455,13 @@ async def test_append_sends_data_in_chunks(mock_write_object_stream, mock_client
     assert first_call[0][0].write_offset == 100
     assert len(first_call[0][0].checksummed_data.content) == _MAX_CHUNK_SIZE_BYTES
     assert first_call[0][0].checksummed_data.crc32c == int.from_bytes(
-        Checksum(data[:_MAX_CHUNK_SIZE_BYTES]).digest()
+        Checksum(data[:_MAX_CHUNK_SIZE_BYTES]).digest(), byteorder="big"
     )
     # Second chunk
     assert second_call[0][0].write_offset == 100 + _MAX_CHUNK_SIZE_BYTES
     assert len(second_call[0][0].checksummed_data.content) == 1
     assert second_call[0][0].checksummed_data.crc32c == int.from_bytes(
-        Checksum(data[_MAX_CHUNK_SIZE_BYTES:]).digest()
+        Checksum(data[_MAX_CHUNK_SIZE_BYTES:]).digest(), byteorder="big"
     )
 
     assert writer.offset == 100 + len(data)

--- a/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -349,9 +349,7 @@ class TestAsyncMultiRangeDownloader:
         assert str(exc.value) == "Underlying bidi-gRPC stream is not open"
         assert not mrd.is_stream_open
 
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_multi_range_downloader.google_crc32c"
-    )
+    @mock.patch("google.cloud.storage._experimental.asyncio._utils.google_crc32c")
     @mock.patch(
         "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
     )

--- a/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -358,7 +358,7 @@ class TestAsyncMultiRangeDownloader:
     ):
         mock_google_crc32c.implementation = "python"
 
-        with pytest.raises(exceptions.NotFound) as exc_info:
+        with pytest.raises(exceptions.FailedPrecondition) as exc_info:
             AsyncMultiRangeDownloader(mock_grpc_client, "bucket", "object")
 
         assert "The google-crc32c package is not installed with C support" in str(


### PR DESCRIPTION
feat: compute chunk wise checksum for bidi_writes and send it via BidiWriteObjectRequest

As a part of this change, also did a small refactoring 
  *  Moved the precondition check to __utils.py_ file
