### PR TITLE
fix: receive eof while closing reads stream

### DIFF
--- a/google/cloud/storage/asyncio/async_write_object_stream.py
+++ b/google/cloud/storage/asyncio/async_write_object_stream.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import List, Optional, Tuple
+import grpc
 from google.cloud import _storage_v2
 from google.cloud.storage.asyncio import _utils
 from google.cloud.storage.asyncio.async_grpc_client import AsyncGrpcClient
@@ -188,7 +189,7 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
         first_resp = await self.socket_like_rpc.recv()
 
         is_eof = (
-            first_resp is None
+            first_resp is None or first_resp == grpc.aio.EOF
             or (
                 getattr(first_resp, "persisted_size", None) is None
             )

--- a/google/cloud/storage/asyncio/async_write_object_stream.py
+++ b/google/cloud/storage/asyncio/async_write_object_stream.py
@@ -187,21 +187,12 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
         # The server may send a final "EOF" response immediately, or it may
         # first send an intermediate response followed by the EOF response depending on whether the object was finalized or not.
         first_resp = await self.socket_like_rpc.recv()
-
-        is_eof = (
-            first_resp is None or first_resp == grpc.aio.EOF
-            or (
-                getattr(first_resp, "persisted_size", None) is None
-            )
-        )
         _utils.update_write_handle_if_exists(self, first_resp)
 
-        if not is_eof:
+        if first_resp != grpc.aio.EOF:
             self.persisted_size = first_resp.persisted_size
             second_resp = await self.socket_like_rpc.recv()
-
-            if second_resp is not None:
-                _utils.update_write_handle_if_exists(self, second_resp)
+            _utils.update_write_handle_if_exists(self, second_resp)
 
     async def send(
         self, bidi_write_object_request: _storage_v2.BidiWriteObjectRequest

--- a/google/cloud/storage/asyncio/async_write_object_stream.py
+++ b/google/cloud/storage/asyncio/async_write_object_stream.py
@@ -192,7 +192,7 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
         if first_resp != grpc.aio.EOF:
             self.persisted_size = first_resp.persisted_size
             second_resp = await self.socket_like_rpc.recv()
-            _utils.update_write_handle_if_exists(self, second_resp)
+            assert second_resp == grpc.aio.EOF
 
     async def send(
         self, bidi_write_object_request: _storage_v2.BidiWriteObjectRequest

--- a/tests/unit/asyncio/test_async_write_object_stream.py
+++ b/tests/unit/asyncio/test_async_write_object_stream.py
@@ -209,3 +209,44 @@ class TestAsyncWriteObjectStream:
             await stream.recv()
         with pytest.raises(ValueError, match="Stream is not open"):
             await stream.close()
+
+    @pytest.mark.asyncio
+    async def test_close_with_persisted_size_then_eof(self, mock_client):
+        """Test close when first recv has persisted_size, second is EOF."""
+        stream = _AsyncWriteObjectStream(mock_client, BUCKET, OBJECT)
+        stream._is_stream_open = True
+        stream.socket_like_rpc = AsyncMock()
+
+        # First response has persisted_size (NOT EOF, intermediate)
+        persisted_resp = _storage_v2.BidiWriteObjectResponse(persisted_size=500)
+        # Second response is EOF (None)
+        eof_resp = None
+
+        stream.socket_like_rpc.send = AsyncMock()
+        stream.socket_like_rpc.recv = AsyncMock(side_effect=[persisted_resp, eof_resp])
+        stream.socket_like_rpc.close = AsyncMock()
+
+        await stream.close()
+
+        # Verify two recv calls: first has persisted_size (NOT EOF), so read second (EOF)
+        assert stream.socket_like_rpc.recv.await_count == 2
+        assert stream.persisted_size == 500
+        assert not stream.is_stream_open
+
+    @pytest.mark.asyncio
+    async def test_close_with_eof_response(self, mock_client):
+        """Test close when first recv is EOF or None."""
+        stream = _AsyncWriteObjectStream(mock_client, BUCKET, OBJECT)
+        stream._is_stream_open = True
+        stream.socket_like_rpc = AsyncMock()
+
+        # First recv returns None (gRPC EOF, stream is already closed)
+        stream.socket_like_rpc.send = AsyncMock()
+        stream.socket_like_rpc.recv = AsyncMock(return_value=None)
+        stream.socket_like_rpc.close = AsyncMock()
+
+        await stream.close()
+
+        # Verify only one recv call (None=EOF, so don't read second)
+        assert stream.socket_like_rpc.recv.await_count == 1
+        assert not stream.is_stream_open


### PR DESCRIPTION
When `writer.close()` is called without setting finalize_on_close flag, we need to get two responses:
1) to get the persisted_size
2) eof response

That's why added a check if the first response is not eof, then again receive the response from the stream.