### PR TITLE
feat(storage): Add async client and async http iterator class

### DIFF
--- a/google/cloud/storage/_experimental/asyncio/async_client.py
+++ b/google/cloud/storage/_experimental/asyncio/async_client.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ try:
     AsyncSession = sessions.AsyncAuthorizedSession
     _AIO_AVAILABLE = True
 except ImportError:
-    AsyncSession = object
     _AIO_AVAILABLE = False
 
 _marker = base_client.marker
@@ -236,5 +235,24 @@ class AsyncClient(BaseClient):
         )
 
     def bucket(self, bucket_name, user_project=None, generation=None):
-        """See super() class"""
-        raise NotImplementedError("This bucket class needs to be implemented.")
+        """Factory constructor for bucket object.
+
+        .. note::
+          This will not make an HTTP request; it simply instantiates
+          a bucket object owned by this client.
+
+        :type bucket_name: str
+        :param bucket_name: The name of the bucket to be instantiated.
+
+        :type user_project: str
+        :param user_project: (Optional) The project ID to be billed for API
+                             requests made via the bucket.
+
+        :type generation: int
+        :param generation: (Optional) If present, selects a specific revision of
+                           this bucket.
+
+        :rtype: :class:`google.cloud.storage._experimental.asyncio.bucket.AsyncBucket`
+        :returns: The bucket object created.
+        """
+        raise NotImplementedError("This AsyncBucket class needs to be implemented.")

