### PR TITLE
chore: replace old teams with cloud-sdk-python-team and gcs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,7 @@
 #
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-
-# @googleapis/cloud-sdk-python-team @googleapis/gcs-team are the default owners for changes in this repo
-*     @googleapis/cloud-sdk-python-team @googleapis/gcs-team @googleapis/gcs-fs
+*     @googleapis/cloud-sdk-python-team @googleapis/gcs-team @googleapis/gcs-fs-team
 
 # @googleapis/python-samples-reviewers @googleapis/gcs-team are the default owners for samples changes
 /samples/   @googleapis/python-samples-reviewers @googleapis/gcs-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# @googleapis/yoshi-python @googleapis/gcs-sdk-team are the default owners for changes in this repo
-*     @googleapis/yoshi-python @googleapis/gcs-sdk-team @googleapis/gcs-fs
+# @googleapis/cloud-sdk-python-team @googleapis/gcs-team are the default owners for changes in this repo
+*     @googleapis/cloud-sdk-python-team @googleapis/gcs-team @googleapis/gcs-fs
 
-# @googleapis/python-samples-reviewers @googleapis/gcs-sdk-team are the default owners for samples changes
-/samples/   @googleapis/python-samples-reviewers @googleapis/gcs-sdk-team
+# @googleapis/python-samples-reviewers @googleapis/gcs-team are the default owners for samples changes
+/samples/   @googleapis/python-samples-reviewers @googleapis/gcs-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,7 +12,7 @@
     "api_id": "storage.googleapis.com",
     "requires_billing": true,
     "default_version": "v2",
-    "codeowner_team": "@googleapis/yoshi-python @googleapis/gcs-sdk-team @googleapis/gcs-fs",
+    "codeowner_team": "@googleapis/cloud-sdk-python-team @googleapis/gcs-team @googleapis/gcs-fs",
     "api_shortname": "storage",
     "api_description": "is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally."
 }


### PR DESCRIPTION
This PR replaces the old yoshi-python team with cloud-sdk-python-team, gcs-fs with gcs-fs-team, and gcs-sdk-team with gcs-team.

b/478003109