### PR TITLE
chore: optimization to reduce number of open TCP connections while running zonal system tests

### DIFF
--- a/cloudbuild/run_zonal_tests.sh
+++ b/cloudbuild/run_zonal_tests.sh
@@ -17,7 +17,6 @@ echo 'Install testing libraries explicitly, as they are not in setup.py'
 pip install --upgrade pip
 pip install pytest pytest-timeout pytest-subtests pytest-asyncio
 pip install google-cloud-testutils google-cloud-kms
-pip install psutil==7.1.3
 pip install -e .
 
 echo '--- Setting up environment variables on VM ---'

--- a/cloudbuild/run_zonal_tests.sh
+++ b/cloudbuild/run_zonal_tests.sh
@@ -17,6 +17,7 @@ echo 'Install testing libraries explicitly, as they are not in setup.py'
 pip install --upgrade pip
 pip install pytest pytest-timeout pytest-subtests pytest-asyncio
 pip install google-cloud-testutils google-cloud-kms
+pip install psutil==7.1.3
 pip install -e .
 
 echo '--- Setting up environment variables on VM ---'

--- a/cloudbuild/run_zonal_tests.sh
+++ b/cloudbuild/run_zonal_tests.sh
@@ -23,5 +23,6 @@ pip install -e .
 echo '--- Setting up environment variables on VM ---'
 export ZONAL_BUCKET=${_ZONAL_BUCKET}
 export RUN_ZONAL_SYSTEM_TESTS=True
-echo '--- Running Zonal tests on VM ---'
+CURRENT_ULIMIT=$(ulimit -n)
+echo '--- Running Zonal tests on VM with ulimit set to ---' $CURRENT_ULIMIT
 pytest -vv -s --log-format='%(asctime)s %(levelname)s %(message)s' --log-date-format='%H:%M:%S' tests/system/test_zonal.py

--- a/cloudbuild/zb-system-tests-cloudbuild.yaml
+++ b/cloudbuild/zb-system-tests-cloudbuild.yaml
@@ -3,7 +3,7 @@ substitutions:
   _ZONE: "us-central1-a"
   _SHORT_BUILD_ID: ${BUILD_ID:0:8}
   _VM_NAME: "py-sdk-sys-test-${_SHORT_BUILD_ID}"
-  _ULIMIT: "10000" # 10k, for gRPC bidi streams
+  # _ULIMIT: "10000" # 10k, for gRPC bidi streams
 
 
 
@@ -68,7 +68,7 @@ steps:
         # Execute the script on the VM via SSH.
         # Capture the exit code to ensure cleanup happens before the build fails.
         set +e
-        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="ulimit -n ${_ULIMIT} COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
+        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="ulimit -n 10000 COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
         EXIT_CODE=$?
         set -e
 

--- a/cloudbuild/zb-system-tests-cloudbuild.yaml
+++ b/cloudbuild/zb-system-tests-cloudbuild.yaml
@@ -3,6 +3,7 @@ substitutions:
   _ZONE: "us-central1-a"
   _SHORT_BUILD_ID: ${BUILD_ID:0:8}
   _VM_NAME: "py-sdk-sys-test-${_SHORT_BUILD_ID}"
+  _ULIMIT: 10000 # 10k, for gRPC bidi streams
 
 
 
@@ -67,7 +68,7 @@ steps:
         # Execute the script on the VM via SSH.
         # Capture the exit code to ensure cleanup happens before the build fails.
         set +e
-        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
+        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="ulimit -n ${_ULIMIT} COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
         EXIT_CODE=$?
         set -e
 

--- a/cloudbuild/zb-system-tests-cloudbuild.yaml
+++ b/cloudbuild/zb-system-tests-cloudbuild.yaml
@@ -3,7 +3,7 @@ substitutions:
   _ZONE: "us-central1-a"
   _SHORT_BUILD_ID: ${BUILD_ID:0:8}
   _VM_NAME: "py-sdk-sys-test-${_SHORT_BUILD_ID}"
-  _ULIMIT: 10000 # 10k, for gRPC bidi streams
+  _ULIMIT: "10000" # 10k, for gRPC bidi streams
 
 
 

--- a/cloudbuild/zb-system-tests-cloudbuild.yaml
+++ b/cloudbuild/zb-system-tests-cloudbuild.yaml
@@ -68,7 +68,7 @@ steps:
         # Execute the script on the VM via SSH.
         # Capture the exit code to ensure cleanup happens before the build fails.
         set +e
-        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="ulimit -n 10000 COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
+        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="ulimit -n 10000; COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
         EXIT_CODE=$?
         set -e
 

--- a/cloudbuild/zb-system-tests-cloudbuild.yaml
+++ b/cloudbuild/zb-system-tests-cloudbuild.yaml
@@ -3,7 +3,7 @@ substitutions:
   _ZONE: "us-central1-a"
   _SHORT_BUILD_ID: ${BUILD_ID:0:8}
   _VM_NAME: "py-sdk-sys-test-${_SHORT_BUILD_ID}"
-  # _ULIMIT: "10000" # 10k, for gRPC bidi streams
+  _ULIMIT: "10000" # 10k, for gRPC bidi streams
 
 
 
@@ -68,7 +68,7 @@ steps:
         # Execute the script on the VM via SSH.
         # Capture the exit code to ensure cleanup happens before the build fails.
         set +e
-        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="ulimit -n 10000; COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
+        gcloud compute ssh ${_VM_NAME} --zone=${_ZONE} --internal-ip --ssh-key-file=/workspace/.ssh/google_compute_engine --command="ulimit -n {_ULIMIT}; COMMIT_SHA=${COMMIT_SHA} _ZONAL_BUCKET=${_ZONAL_BUCKET} bash run_zonal_tests.sh"
         EXIT_CODE=$?
         set -e
 

--- a/tests/system/test_zonal.py
+++ b/tests/system/test_zonal.py
@@ -1,5 +1,4 @@
 # py standard imports
-import asyncio
 import os
 import uuid
 from io import BytesIO


### PR DESCRIPTION
chore: optimization to reduce number of open TCP connections while running zonal system tests

1. Increase `ulimit -n 10000` before ssh'ing into the VM where system tests for zonal buckets are running.
2. Delete `mrd` and `writer` instance and trigger `gc.collect()`  ( this alone should suffice but increasing doing the above optimization to avoid future issues.