--- a/google/cloud/storage/_experimental/asyncio/async_client.py
+++ b/google/cloud/storage/_experimental/asyncio/async_client.py
@@ -1,0 +1,240 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Asynchronous client for interacting with Google Cloud Storage."""
+
+import functools
+
+from google.cloud.storage._experimental.asyncio.async_helpers import ASYNC_DEFAULT_TIMEOUT
+from google.cloud.storage._experimental.asyncio.async_helpers import ASYNC_DEFAULT_RETRY
+from google.cloud.storage._experimental.asyncio.async_helpers import AsyncHTTPIterator
+from google.cloud.storage._experimental.asyncio.async_helpers import _do_nothing_page_start
+from google.cloud.storage._opentelemetry_tracing import create_trace_span
+from google.cloud.storage._experimental.asyncio.async_creds import AsyncCredsWrapper
+from google.cloud.storage.abstracts.base_client import BaseClient
+from google.cloud.storage._experimental.asyncio.async_connection import AsyncConnection
+from google.cloud.storage.abstracts import base_client
+
+try:
+    from google.auth.aio.transport import sessions
+    AsyncSession = sessions.AsyncAuthorizedSession
+    _AIO_AVAILABLE = True
+except ImportError:
+    AsyncSession = object
+    _AIO_AVAILABLE = False
+
+_marker = base_client.marker
+
+
+class AsyncClient(BaseClient):
+    """Asynchronous client to interact with Google Cloud Storage."""
+
+    def __init__(
+        self,
+        project=_marker,
+        credentials=None,
+        _async_http=None,
+        client_info=None,
+        client_options=None,
+        extra_headers={},
+        *,
+        api_key=None,
+    ):
+        if not _AIO_AVAILABLE:
+            # Python 3.9 or less comes with an older version of google-auth library which doesn't support asyncio
+            raise ImportError(
+                "Failed to import 'google.auth.aio', Consider using a newer python version (>=3.10)"
+                " or newer version of google-auth library to mitigate this issue."
+            )
+
+        if self._use_client_cert:
+            # google.auth.aio.transports.sessions.AsyncAuthorizedSession currently doesn't support configuring mTLS.
+            # In future, we can monkey patch the above, and do provide mTLS support, but that is not a priority
+            # at the moment.
+            raise ValueError("Async Client currently do not support mTLS")
+
+        # We initialize everything as per synchronous client.
+        super().__init__(
+            project=project,
+            credentials=credentials,
+            client_info=client_info,
+            client_options=client_options,
+            extra_headers=extra_headers,
+            api_key=api_key
+        )
+        self.credentials = AsyncCredsWrapper(self._credentials) # self._credential is synchronous.
+        self._connection = AsyncConnection(self, **self.connection_kw_args) # adapter for async communication
+        self._async_http_internal = _async_http
+        self._async_http_passed_by_user = (_async_http is not None)
+
+    @property
+    def async_http(self):
+        """Returns the existing asynchronous session, or create one if it does not exists."""
+        if self._async_http_internal is None:
+            self._async_http_internal = AsyncSession(credentials=self.credentials)
+        return self._async_http_internal
+
+    async def close(self):
+        """Close the session, if it exists"""
+        if self._async_http_internal is not None and not self._async_http_passed_by_user:
+            await self._async_http_internal.close()
+
+    async def _get_resource(
+        self,
+        path,
+        query_params=None,
+        headers=None,
+        timeout=ASYNC_DEFAULT_TIMEOUT,
+        retry=ASYNC_DEFAULT_RETRY,
+        _target_object=None,
+    ):
+        """See super() class"""
+        return await self._connection.api_request(
+            method="GET",
+            path=path,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=_target_object,
+        )
+
+    def _list_resource(
+        self,
+        path,
+        item_to_value,
+        page_token=None,
+        max_results=None,
+        extra_params=None,
+        page_start=_do_nothing_page_start,
+        page_size=None,
+        timeout=ASYNC_DEFAULT_TIMEOUT,
+        retry=ASYNC_DEFAULT_RETRY,
+    ):
+        """See super() class"""
+        kwargs = {
+            "method": "GET",
+            "path": path,
+            "timeout": timeout,
+        }
+        with create_trace_span(
+            name="Storage.AsyncClient._list_resource_returns_iterator",
+            client=self,
+            api_request=kwargs,
+            retry=retry,
+        ):
+            api_request = functools.partial(
+                self._connection.api_request, timeout=timeout, retry=retry
+            )
+        return AsyncHTTPIterator(
+            client=self,
+            api_request=api_request,
+            path=path,
+            item_to_value=item_to_value,
+            page_token=page_token,
+            max_results=max_results,
+            extra_params=extra_params,
+            page_start=page_start,
+            page_size=page_size,
+        )
+
+    async def _patch_resource(
+        self,
+        path,
+        data,
+        query_params=None,
+        headers=None,
+        timeout=ASYNC_DEFAULT_TIMEOUT,
+        retry=None,
+        _target_object=None,
+    ):
+        """See super() class"""
+        return await self._connection.api_request(
+            method="PATCH",
+            path=path,
+            data=data,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=_target_object,
+        )
+
+    async def _put_resource(
+        self,
+        path,
+        data,
+        query_params=None,
+        headers=None,
+        timeout=ASYNC_DEFAULT_TIMEOUT,
+        retry=None,
+        _target_object=None,
+    ):
+        """See super() class"""
+        return await self._connection.api_request(
+            method="PUT",
+            path=path,
+            data=data,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=_target_object,
+        )
+
+    async def _post_resource(
+        self,
+        path,
+        data,
+        query_params=None,
+        headers=None,
+        timeout=ASYNC_DEFAULT_TIMEOUT,
+        retry=None,
+        _target_object=None,
+    ):
+        """See super() class"""
+        return await self._connection.api_request(
+            method="POST",
+            path=path,
+            data=data,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=_target_object,
+        )
+
+    async def _delete_resource(
+        self,
+        path,
+        query_params=None,
+        headers=None,
+        timeout=ASYNC_DEFAULT_TIMEOUT,
+        retry=ASYNC_DEFAULT_RETRY,
+        _target_object=None,
+    ):
+        """See super() class"""
+        return await self._connection.api_request(
+            method="DELETE",
+            path=path,
+            query_params=query_params,
+            headers=headers,
+            timeout=timeout,
+            retry=retry,
+            _target_object=_target_object,
+        )
+
+    def bucket(self, bucket_name, user_project=None, generation=None):
+        """See super() class"""
+        raise NotImplementedError("This bucket class needs to be implemented.")

--- a/google/cloud/storage/_experimental/asyncio/async_helpers.py
+++ b/google/cloud/storage/_experimental/asyncio/async_helpers.py
@@ -1,0 +1,142 @@
+"""Helper utility for async client."""
+
+from google.api_core import retry_async
+from google.cloud.storage import retry as storage_retry
+from google.cloud.storage import _helpers
+from google.api_core.page_iterator_async import AsyncIterator
+from google.api_core.page_iterator import Page
+
+
+ASYNC_DEFAULT_RETRY = retry_async.AsyncRetry(predicate=storage_retry._should_retry)
+ASYNC_DEFAULT_TIMEOUT = _helpers._DEFAULT_TIMEOUT
+
+
+async def _do_nothing_page_start(iterator, page, response):
+    """Async Helper to provide custom behavior after a :class:`Page` is started.
+
+    This is a do-nothing stand-in as the default value.
+
+    Args:
+        iterator (Iterator): An iterator that holds some request info.
+        page (Page): The page that was just created.
+        response (Any): The API response for a page.
+    """
+    # pylint: disable=unused-argument
+    pass
+
+class AsyncHTTPIterator(AsyncIterator):
+    """A generic class for iterating through HTTP/JSON API list responses asynchronously.
+
+    Args:
+        client (google.cloud.storage._experimental.asyncio.async_client.AsyncClient): The API client.
+        api_request (Callable): The **async** function to use to make API requests.
+            This must be an awaitable.
+        path (str): The method path to query for the list of items.
+        item_to_value (Callable[AsyncIterator, Any]): Callable to convert an item 
+            from the type in the JSON response into a native object.
+        items_key (str): The key in the API response where the list of items
+            can be found.
+        page_token (str): A token identifying a page in a result set.
+        page_size (int): The maximum number of results to fetch per page.
+        max_results (int): The maximum number of results to fetch.
+        extra_params (dict): Extra query string parameters for the API call.
+        page_start (Callable): Callable to provide special behavior after a new page 
+            is created.
+        next_token (str): The name of the field used in the response for page tokens.
+    """
+
+    _DEFAULT_ITEMS_KEY = "items"
+    _PAGE_TOKEN = "pageToken"
+    _MAX_RESULTS = "maxResults"
+    _NEXT_TOKEN = "nextPageToken"
+    _RESERVED_PARAMS = frozenset([_PAGE_TOKEN])
+
+    def __init__(
+        self,
+        client,
+        api_request,
+        path,
+        item_to_value,
+        items_key=_DEFAULT_ITEMS_KEY,
+        page_token=None,
+        page_size=None,
+        max_results=None,
+        extra_params=None,
+        page_start=_do_nothing_page_start,
+        next_token=_NEXT_TOKEN,
+    ):
+        super().__init__(
+            client, item_to_value, page_token=page_token, max_results=max_results
+        )
+        self.api_request = api_request
+        self.path = path
+        self._items_key = items_key
+        self._page_size = page_size
+        self._page_start = page_start
+        self._next_token = next_token
+        self.extra_params = extra_params.copy() if extra_params else {}
+        self._verify_params()
+
+    def _verify_params(self):
+        """Verifies the parameters don't use any reserved parameter."""
+        reserved_in_use = self._RESERVED_PARAMS.intersection(self.extra_params)
+        if reserved_in_use:
+            raise ValueError("Using a reserved parameter", reserved_in_use)
+
+    async def _next_page(self):
+        """Get the next page in the iterator asynchronously.
+
+        Returns:
+            Optional[Page]: The next page in the iterator or None if
+                there are no pages left.
+        """
+        if self._has_next_page():
+            response = await self._get_next_page_response()
+            items = response.get(self._items_key, ())
+
+            # We reuse the synchronous Page class as it is just a container
+            page = Page(self, items, self.item_to_value, raw_page=response)
+
+            await self._page_start(self, page, response)
+            self.next_page_token = response.get(self._next_token)
+            return page
+        else:
+            return None
+
+    def _has_next_page(self):
+        """Determines whether or not there are more pages with results."""
+        if self.page_number == 0:
+            return True
+
+        if self.max_results is not None:
+            if self.num_results >= self.max_results:
+                return False
+
+        return self.next_page_token is not None
+
+    def _get_query_params(self):
+        """Getter for query parameters for the next request."""
+        result = {}
+        if self.next_page_token is not None:
+            result[self._PAGE_TOKEN] = self.next_page_token
+
+        page_size = None
+        if self.max_results is not None:
+            page_size = self.max_results - self.num_results
+            if self._page_size is not None:
+                page_size = min(page_size, self._page_size)
+        elif self._page_size is not None:
+            page_size = self._page_size
+
+        if page_size is not None:
+            result[self._MAX_RESULTS] = page_size
+
+        result.update(self.extra_params)
+        return result
+
+    async def _get_next_page_response(self):
+        """Requests the next page from the path provided asynchronously."""
+        params = self._get_query_params()
+        return await self.api_request(
+            method="GET", path=self.path, query_params=params
+        )

