### PR TITLE
chore(librarian): bump library version to 3.7.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:8e2c32496077054105bd06c54a59d6a6694287bc053588e24debe6da6920ad91
 libraries:
   - id: google-cloud-storage
-    version: 3.6.0
+    version: 3.7.0
     last_generated_commit: 5400ccce473c439885bd6bf2924fd242271bfcab
     apis:
       - path: google/storage/v2


### PR DESCRIPTION
Bump the current version in `.librarian/state.yaml` to `3.7.0` to cater for https://github.com/googleapis/python-storage/pull/1621 which was released on December 9 2025. 

This will address the issue in https://github.com/googleapis/python-storage/pull/1701 where librarian sets the version to `3.7.0` which has already been released. 

The reason that this manual PR is needed is because the release on December 9th used a different tool `release-please` which does not update the `.librarian/state.yaml` file.