### PR TITLE
feat: add get_object method for async grpc client

### DIFF
--- a/google/cloud/storage/asyncio/async_grpc_client.py
+++ b/google/cloud/storage/asyncio/async_grpc_client.py
@@ -215,7 +215,7 @@ class AsyncGrpcClient:
             if_generation_not_match=if_generation_not_match,
             if_metageneration_match=if_metageneration_match,
             if_metageneration_not_match=if_metageneration_not_match,
-            soft_deleted=soft_deleted if soft_deleted is not None else False,
+            soft_deleted=soft_deleted or False,
             **kwargs,
         )
 

--- a/google/cloud/storage/asyncio/async_grpc_client.py
+++ b/google/cloud/storage/asyncio/async_grpc_client.py
@@ -158,3 +158,66 @@ class AsyncGrpcClient:
             **kwargs,
         )
         await self._grpc_client.delete_object(request=request)
+
+    async def get_object(
+        self,
+        bucket_name,
+        object_name,
+        generation=None,
+        if_generation_match=None,
+        if_generation_not_match=None,
+        if_metageneration_match=None,
+        if_metageneration_not_match=None,
+        soft_deleted=None,
+        **kwargs,
+    ):
+        """Retrieves an object's metadata.
+
+        In the gRPC API, this is performed by the GetObject RPC, which
+        returns the object resource (metadata) without the object's data.
+
+        :type bucket_name: str
+        :param bucket_name: The name of the bucket in which the object resides.
+
+        :type object_name: str
+        :param object_name: The name of the object.
+
+        :type generation: int
+        :param generation:
+            (Optional) If present, selects a specific generation of an object.
+
+        :type if_generation_match: int
+        :param if_generation_match: (Optional) Precondition for object generation match.
+
+        :type if_generation_not_match: int
+        :param if_generation_not_match: (Optional) Precondition for object generation mismatch.
+
+        :type if_metageneration_match: int
+        :param if_metageneration_match: (Optional) Precondition for metageneration match.
+
+        :type if_metageneration_not_match: int
+        :param if_metageneration_not_match: (Optional) Precondition for metageneration mismatch.
+
+        :type soft_deleted: bool
+        :param soft_deleted:
+            (Optional) If True, return the soft-deleted version of this object.
+
+        :rtype: :class:`google.cloud._storage_v2.types.Object`
+        :returns: The object metadata resource.
+        """
+        bucket_path = f"projects/_/buckets/{bucket_name}"
+
+        request = storage_v2.GetObjectRequest(
+            bucket=bucket_path,
+            object=object_name,
+            generation=generation,
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+            soft_deleted=soft_deleted if soft_deleted is not None else False,
+            **kwargs,
+        )
+
+        # Calls the underlying GAPIC StorageAsyncClient.get_object method
+        return await self._grpc_client.get_object(request=request)

--- a/tests/system/test_zonal.py
+++ b/tests/system/test_zonal.py
@@ -601,3 +601,56 @@ def test_delete_object_using_grpc_client(event_loop, grpc_client_direct):
         gc.collect()
 
     event_loop.run_until_complete(_run())
+
+def test_get_object_after_appendable_write(
+    grpc_clients,
+    grpc_client_direct,
+    event_loop,
+    storage_client,
+    blobs_to_delete,
+):
+    """Test getting object metadata after writing with AsyncAppendableObjectWriter.
+
+    This test:
+    1. Creates a test object using AsyncAppendableObjectWriter
+    2. Appends content to the object (without finalizing)
+    3. Closes the write stream
+    4. Fetches the object metadata using AsyncGrpcClient.get_object()
+    5. Verifies the object size matches the written data
+    """
+
+    async def _run():
+        grpc_client = grpc_client_direct
+        object_name = f"test-get-object-{uuid.uuid4().hex}"
+        test_data = b"Some test data bytes."
+        expected_size = len(test_data)
+
+        writer = AsyncAppendableObjectWriter(
+            grpc_client,
+            _ZONAL_BUCKET,
+            object_name,
+        )
+
+        await writer.open()
+        await writer.append(test_data)
+        await writer.close(finalize_on_close=False)
+
+        obj = await grpc_client.get_object(
+            bucket_name=_ZONAL_BUCKET,
+            object_name=object_name,
+        )
+
+        # Assert
+        assert obj is not None
+        assert obj.name == object_name
+        assert obj.bucket == f"projects/_/buckets/{_ZONAL_BUCKET}"
+        assert obj.size == expected_size, (
+            f"Expected object size {expected_size}, got {obj.size}"
+        )
+
+        # Cleanup
+        blobs_to_delete.append(storage_client.bucket(_ZONAL_BUCKET).blob(object_name))
+        del writer
+        gc.collect()
+
+    event_loop.run_until_complete(_run())