--- a/google/cloud/storage/abstracts/base_client.py
+++ b/google/cloud/storage/abstracts/base_client.py
@@ -122,18 +122,7 @@ class BaseClient(ClientWithProject, ABC):
         #    be raised.
 
         elif self._universe_domain:
-            # The final decision of whether to use mTLS takes place in
-            # google-auth-library-python. We peek at the environment variable
-            # here only to issue an exception in case of a conflict.
-            use_client_cert = False
-            if hasattr(mtls, "should_use_client_cert"):
-                use_client_cert = mtls.should_use_client_cert()
-            else:
-                use_client_cert = (
-                    os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true"
-                )
-
-            if use_client_cert:
+            if self._use_client_cert:
                 raise ValueError(
                     'The "GOOGLE_API_USE_CLIENT_CERTIFICATE" env variable is '
                     'set to "true" and a non-default universe domain is '
@@ -259,7 +248,22 @@ class BaseClient(ClientWithProject, ABC):
         """
         if self._base_connection is not None:
             raise ValueError("Connection already set on client")
-        self._base_connection = value
+        self._base_connection = value     
+
+    @property
+    def _use_client_cert(self):
+        """Returns true if mTLS is enabled"""
+        # The final decision of whether to use mTLS takes place in
+        # google-auth-library-python. We peek at the environment variable
+        # here only to issue an exception in case of a conflict.
+        use_client_cert = False
+        if hasattr(mtls, "should_use_client_cert"):
+            use_client_cert = mtls.should_use_client_cert()
+        else:
+            use_client_cert = (
+                os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE") == "true"
+            )
+        return use_client_cert
 
     def _push_batch(self, batch):
         """Push a batch onto our stack.

--- a/tests/unit/asyncio/test_async_client.py
+++ b/tests/unit/asyncio/test_async_client.py
@@ -1,0 +1,280 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import sys
+import pytest
+from google.auth.credentials import Credentials
+from google.cloud.storage._experimental.asyncio.async_client import AsyncClient
+from google.cloud.storage._experimental.asyncio.async_helpers import AsyncHTTPIterator
+
+# Aliases to match sync test style
+_marker = object()
+
+def _make_credentials():
+    creds = mock.Mock(spec=Credentials)
+    creds.universe_domain = "googleapis.com"
+    return creds
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), 
+    reason="Async Client requires Python 3.10+ due to google-auth-library asyncio support"
+)
+class TestAsyncClient:
+    @staticmethod
+    def _get_target_class():
+        return AsyncClient
+
+    def _make_one(self, *args, **kw):
+        return self._get_target_class()(*args, **kw)
+
+    def test_ctor_defaults(self):
+        PROJECT = "PROJECT"
+        credentials = _make_credentials()
+
+        # We mock AsyncConnection to prevent network logic during init
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection") as MockConn:
+            client = self._make_one(project=PROJECT, credentials=credentials)
+
+        assert client.project == PROJECT
+        assert isinstance(client._connection, mock.Mock) # It is the instance of the Mock
+        assert client._connection == MockConn.return_value
+        
+        # Verify specific async attributes
+        assert client._async_http_internal is None
+        assert client._async_http_passed_by_user is False
+        
+        # Verify inheritance from BaseClient worked (batch stack, etc)
+        assert client.current_batch is None
+        assert list(client._batch_stack) == []
+
+    def test_ctor_mtls_raises_error(self):
+        credentials = _make_credentials()
+        
+        # Simulate environment where mTLS is enabled
+        with mock.patch("google.cloud.storage.abstracts.base_client.BaseClient._use_client_cert", new_callable=mock.PropertyMock) as mock_mtls:
+            mock_mtls.return_value = True
+            
+            with pytest.raises(ValueError, match="Async Client currently do not support mTLS"):
+                self._make_one(credentials=credentials)
+
+    def test_ctor_w_async_http_passed(self):
+        credentials = _make_credentials()
+        async_http = mock.Mock()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(
+                project="PROJECT", 
+                credentials=credentials, 
+                _async_http=async_http
+            )
+
+        assert client._async_http_internal is async_http
+        assert client._async_http_passed_by_user is True
+
+    def test_async_http_property_creates_session(self):
+        credentials = _make_credentials()
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+        
+        assert client._async_http_internal is None
+
+        # Mock the auth session class
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncSession") as MockSession:
+            session = client.async_http
+            
+            assert session is MockSession.return_value
+            assert client._async_http_internal is session
+            # Should be initialized with the AsyncCredsWrapper, not the raw credentials
+            MockSession.assert_called_once()
+            call_kwargs = MockSession.call_args[1]
+            assert call_kwargs['credentials'] == client.credentials
+
+    @pytest.mark.asyncio
+    async def test_close_manages_session_lifecycle(self):
+        credentials = _make_credentials()
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+
+        # 1. Internal session created by client -> Client closes it
+        mock_internal = mock.AsyncMock()
+        client._async_http_internal = mock_internal
+        client._async_http_passed_by_user = False
+        
+        await client.close()
+        mock_internal.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_ignores_user_session(self):
+        credentials = _make_credentials()
+        user_session = mock.AsyncMock()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(
+                project="PROJECT", 
+                credentials=credentials, 
+                _async_http=user_session
+            )
+
+        # 2. External session passed by user -> Client DOES NOT close it
+        await client.close()
+        user_session.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_resource(self):
+        path = "/b/bucket"
+        query_params = {"foo": "bar"}
+        credentials = _make_credentials()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+        
+        # Mock the connection's api_request
+        client._connection.api_request = mock.AsyncMock(return_value="response")
+
+        result = await client._get_resource(path, query_params=query_params)
+
+        assert result == "response"
+        client._connection.api_request.assert_awaited_once_with(
+            method="GET",
+            path=path,
+            query_params=query_params,
+            headers=None,
+            timeout=mock.ANY,
+            retry=mock.ANY,
+            _target_object=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_resource(self):        
+        path = "/b/bucket/o"
+        item_to_value = mock.Mock()
+        credentials = _make_credentials()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+
+        iterator = client._list_resource(
+            path=path,
+            item_to_value=item_to_value,
+            max_results=10,
+            page_token="token"
+        )
+
+        assert isinstance(iterator, AsyncHTTPIterator)
+        assert iterator.path == path
+        assert iterator.max_results == 10
+
+    @pytest.mark.asyncio
+    async def test_patch_resource(self):
+        path = "/b/bucket"
+        data = {"key": "val"}
+        credentials = _make_credentials()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+        
+        client._connection.api_request = mock.AsyncMock()
+
+        await client._patch_resource(path, data=data)
+
+        client._connection.api_request.assert_awaited_once_with(
+            method="PATCH",
+            path=path,
+            data=data,
+            query_params=None,
+            headers=None,
+            timeout=mock.ANY,
+            retry=None,
+            _target_object=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_put_resource(self):
+        path = "/b/bucket/o/obj"
+        data = b"bytes"
+        credentials = _make_credentials()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+        
+        client._connection.api_request = mock.AsyncMock()
+
+        await client._put_resource(path, data=data)
+
+        client._connection.api_request.assert_awaited_once_with(
+            method="PUT",
+            path=path,
+            data=data,
+            query_params=None,
+            headers=None,
+            timeout=mock.ANY,
+            retry=None,
+            _target_object=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_post_resource(self):
+        path = "/b/bucket/o/obj/compose"
+        data = {"source": []}
+        credentials = _make_credentials()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+        
+        client._connection.api_request = mock.AsyncMock()
+
+        await client._post_resource(path, data=data)
+
+        client._connection.api_request.assert_awaited_once_with(
+            method="POST",
+            path=path,
+            data=data,
+            query_params=None,
+            headers=None,
+            timeout=mock.ANY,
+            retry=None,
+            _target_object=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_resource(self):
+        path = "/b/bucket"
+        credentials = _make_credentials()
+        
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+        
+        client._connection.api_request = mock.AsyncMock()
+
+        await client._delete_resource(path)
+
+        client._connection.api_request.assert_awaited_once_with(
+            method="DELETE",
+            path=path,
+            query_params=None,
+            headers=None,
+            timeout=mock.ANY,
+            retry=mock.ANY,
+            _target_object=None
+        )
+
+    def test_bucket_not_implemented(self):
+        credentials = _make_credentials()
+        with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
+            client = self._make_one(project="PROJECT", credentials=credentials)
+            
+        with pytest.raises(NotImplementedError):
+            client.bucket("my-bucket")

--- a/tests/unit/asyncio/test_async_client.py
+++ b/tests/unit/asyncio/test_async_client.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ from google.cloud.storage._experimental.asyncio.async_helpers import AsyncHTTPIt
 # Aliases to match sync test style
 _marker = object()
 
+
 def _make_credentials():
     creds = mock.Mock(spec=Credentials)
     creds.universe_domain = "googleapis.com"
@@ -29,7 +30,7 @@ def _make_credentials():
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 10), 
+    sys.version_info < (3, 10),
     reason="Async Client requires Python 3.10+ due to google-auth-library asyncio support"
 )
 class TestAsyncClient:
@@ -49,35 +50,36 @@ class TestAsyncClient:
             client = self._make_one(project=PROJECT, credentials=credentials)
 
         assert client.project == PROJECT
-        assert isinstance(client._connection, mock.Mock) # It is the instance of the Mock
+        # It is the instance of the Mock
+        assert isinstance(client._connection, mock.Mock)
         assert client._connection == MockConn.return_value
-        
+
         # Verify specific async attributes
         assert client._async_http_internal is None
         assert client._async_http_passed_by_user is False
-        
+
         # Verify inheritance from BaseClient worked (batch stack, etc)
         assert client.current_batch is None
         assert list(client._batch_stack) == []
 
     def test_ctor_mtls_raises_error(self):
         credentials = _make_credentials()
-        
+
         # Simulate environment where mTLS is enabled
         with mock.patch("google.cloud.storage.abstracts.base_client.BaseClient._use_client_cert", new_callable=mock.PropertyMock) as mock_mtls:
             mock_mtls.return_value = True
-            
+
             with pytest.raises(ValueError, match="Async Client currently do not support mTLS"):
                 self._make_one(credentials=credentials)
 
     def test_ctor_w_async_http_passed(self):
         credentials = _make_credentials()
         async_http = mock.Mock()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(
-                project="PROJECT", 
-                credentials=credentials, 
+                project="PROJECT",
+                credentials=credentials,
                 _async_http=async_http
             )
 
@@ -88,13 +90,13 @@ class TestAsyncClient:
         credentials = _make_credentials()
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
-        
+
         assert client._async_http_internal is None
 
         # Mock the auth session class
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncSession") as MockSession:
             session = client.async_http
-            
+
             assert session is MockSession.return_value
             assert client._async_http_internal is session
             # Should be initialized with the AsyncCredsWrapper, not the raw credentials
@@ -112,7 +114,7 @@ class TestAsyncClient:
         mock_internal = mock.AsyncMock()
         client._async_http_internal = mock_internal
         client._async_http_passed_by_user = False
-        
+
         await client.close()
         mock_internal.close.assert_awaited_once()
 
@@ -120,11 +122,11 @@ class TestAsyncClient:
     async def test_close_ignores_user_session(self):
         credentials = _make_credentials()
         user_session = mock.AsyncMock()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(
-                project="PROJECT", 
-                credentials=credentials, 
+                project="PROJECT",
+                credentials=credentials,
                 _async_http=user_session
             )
 
@@ -137,12 +139,13 @@ class TestAsyncClient:
         path = "/b/bucket"
         query_params = {"foo": "bar"}
         credentials = _make_credentials()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
-        
+
         # Mock the connection's api_request
-        client._connection.api_request = mock.AsyncMock(return_value="response")
+        client._connection.api_request = mock.AsyncMock(
+            return_value="response")
 
         result = await client._get_resource(path, query_params=query_params)
 
@@ -158,11 +161,11 @@ class TestAsyncClient:
         )
 
     @pytest.mark.asyncio
-    async def test_list_resource(self):        
+    async def test_list_resource(self):
         path = "/b/bucket/o"
         item_to_value = mock.Mock()
         credentials = _make_credentials()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
 
@@ -182,10 +185,10 @@ class TestAsyncClient:
         path = "/b/bucket"
         data = {"key": "val"}
         credentials = _make_credentials()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
-        
+
         client._connection.api_request = mock.AsyncMock()
 
         await client._patch_resource(path, data=data)
@@ -206,10 +209,10 @@ class TestAsyncClient:
         path = "/b/bucket/o/obj"
         data = b"bytes"
         credentials = _make_credentials()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
-        
+
         client._connection.api_request = mock.AsyncMock()
 
         await client._put_resource(path, data=data)
@@ -230,10 +233,10 @@ class TestAsyncClient:
         path = "/b/bucket/o/obj/compose"
         data = {"source": []}
         credentials = _make_credentials()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
-        
+
         client._connection.api_request = mock.AsyncMock()
 
         await client._post_resource(path, data=data)
@@ -253,10 +256,10 @@ class TestAsyncClient:
     async def test_delete_resource(self):
         path = "/b/bucket"
         credentials = _make_credentials()
-        
+
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
-        
+
         client._connection.api_request = mock.AsyncMock()
 
         await client._delete_resource(path)
@@ -275,6 +278,6 @@ class TestAsyncClient:
         credentials = _make_credentials()
         with mock.patch("google.cloud.storage._experimental.asyncio.async_client.AsyncConnection"):
             client = self._make_one(project="PROJECT", credentials=credentials)
-            
+
         with pytest.raises(NotImplementedError):
             client.bucket("my-bucket")

--- a/tests/unit/asyncio/test_async_helpers.py
+++ b/tests/unit/asyncio/test_async_helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/asyncio/test_async_helpers.py
+++ b/tests/unit/asyncio/test_async_helpers.py
@@ -1,0 +1,265 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import pytest
+from google.api_core.page_iterator import Page
+from google.cloud.storage._experimental.asyncio.async_helpers import AsyncHTTPIterator
+
+
+async def _safe_anext(iterator):
+    """Helper to get the next item or return None (Py3.9 compatible)."""
+    try:
+        return await iterator.__anext__()
+    except StopAsyncIteration:
+        return None
+
+
+class TestAsyncHTTPIterator:
+
+    def _make_one(self, *args, **kw):
+        return AsyncHTTPIterator(*args, **kw)
+
+    @pytest.mark.asyncio
+    async def test_iterate_items_single_page(self):
+        """Test simple iteration over one page of results."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock()     
+        api_request.return_value = {
+            "items": ["a", "b"]
+        }
+        
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=lambda _, x: x.upper(),
+        )
+
+        results = []
+        async for item in iterator:
+            results.append(item)
+
+        assert results == ["A", "B"]
+        assert iterator.num_results == 2
+        assert iterator.page_number == 1        
+        api_request.assert_awaited_once_with(
+            method="GET",
+            path="/path",
+            query_params={} 
+        )
+
+    @pytest.mark.asyncio
+    async def test_iterate_items_multiple_pages(self):
+        """Test pagination flow passes tokens correctly."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock()
+        
+        # Setup Response: 2 Pages
+        api_request.side_effect = [
+            {"items": ["1", "2"], "nextPageToken": "token-A"}, # Page 1
+            {"items": ["3"], "nextPageToken": "token-B"},      # Page 2
+            {"items": []}                                      # Page 3 (Empty/End)
+        ]
+        
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=lambda _, x: int(x),
+        )
+
+        results = [i async for i in iterator]
+
+        assert results == [1, 2, 3]
+        assert api_request.call_count == 3
+        
+        calls = api_request.call_args_list
+        assert calls[0].kwargs["query_params"] == {}
+        assert calls[1].kwargs["query_params"] == {"pageToken": "token-A"}
+        assert calls[2].kwargs["query_params"] == {"pageToken": "token-B"}
+
+    @pytest.mark.asyncio
+    async def test_iterate_pages_public_property(self):
+        """Test the .pages property which yields Page objects instead of items."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock()
+        
+        api_request.side_effect = [
+            {"items": ["a"], "nextPageToken": "next"},
+            {"items": ["b"]}
+        ]
+        
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=lambda _, x: x,
+        )
+
+        pages = []
+        async for page in iterator.pages:
+            pages.append(page)
+            assert isinstance(page, Page)
+
+        assert len(pages) == 2
+        assert list(pages[0]) == ["a"]
+        assert list(pages[1]) == ["b"]        
+        assert iterator.page_number == 2
+
+    @pytest.mark.asyncio
+    async def test_max_results_limits_requests(self):
+        """Test that max_results alters the request parameters dynamically."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock()
+        
+        # Setup: We want 5 items total.
+        # Page 1 returns 3 items.
+        # Page 2 *should* only be asked for 2 items.
+        api_request.side_effect = [
+            {"items": ["a", "b", "c"], "nextPageToken": "t1"},
+            {"items": ["d", "e"], "nextPageToken": "t2"},
+        ]
+        
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=lambda _, x: x,
+            max_results=5 # <--- Limit set here
+        )
+
+        results = [i async for i in iterator]
+
+        assert len(results) == 5
+        assert results == ["a", "b", "c", "d", "e"]
+        
+        # Verify Request 1: Asked for max 5
+        call1_params = api_request.call_args_list[0].kwargs["query_params"]
+        assert call1_params["maxResults"] == 5
+        
+        # Verify Request 2: Asked for max 2 (5 - 3 already fetched)
+        call2_params = api_request.call_args_list[1].kwargs["query_params"]
+        assert call2_params["maxResults"] == 2
+        assert call2_params["pageToken"] == "t1"
+
+    @pytest.mark.asyncio
+    async def test_extra_params_passthrough(self):
+        """Test that extra_params are merged into every request."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock(return_value={"items": []})
+        
+        custom_params = {"projection": "full", "delimiter": "/"}
+        
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=mock.Mock(),
+            extra_params=custom_params # <--- Input
+        )
+
+        # Trigger a request
+        await _safe_anext(iterator)
+
+        # Verify Request Pattern
+        call_params = api_request.call_args.kwargs["query_params"]
+        assert call_params["projection"] == "full"
+        assert call_params["delimiter"] == "/"
+
+    @pytest.mark.asyncio
+    async def test_page_size_configuration(self):
+        """Test that page_size is sent as maxResults if no global max_results is set."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock(return_value={"items": []})
+        
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=mock.Mock(),
+            page_size=50 # <--- User preference
+        )
+
+        await _safe_anext(iterator)
+
+        # Verify Request Pattern
+        call_params = api_request.call_args.kwargs["query_params"]
+        assert call_params["maxResults"] == 50
+
+    @pytest.mark.asyncio
+    async def test_page_start_callback(self):
+        """Verify the page_start callback is invoked during iteration."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock(return_value={"items": ["x"]})
+        callback = mock.AsyncMock()
+
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=lambda _, x: x,
+            page_start=callback
+        )
+
+        # Run iteration
+        async for _ in iterator:
+            pass
+
+        # Verify callback was awaited
+        callback.assert_awaited_once()
+        args = callback.call_args[0]
+        assert args[0] is iterator
+        assert isinstance(args[1], Page)
+        assert args[2] == {"items": ["x"]}
+
+    @pytest.mark.asyncio
+    async def test_iterate_empty_response(self):
+        """Test iteration over an empty result set."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock(return_value={"items": []})
+
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=mock.Mock(),
+        )
+
+        results = [i async for i in iterator]
+        assert results == []
+        assert iterator.num_results == 0
+        assert iterator.page_number == 1
+
+    @pytest.mark.asyncio
+    async def test_error_if_iterated_twice(self):
+        """Verify the iterator cannot be restarted once started."""
+        client = mock.Mock()
+        api_request = mock.AsyncMock(return_value={"items": []})
+
+        iterator = self._make_one(
+            client=client,
+            api_request=api_request,
+            path="/path",
+            item_to_value=mock.Mock(),
+        )
+
+        # First Start
+        async for _ in iterator:
+            pass
+            
+        # Second Start (Should Fail)
+        with pytest.raises(ValueError, match="Iterator has already started"):
+            async for _ in iterator:
+                pass


### PR DESCRIPTION
1. Add async client implementation.
2. Add AsyncHTTPIterator deriving from google.api_core.page_iterator_async.AsyncIterator as an alternative to google.api_core.page_iterator.HTTPIterator

The AsyncHTTPIterator doesn't exists, and hence needs to be implemented. 