### PR TITLE
fix: pass token correctly, '&' instead of ','

### DIFF
--- a/google/cloud/storage/asyncio/async_appendable_object_writer.py
+++ b/google/cloud/storage/asyncio/async_appendable_object_writer.py
@@ -310,7 +310,7 @@ class AsyncAppendableObjectWriter:
                 )
 
             await self.write_obj_stream.open(
-                metadata=current_metadata if metadata else None
+                metadata=current_metadata if current_metadata else None
             )
 
             if self.write_obj_stream.generation_number:

--- a/google/cloud/storage/asyncio/async_read_object_stream.py
+++ b/google/cloud/storage/asyncio/async_read_object_stream.py
@@ -115,7 +115,7 @@ class _AsyncReadObjectStream(_AsyncAbstractObjectStream):
                     other_metadata.append((key, value))
 
         current_metadata = other_metadata
-        current_metadata.append(("x-goog-request-params", "&".join(reversed(request_params))))
+        current_metadata.append(("x-goog-request-params", "&".join(request_params)))
 
         self.socket_like_rpc = AsyncBidiRpc(
             self.rpc,

--- a/google/cloud/storage/asyncio/async_read_object_stream.py
+++ b/google/cloud/storage/asyncio/async_read_object_stream.py
@@ -115,7 +115,7 @@ class _AsyncReadObjectStream(_AsyncAbstractObjectStream):
                     other_metadata.append((key, value))
 
         current_metadata = other_metadata
-        current_metadata.append(("x-goog-request-params", ",".join(request_params)))
+        current_metadata.append(("x-goog-request-params", "&".join(reversed(request_params))))
 
         self.socket_like_rpc = AsyncBidiRpc(
             self.rpc,

--- a/google/cloud/storage/asyncio/async_write_object_stream.py
+++ b/google/cloud/storage/asyncio/async_write_object_stream.py
@@ -145,7 +145,7 @@ class _AsyncWriteObjectStream(_AsyncAbstractObjectStream):
                 else:
                     final_metadata.append((key, value))
 
-        final_metadata.append(("x-goog-request-params", ",".join(request_param_values)))
+        final_metadata.append(("x-goog-request-params", "&".join(request_param_values)))
 
         self.socket_like_rpc = AsyncBidiRpc(
             self.rpc,


### PR DESCRIPTION
fix: pass token correctly, '&' instead of ','