--- a/tests/unit/asyncio/test_async_grpc_client.py
+++ b/tests/unit/asyncio/test_async_grpc_client.py
@@ -254,7 +254,6 @@ class TestAsyncGrpcClient:
         assert request.if_generation_not_match == if_generation_not_match
         assert request.if_metageneration_match == if_metageneration_match
         assert request.if_metageneration_not_match == if_metageneration_not_match
-        assert request.soft_deleted is False
 
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
     @pytest.mark.asyncio
@@ -283,6 +282,7 @@ class TestAsyncGrpcClient:
         request = call_kwargs["request"]
         assert request.bucket == "projects/_/buckets/bucket"
         assert request.object == "object"
+        assert request.soft_deleted is False
 
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
     @pytest.mark.asyncio

--- a/tests/unit/asyncio/test_async_grpc_client.py
+++ b/tests/unit/asyncio/test_async_grpc_client.py
@@ -254,3 +254,77 @@ class TestAsyncGrpcClient:
         assert request.if_generation_not_match == if_generation_not_match
         assert request.if_metageneration_match == if_metageneration_match
         assert request.if_metageneration_not_match == if_metageneration_not_match
+
+    @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
+    @pytest.mark.asyncio
+    async def test_get_object(self, mock_async_storage_client):
+        # Arrange
+        mock_transport_cls = mock.MagicMock()
+        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_gapic_client = mock.AsyncMock()
+        mock_async_storage_client.return_value = mock_gapic_client
+
+        client = async_grpc_client.AsyncGrpcClient(
+            credentials=_make_credentials(spec=AnonymousCredentials)
+        )
+
+        bucket_name = "bucket"
+        object_name = "object"
+
+        # Act
+        await client.get_object(
+            bucket_name,
+            object_name,
+        )
+
+        # Assert
+        call_args, call_kwargs = mock_gapic_client.get_object.call_args
+        request = call_kwargs["request"]
+        assert request.bucket == "projects/_/buckets/bucket"
+        assert request.object == "object"
+
+    @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
+    @pytest.mark.asyncio
+    async def test_get_object_with_all_parameters(self, mock_async_storage_client):
+        # Arrange
+        mock_transport_cls = mock.MagicMock()
+        mock_async_storage_client.get_transport_class.return_value = mock_transport_cls
+        mock_gapic_client = mock.AsyncMock()
+        mock_async_storage_client.return_value = mock_gapic_client
+
+        client = async_grpc_client.AsyncGrpcClient(
+            credentials=_make_credentials(spec=AnonymousCredentials)
+        )
+
+        bucket_name = "bucket"
+        object_name = "object"
+        generation = 123
+        if_generation_match = 456
+        if_generation_not_match = 789
+        if_metageneration_match = 111
+        if_metageneration_not_match = 222
+        soft_deleted = True
+
+        # Act
+        await client.get_object(
+            bucket_name,
+            object_name,
+            generation=generation,
+            if_generation_match=if_generation_match,
+            if_generation_not_match=if_generation_not_match,
+            if_metageneration_match=if_metageneration_match,
+            if_metageneration_not_match=if_metageneration_not_match,
+            soft_deleted=soft_deleted,
+        )
+
+        # Assert
+        call_args, call_kwargs = mock_gapic_client.get_object.call_args
+        request = call_kwargs["request"]
+        assert request.bucket == "projects/_/buckets/bucket"
+        assert request.object == "object"
+        assert request.generation == generation
+        assert request.if_generation_match == if_generation_match
+        assert request.if_generation_not_match == if_generation_not_match
+        assert request.if_metageneration_match == if_metageneration_match
+        assert request.if_metageneration_not_match == if_metageneration_not_match
+        assert request.soft_deleted is True

--- a/tests/unit/asyncio/test_async_grpc_client.py
+++ b/tests/unit/asyncio/test_async_grpc_client.py
@@ -254,6 +254,7 @@ class TestAsyncGrpcClient:
         assert request.if_generation_not_match == if_generation_not_match
         assert request.if_metageneration_match == if_metageneration_match
         assert request.if_metageneration_not_match == if_metageneration_not_match
+        assert request.soft_deleted is False
 
     @mock.patch("google.cloud._storage_v2.StorageAsyncClient")
     @pytest.mark.asyncio


### PR DESCRIPTION
This method can be used to fetch the metadata of an object using the async grpc API.
