### PR TITLE
fix!: Change contructors of MRD and AAOW AsyncGrpcClient.grpc_client to AsyncGrpcClient

### DIFF
--- a/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
+++ b/google/cloud/storage/_experimental/asyncio/async_appendable_object_writer.py
@@ -114,7 +114,7 @@ class AsyncAppendableObjectWriter:
 
     def __init__(
         self,
-        client: AsyncGrpcClient.grpc_client,
+        client: AsyncGrpcClient,
         bucket_name: str,
         object_name: str,
         generation: Optional[int] = None,
@@ -155,7 +155,7 @@ class AsyncAppendableObjectWriter:
         await writer.close()
         ```
 
-        :type client: :class:`~google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client`
+        :type client: :class:`~google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient`
         :param client: async grpc client to use for making API requests.
 
         :type bucket_name: str
@@ -304,7 +304,7 @@ class AsyncAppendableObjectWriter:
                 self._is_stream_open = False
 
             self.write_obj_stream = _AsyncWriteObjectStream(
-                client=self.client,
+                client=self.client.grpc_client,
                 bucket_name=self.bucket_name,
                 object_name=self.object_name,
                 generation_number=self.generation,

--- a/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
+++ b/google/cloud/storage/_experimental/asyncio/async_multi_range_downloader.py
@@ -125,7 +125,7 @@ class AsyncMultiRangeDownloader:
     @classmethod
     async def create_mrd(
         cls,
-        client: AsyncGrpcClient.grpc_client,
+        client: AsyncGrpcClient,
         bucket_name: str,
         object_name: str,
         generation_number: Optional[int] = None,
@@ -136,7 +136,7 @@ class AsyncMultiRangeDownloader:
         """Initializes a MultiRangeDownloader and opens the underlying bidi-gRPC
         object for reading.
 
-        :type client: :class:`~google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client`
+        :type client: :class:`~google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient`
         :param client: The asynchronous client to use for making API requests.
 
         :type bucket_name: str
@@ -168,7 +168,7 @@ class AsyncMultiRangeDownloader:
 
     def __init__(
         self,
-        client: AsyncGrpcClient.grpc_client,
+        client: AsyncGrpcClient,
         bucket_name: str,
         object_name: str,
         generation_number: Optional[int] = None,
@@ -177,7 +177,7 @@ class AsyncMultiRangeDownloader:
         """Constructor for AsyncMultiRangeDownloader, clients are not adviced to
          use it directly. Instead it's adviced to use the classmethod `create_mrd`.
 
-        :type client: :class:`~google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client`
+        :type client: :class:`~google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient`
         :param client: The asynchronous client to use for making API requests.
 
         :type bucket_name: str
@@ -273,7 +273,7 @@ class AsyncMultiRangeDownloader:
                 self._is_stream_open = False
 
             self.read_obj_str = _AsyncReadObjectStream(
-                client=self.client,
+                client=self.client.grpc_client,
                 bucket_name=self.bucket_name,
                 object_name=self.object_name,
                 generation_number=self.generation_number,
@@ -432,7 +432,7 @@ class AsyncMultiRangeDownloader:
 
                         # Re-initialize stream
                         self.read_obj_str = _AsyncReadObjectStream(
-                            client=self.client,
+                            client=self.client.grpc_client,
                             bucket_name=self.bucket_name,
                             object_name=self.object_name,
                             generation_number=self.generation_number,

--- a/samples/snippets/zonal_buckets/storage_create_and_write_appendable_object.py
+++ b/samples/snippets/zonal_buckets/storage_create_and_write_appendable_object.py
@@ -35,7 +35,7 @@ async def storage_create_and_write_appendable_object(
     """
 
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
     writer = AsyncAppendableObjectWriter(
         client=grpc_client,
         bucket_name=bucket_name,

--- a/samples/snippets/zonal_buckets/storage_finalize_appendable_object_upload.py
+++ b/samples/snippets/zonal_buckets/storage_finalize_appendable_object_upload.py
@@ -33,7 +33,7 @@ async def storage_finalize_appendable_object_upload(
     """
 
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
     writer = AsyncAppendableObjectWriter(
         client=grpc_client,
         bucket_name=bucket_name,

--- a/samples/snippets/zonal_buckets/storage_open_multiple_objects_ranged_read.py
+++ b/samples/snippets/zonal_buckets/storage_open_multiple_objects_ranged_read.py
@@ -36,7 +36,7 @@ async def storage_open_multiple_objects_ranged_read(
     grpc_client: an existing grpc_client to use, this is only for testing.
     """
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
 
     async def _download_range(object_name):
         """Helper coroutine to download a range from a single object."""

--- a/samples/snippets/zonal_buckets/storage_open_object_multiple_ranged_read.py
+++ b/samples/snippets/zonal_buckets/storage_open_object_multiple_ranged_read.py
@@ -33,7 +33,7 @@ async def storage_open_object_multiple_ranged_read(
     grpc_client: an existing grpc_client to use, this is only for testing.
     """
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
 
     mrd = AsyncMultiRangeDownloader(grpc_client, bucket_name, object_name)
 

--- a/samples/snippets/zonal_buckets/storage_open_object_read_full_object.py
+++ b/samples/snippets/zonal_buckets/storage_open_object_read_full_object.py
@@ -33,7 +33,7 @@ async def storage_open_object_read_full_object(
     grpc_client: an existing grpc_client to use, this is only for testing.
     """
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
 
     # mrd = Multi-Range-Downloader
     mrd = AsyncMultiRangeDownloader(grpc_client, bucket_name, object_name)

--- a/samples/snippets/zonal_buckets/storage_open_object_single_ranged_read.py
+++ b/samples/snippets/zonal_buckets/storage_open_object_single_ranged_read.py
@@ -33,7 +33,7 @@ async def storage_open_object_single_ranged_read(
     grpc_client: an existing grpc_client to use, this is only for testing.
     """
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
 
     mrd = AsyncMultiRangeDownloader(grpc_client, bucket_name, object_name)
 

--- a/samples/snippets/zonal_buckets/storage_pause_and_resume_appendable_upload.py
+++ b/samples/snippets/zonal_buckets/storage_pause_and_resume_appendable_upload.py
@@ -32,7 +32,7 @@ async def storage_pause_and_resume_appendable_upload(
     grpc_client: an existing grpc_client to use, this is only for testing.
     """
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
 
     writer1 = AsyncAppendableObjectWriter(
         client=grpc_client,

--- a/samples/snippets/zonal_buckets/storage_read_appendable_object_tail.py
+++ b/samples/snippets/zonal_buckets/storage_read_appendable_object_tail.py
@@ -90,7 +90,7 @@ async def read_appendable_object_tail(
     grpc_client: an existing grpc_client to use, this is only for testing.
     """
     if grpc_client is None:
-        grpc_client = AsyncGrpcClient().grpc_client
+        grpc_client = AsyncGrpcClient()
     writer = AsyncAppendableObjectWriter(
         client=grpc_client,
         bucket_name=bucket_name,

--- a/samples/snippets/zonal_buckets/zonal_snippets_test.py
+++ b/samples/snippets/zonal_buckets/zonal_snippets_test.py
@@ -48,7 +48,7 @@ _ZONAL_BUCKET = os.getenv("ZONAL_BUCKET")
 
 async def create_async_grpc_client():
     """Initializes async client and gets the current event loop."""
-    return AsyncGrpcClient().grpc_client
+    return AsyncGrpcClient()
 
 
 # Forcing a single event loop for the whole test session

--- a/tests/perf/microbenchmarks/conftest.py
+++ b/tests/perf/microbenchmarks/conftest.py
@@ -78,7 +78,7 @@ async def upload_appendable_object(bucket_name, object_name, object_size, chunk_
     # this method is to write "appendable" objects which will be used for
     # benchmarking reads, hence not concerned performance of writes here.
     writer = AsyncAppendableObjectWriter(
-        AsyncGrpcClient().grpc_client,
+        AsyncGrpcClient(),
         bucket_name,
         object_name,
         writer_options={"FLUSH_INTERVAL_BYTES": 1026 * 1024**2},

--- a/tests/perf/microbenchmarks/reads/test_reads.py
+++ b/tests/perf/microbenchmarks/reads/test_reads.py
@@ -47,7 +47,7 @@ all_params = config._get_params()
 
 async def create_client():
     """Initializes async client and gets the current event loop."""
-    return AsyncGrpcClient().grpc_client
+    return AsyncGrpcClient()
 
 
 async def download_chunks_using_mrd_async(client, filename, other_params, chunks):

--- a/tests/perf/microbenchmarks/writes/test_writes.py
+++ b/tests/perf/microbenchmarks/writes/test_writes.py
@@ -49,7 +49,7 @@ all_params = config.get_write_params()
 
 async def create_client():
     """Initializes async client and gets the current event loop."""
-    return AsyncGrpcClient().grpc_client
+    return AsyncGrpcClient()
 
 
 async def upload_chunks_using_grpc_async(client, filename, other_params):

--- a/tests/system/test_zonal.py
+++ b/tests/system/test_zonal.py
@@ -36,7 +36,7 @@ _BYTES_TO_UPLOAD = b"dummy_bytes_to_write_read_and_delete_appendable_object"
 
 async def create_async_grpc_client(attempt_direct_path=True):
     """Initializes async client and gets the current event loop."""
-    return AsyncGrpcClient(attempt_direct_path=attempt_direct_path).grpc_client
+    return AsyncGrpcClient(attempt_direct_path=attempt_direct_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/asyncio/test_async_appendable_object_writer.py
+++ b/tests/unit/asyncio/test_async_appendable_object_writer.py
@@ -87,7 +87,8 @@ class TestIsWriteRetryable:
 @pytest.fixture
 def mock_appendable_writer():
     """Fixture to provide a mock AsyncAppendableObjectWriter setup."""
-    mock_client = mock.AsyncMock()
+    mock_client = mock.MagicMock()
+    mock_client.grpc_client = mock.AsyncMock()
     # Internal stream class patch
     stream_patcher = mock.patch(
         "google.cloud.storage._experimental.asyncio.async_appendable_object_writer._AsyncWriteObjectStream"

--- a/tests/unit/asyncio/test_async_multi_range_downloader.py
+++ b/tests/unit/asyncio/test_async_multi_range_downloader.py
@@ -46,13 +46,15 @@ class TestAsyncMultiRangeDownloader:
     @pytest.mark.asyncio
     async def _make_mock_mrd(
         self,
-        mock_grpc_client,
         mock_cls_async_read_object_stream,
         bucket_name=_TEST_BUCKET_NAME,
         object_name=_TEST_OBJECT_NAME,
         generation_number=_TEST_GENERATION_NUMBER,
         read_handle=_TEST_READ_HANDLE,
     ):
+        mock_client = mock.MagicMock()
+        mock_client.grpc_client = mock.AsyncMock()
+
         mock_stream = mock_cls_async_read_object_stream.return_value
         mock_stream.open = AsyncMock()
         mock_stream.generation_number = _TEST_GENERATION_NUMBER
@@ -60,29 +62,22 @@ class TestAsyncMultiRangeDownloader:
         mock_stream.read_handle = _TEST_READ_HANDLE
 
         mrd = await AsyncMultiRangeDownloader.create_mrd(
-            mock_grpc_client, bucket_name, object_name, generation_number, read_handle
+            mock_client, bucket_name, object_name, generation_number, read_handle
         )
 
-        return mrd
+        return mrd, mock_client
 
     @mock.patch(
         "google.cloud.storage._experimental.asyncio.async_multi_range_downloader._AsyncReadObjectStream"
     )
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
-    async def test_create_mrd(
-        self, mock_grpc_client, mock_cls_async_read_object_stream
-    ):
+    async def test_create_mrd(self, mock_cls_async_read_object_stream):
         # Arrange & Act
-        mrd = await self._make_mock_mrd(
-            mock_grpc_client, mock_cls_async_read_object_stream
-        )
+        mrd, mock_client = await self._make_mock_mrd(mock_cls_async_read_object_stream)
 
         # Assert
         mock_cls_async_read_object_stream.assert_called_once_with(
-            client=mock_grpc_client,
+            client=mock_client.grpc_client,
             bucket_name=_TEST_BUCKET_NAME,
             object_name=_TEST_OBJECT_NAME,
             generation_number=_TEST_GENERATION_NUMBER,
@@ -91,7 +86,7 @@ class TestAsyncMultiRangeDownloader:
 
         mrd.read_obj_str.open.assert_called_once()
 
-        assert mrd.client == mock_grpc_client
+        assert mrd.client == mock_client
         assert mrd.bucket_name == _TEST_BUCKET_NAME
         assert mrd.object_name == _TEST_OBJECT_NAME
         assert mrd.generation_number == _TEST_GENERATION_NUMBER
@@ -105,12 +100,9 @@ class TestAsyncMultiRangeDownloader:
     @mock.patch(
         "google.cloud.storage._experimental.asyncio.async_multi_range_downloader._AsyncReadObjectStream"
     )
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
     async def test_download_ranges_via_async_gather(
-        self, mock_grpc_client, mock_cls_async_read_object_stream, mock_random_int
+        self, mock_cls_async_read_object_stream, mock_random_int
     ):
         # Arrange
         data = b"these_are_18_chars"
@@ -120,9 +112,7 @@ class TestAsyncMultiRangeDownloader:
             Checksum(data[10:16]).digest(), "big"
         )
 
-        mock_mrd = await self._make_mock_mrd(
-            mock_grpc_client, mock_cls_async_read_object_stream
-        )
+        mock_mrd, _ = await self._make_mock_mrd(mock_cls_async_read_object_stream)
 
         mock_random_int.side_effect = [456, 91011]
 
@@ -181,21 +171,16 @@ class TestAsyncMultiRangeDownloader:
     @mock.patch(
         "google.cloud.storage._experimental.asyncio.async_multi_range_downloader._AsyncReadObjectStream"
     )
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
     async def test_download_ranges(
-        self, mock_grpc_client, mock_cls_async_read_object_stream, mock_random_int
+        self, mock_cls_async_read_object_stream, mock_random_int
     ):
         # Arrange
         data = b"these_are_18_chars"
         crc32c = Checksum(data).digest()
         crc32c_int = int.from_bytes(crc32c, "big")
 
-        mock_mrd = await self._make_mock_mrd(
-            mock_grpc_client, mock_cls_async_read_object_stream
-        )
+        mock_mrd, _ = await self._make_mock_mrd(mock_cls_async_read_object_stream)
 
         mock_random_int.side_effect = [456]
 
@@ -232,16 +217,12 @@ class TestAsyncMultiRangeDownloader:
         )
         assert buffer.getvalue() == data
 
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
-    async def test_downloading_ranges_with_more_than_1000_should_throw_error(
-        self, mock_grpc_client
-    ):
+    async def test_downloading_ranges_with_more_than_1000_should_throw_error(self):
         # Arrange
+        mock_client = mock.MagicMock()
         mrd = AsyncMultiRangeDownloader(
-            mock_grpc_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
+            mock_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
         )
 
         # Act + Assert
@@ -257,16 +238,13 @@ class TestAsyncMultiRangeDownloader:
     @mock.patch(
         "google.cloud.storage._experimental.asyncio.async_multi_range_downloader._AsyncReadObjectStream"
     )
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
     async def test_opening_mrd_more_than_once_should_throw_error(
-        self, mock_grpc_client, mock_cls_async_read_object_stream
+        self, mock_cls_async_read_object_stream
     ):
         # Arrange
-        mrd = await self._make_mock_mrd(
-            mock_grpc_client, mock_cls_async_read_object_stream
+        mrd, _ = await self._make_mock_mrd(
+            mock_cls_async_read_object_stream
         )  # mock mrd is already opened
 
         # Act + Assert
@@ -279,14 +257,11 @@ class TestAsyncMultiRangeDownloader:
     @mock.patch(
         "google.cloud.storage._experimental.asyncio.async_multi_range_downloader._AsyncReadObjectStream"
     )
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
-    async def test_close_mrd(self, mock_grpc_client, mock_cls_async_read_object_stream):
+    async def test_close_mrd(self, mock_cls_async_read_object_stream):
         # Arrange
-        mrd = await self._make_mock_mrd(
-            mock_grpc_client, mock_cls_async_read_object_stream
+        mrd, _ = await self._make_mock_mrd(
+            mock_cls_async_read_object_stream
         )  # mock mrd is already opened
         mrd.read_obj_str.close = AsyncMock()
 
@@ -296,14 +271,12 @@ class TestAsyncMultiRangeDownloader:
         # Assert
         assert not mrd.is_stream_open
 
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
-    async def test_close_mrd_not_opened_should_throw_error(self, mock_grpc_client):
+    async def test_close_mrd_not_opened_should_throw_error(self):
         # Arrange
+        mock_client = mock.MagicMock()
         mrd = AsyncMultiRangeDownloader(
-            mock_grpc_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
+            mock_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
         )
         # Act + Assert
         with pytest.raises(ValueError) as exc:
@@ -313,16 +286,12 @@ class TestAsyncMultiRangeDownloader:
         assert str(exc.value) == "Underlying bidi-gRPC stream is not open"
         assert not mrd.is_stream_open
 
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
-    async def test_downloading_without_opening_should_throw_error(
-        self, mock_grpc_client
-    ):
+    async def test_downloading_without_opening_should_throw_error(self):
         # Arrange
+        mock_client = mock.MagicMock()
         mrd = AsyncMultiRangeDownloader(
-            mock_grpc_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
+            mock_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
         )
 
         # Act + Assert
@@ -334,16 +303,14 @@ class TestAsyncMultiRangeDownloader:
         assert not mrd.is_stream_open
 
     @mock.patch("google.cloud.storage._experimental.asyncio._utils.google_crc32c")
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     def test_init_raises_if_crc32c_c_extension_is_missing(
-        self, mock_grpc_client, mock_google_crc32c
+        self, mock_google_crc32c
     ):
         mock_google_crc32c.implementation = "python"
+        mock_client = mock.MagicMock()
 
         with pytest.raises(exceptions.FailedPrecondition) as exc_info:
-            AsyncMultiRangeDownloader(mock_grpc_client, "bucket", "object")
+            AsyncMultiRangeDownloader(mock_client, "bucket", "object")
 
         assert "The google-crc32c package is not installed with C support" in str(
             exc_info.value
@@ -353,16 +320,14 @@ class TestAsyncMultiRangeDownloader:
     @mock.patch(
         "google.cloud.storage._experimental.asyncio.retry.reads_resumption_strategy.Checksum"
     )
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     async def test_download_ranges_raises_on_checksum_mismatch(
-        self, mock_client, mock_checksum_class
+        self, mock_checksum_class
     ):
         from google.cloud.storage._experimental.asyncio.async_multi_range_downloader import (
             AsyncMultiRangeDownloader,
         )
 
+        mock_client = mock.MagicMock()
         mock_stream = mock.AsyncMock(
             spec=async_read_object_stream._AsyncReadObjectStream
         )
@@ -410,16 +375,14 @@ class TestAsyncMultiRangeDownloader:
         "google.cloud.storage._experimental.asyncio.async_multi_range_downloader.AsyncMultiRangeDownloader.close",
         new_callable=AsyncMock,
     )
-    @mock.patch(
-        "google.cloud.storage._experimental.asyncio.async_grpc_client.AsyncGrpcClient.grpc_client"
-    )
     @pytest.mark.asyncio
     async def test_async_context_manager_calls_open_and_close(
-        self, mock_grpc_client, mock_close, mock_open
+        self, mock_close, mock_open
     ):
         # Arrange
+        mock_client = mock.MagicMock()
         mrd = AsyncMultiRangeDownloader(
-            mock_grpc_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
+            mock_client, _TEST_BUCKET_NAME, _TEST_OBJECT_NAME
         )
 
         # To simulate the behavior of open and close changing the stream state


### PR DESCRIPTION
Change contructors of MRD and AAOW `AsyncGrpcClient.grpc_client` to `AsyncGrpcClient`. This will help us extend multiple methods in AsyncGrpcClient in future. 

More details in b/479030029 
